### PR TITLE
Fixes for oc-inet:ip-address.

### DIFF
--- a/release/models/types/openconfig-inet-types.yang
+++ b/release/models/types/openconfig-inet-types.yang
@@ -51,7 +51,7 @@ module openconfig-inet-types {
     type string {
       pattern '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'        +
               '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4]'  +
-              '[0-9]|25[0-5])$';
+              '[0-9]|25[0-5])(%\w+)?$';
     }
     description
       "An IPv4 address in dotted quad notation.";
@@ -64,14 +64,14 @@ module openconfig-inet-types {
           // therefore this regexp is complex.
           '^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
           '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
-          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}'         +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'        +
           '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
           '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
           '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
           '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
           '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
           ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
-          ')$';
+          ')(%\w+)$';
     }
     description
       "An IPv6 address represented as either a full address; shortened


### PR DESCRIPTION
This commit fixes a missing operator in the ipv6-address regex, as well
as adding support for zoned addresses in both ipv4-address and
ipv6-address.