### PR TITLE
Change 'labeled' nomenclature to match IETF and vendor implementaion naming

### DIFF
--- a/release/models/bgp/openconfig-bgp-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-multiprotocol.yang
@@ -88,12 +88,12 @@ module openconfig-bgp-multiprotocol {
     }
   }
 
-  grouping ipv4-labelled-unicast-group {
+  grouping ipv4-labeled-unicast-group {
     description
       "Group for IPv4 Labelled Unicast configuration options";
 
-    container ipv4-labelled-unicast {
-      when "../afi-safi-name = 'bgp-mp:ipv4-labelled-unicast'" {
+    container ipv4-labeled-unicast {
+      when "../afi-safi-name = 'bgp-mp:ipv4-labeled-unicast'" {
         description
           "Include this container for IPv4 Labelled Unicast specific
           configuration";
@@ -108,12 +108,12 @@ module openconfig-bgp-multiprotocol {
     }
   }
 
-  grouping ipv6-labelled-unicast-group {
+  grouping ipv6-labeled-unicast-group {
     description
       "Group for IPv6 Labelled Unicast configuration options";
 
-    container ipv6-labelled-unicast {
-      when "../afi-safi-name = 'bgp-mp:ipv6-labelled-unicast'" {
+    container ipv6-labeled-unicast {
+      when "../afi-safi-name = 'bgp-mp:ipv6-labeled-unicast'" {
         description
           "Include this container for IPv6 Labelled Unicast specific
           configuration";
@@ -717,8 +717,8 @@ module openconfig-bgp-multiprotocol {
 
       uses ipv4-unicast-group;
       uses ipv6-unicast-group;
-      uses ipv4-labelled-unicast-group;
-      uses ipv6-labelled-unicast-group;
+      uses ipv4-labeled-unicast-group;
+      uses ipv6-labeled-unicast-group;
       uses l3vpn-ipv4-unicast-group;
       uses l3vpn-ipv6-unicast-group;
       uses l3vpn-ipv4-multicast-group;

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -95,14 +95,14 @@ module openconfig-bgp-types {
     reference "RFC4760";
   }
 
-  identity IPV4-LABELLED-UNICAST {
+  identity IPV4-LABELED-UNICAST {
     base afi-safi-type;
     description
       "Labelled IPv4 unicast (AFI,SAFI = 1,4)";
     reference "RFC3107";
   }
 
-  identity IPV6-LABELLED-UNICAST {
+  identity IPV6-LABELED-UNICAST {
     base afi-safi-type;
     description
       "Labelled IPv6 unicast (AFI,SAFI = 2,4)";

--- a/release/models/mpls/openconfig-mpls-sr.yang
+++ b/release/models/mpls/openconfig-mpls-sr.yang
@@ -293,7 +293,7 @@ module openconfig-mpls-sr {
         enum "EXPLICIT-NULL" {
           description
             "Specifies that the explicit null label is to be used
-            when the penultimate hop forwards a labelled packet to
+            when the penultimate hop forwards a labeled packet to
             this Prefix-SID";
         }
         enum "UNCHANGED" {


### PR DESCRIPTION
Suggest keeping naming uniform per RFC wording and existing vendor implementations unless there is a good reason to diverge.