### PR TITLE
Set config to false for state containers.

### DIFF
--- a/release/models/bgp/openconfig-bgp-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-multiprotocol.yang
@@ -372,6 +372,7 @@ module openconfig-bgp-multiprotocol {
         uses bgp-use-multiple-paths_config;
       }
       container state {
+        config false;
         description
           "State parameters relating to multipath";
         uses bgp-use-multiple-paths_config;
@@ -426,6 +427,7 @@ module openconfig-bgp-multiprotocol {
         uses bgp-use-multiple-paths_config;
       }
       container state {
+        config false;
         description
           "State parameters relating to multipath";
         uses bgp-use-multiple-paths_config;


### PR DESCRIPTION
This commit fixes two missing config statements in bgp-use-multiple-paths.