### PR TITLE
pattern statement does not follow W3C guidelines for regular expression. 

### DIFF
--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -82,7 +82,7 @@ module openconfig-bgp-policy {
     type union {
       type uint32;
       type string {
-        pattern "^[+-][0-9]+";
+        pattern "[+-][0-9]+";
       }
       type enumeration {
         enum IGP {

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -185,7 +185,7 @@ module openconfig-routing-policy {
 
     leaf masklength-range {
       type string {
-        pattern '^([0-9]+\.\.[0-9]+)|exact$';
+        pattern '([0-9]+\.\.[0-9]+)|exact';
       }
       description
         "Defines a range for the masklength, or 'exact' if


### PR DESCRIPTION
RFC 6020 is clear that the pattern statement has to follow the regular expression format defined by W3C. These two pattern statements for some reason do not.