### PR TITLE
Initial check-in of 0.1.0 WiFi models

### DIFF
--- a/release/models/wifi/.spec.yml
+++ b/release/models/wifi/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-wifi-mac
+  docs:
+    - wifi/mac/openconfig-wifi-mac.yang
+    - wifi/types/openconfig-wifi-types.yang
+  build:
+    - wifi/mac/openconfig-wifi-mac.yang
+  run-ci: true

--- a/release/models/wifi/.spec.yml
+++ b/release/models/wifi/.spec.yml
@@ -1,7 +1,0 @@
-- name: openconfig-wifi-mac
-  docs:
-    - wifi/mac/openconfig-wifi-mac.yang
-    - wifi/types/openconfig-wifi-types.yang
-  build:
-    - wifi/mac/openconfig-wifi-mac.yang
-  run-ci: true

--- a/release/models/wifi/README.md
+++ b/release/models/wifi/README.md
@@ -1,0 +1,34 @@
+# wifi-models
+Development of configuration and operational state models for WiFi
+
+Open Config is a collaboration between network operators to develop and standardize a set of vendor-neutral network configuration models. Models are written using the YANG data modeling language (IETF RFC 6020).
+
+The configuration models in this repository are made available under the Apache 2.0 license (see the LICENSE file). Since the models are intended to be published in the IETF, participants must be willing to adhere to the IETF Note Well statement as well as BCP 78 and BCP 79.
+
+# Working with YANG models
+The recommended tool for "compiling" and manipulating YANG models is the open source pyang tool. For example to see a text-based tree view of a yang module, run the following command:
+
+pyang -f tree --ietf --strict <module.yang>
+
+Note that the --ietf and --strict flags should be used to ensure compatibility with IETF module guidelines, and strict YANG compliance, respectively. Additional OpenConfig validation can be achieved through using the OpenConfig linter.
+
+# WiFi Model Flow
+The following layout will be used to model the various components that make up a WiFi Network. In general if there are >2 leafs related to one feature, those are placed in their own container. See openconfig-wifi-mac.yang:wmm/dot11r/dot11v etc for example
+
+## openconfig-wifi-mac.yang
+ All MAC layer configuration/state.
+
+## openconfig-wifi-phy.yang
+ All PHY layer configuration/state.
+
+## openconfig-system-wifi-ext.yang
+Augmentation model of openconfig-system.yang
+Used for non-802.11 config/state, for example:
+ NTP, clock, hostname, Joined APs, etc.
+
+## openconfig-wifi-types.yang
+Types definition file for wifi-specific types.
+
+In addition to the above models, it is expected that some WiFi networks utilize network elements (such as Wireless Lan Controllers) with components that share common config/state leafs with Routers/Switches. In such cases, vendors will be expected to support existing models, already published. 
+For example:
+SFP's and there related config/state, will utilize openconfig-platform-transceiver.yang.

--- a/release/models/wifi/README.md
+++ b/release/models/wifi/README.md
@@ -3,14 +3,10 @@ Development of configuration and operational state models for WiFi
 
 Open Config is a collaboration between network operators to develop and standardize a set of vendor-neutral network configuration models. Models are written using the YANG data modeling language (IETF RFC 6020).
 
-The configuration models in this repository are made available under the Apache 2.0 license (see the LICENSE file). Since the models are intended to be published in the IETF, participants must be willing to adhere to the IETF Note Well statement as well as BCP 78 and BCP 79.
+The configuration models in this repository are made available under the Apache 2.0 license (see the LICENSE file). 
 
 # Working with YANG models
-The recommended tool for "compiling" and manipulating YANG models is the open source pyang tool. For example to see a text-based tree view of a yang module, run the following command:
-
-pyang -f tree --ietf --strict <module.yang>
-
-Note that the --ietf and --strict flags should be used to ensure compatibility with IETF module guidelines, and strict YANG compliance, respectively. Additional OpenConfig validation can be achieved through using the OpenConfig linter.
+The recommended tool for "compiling" and manipulating YANG models is the open source pyang tool. 
 
 # WiFi Model Flow
 The following layout will be used to model the various components that make up a WiFi Network. In general if there are >2 leafs related to one feature, those are placed in their own container. See openconfig-wifi-mac.yang:wmm/dot11r/dot11v etc for example

--- a/release/models/wifi/mac/.spec.yml
+++ b/release/models/wifi/mac/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-wifi-mac
+  docs:
+    - wifi/mac/openconfig-wifi-mac.yang
+    - wifi/types/openconfig-wifi-types.yang
+  build:
+    - wifi/mac/openconfig-wifi-mac.yang
+  run-ci: true

--- a/release/models/wifi/mac/openconfig-wifi-mac.yang
+++ b/release/models/wifi/mac/openconfig-wifi-mac.yang
@@ -1,0 +1,1415 @@
+module openconfig-wifi-mac {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/wifi/mac";
+
+  // Assign this module a prefix to be used by other modules, when imported.
+  prefix "oc-wifi-mac";
+
+  import openconfig-yang-types { prefix oc-yang; }
+  // OC-specific types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-vlan-types { prefix oc-vlan-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-wifi-types { prefix oc-wifi-types; }
+  import openconfig-types { prefix oc-types; }
+
+  // Some required meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Model for managing MAC layer configuration of Radio interfaces.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2017-07-25" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping ssid-common-config {
+    description
+      "Configuration items common to all logical SSIDs.";
+
+    leaf name {
+      type string;
+      description
+        "The name of the SSID.";
+    }
+
+    leaf enabled {
+      type boolean;
+      default "true";
+      description
+        "The desired operational state (up/down) of this SSID.";
+    }
+
+    leaf hidden {
+      type boolean;
+      default "false";
+      description
+        "Whether this SSID IE is hidden within Beacons.";
+    }
+
+    leaf vlan-id {
+      type oc-vlan-types:vlan-id;
+      description
+        "Optional VLAN tag used by the SSID. When unspecified, defaults
+        to untagged.";
+    }
+
+    leaf operating-frequency {
+      type identityref {
+        base oc-wifi-types:OPERATING_FREQUENCY;
+      }
+      default "oc-wifi-types:FREQ_2_5_GHZ";
+      description
+        "Operating frequency of this SSID. When none specified, the default is
+        dual-band.";
+    }
+
+    leaf-list basic-data-rates {
+      type identityref {
+        base oc-wifi-types:DATA_RATE;
+      }
+      description
+        "Basic data-rates for the SSID.";
+    }
+
+    leaf-list supported-data-rates {
+      type identityref {
+        base oc-wifi-types:DATA_RATE;
+      }
+      description
+        "Supported data-rates for the SSID.";
+    }
+    // MCS rates explicitly absent, as they are typically not pruned.
+
+    leaf broadcast-filter {
+      type boolean;
+      description
+        "Convert all downstream broadcast ARP to unicast
+        only if Station is associated to the AP. Drop packet
+        if Station is not associated to the AP. All other
+        broadcast, except DHCP, is dropped by the AP.
+
+        DHCP Offers/ACKs are converted to Unicast, over-the-air.";
+    }
+
+    leaf multicast-filter {
+      type boolean;
+      description
+        "Drop all downstream Multicast packets.";
+    }
+
+    leaf ipv6-ndp-filter {
+      type boolean;
+      description
+        "Neighbor Advertisements will be cached at the AP (or WLC)
+        and unicast in response to Neighbor Solicitations.
+
+        Router Advertisements, in response to a Router Solicitation
+        are converted to Unicast for over-the-air transmission.";
+    }
+
+    leaf ipv6-ndp-filter-timer {
+      type uint16;
+      units seconds;
+      description
+        "Time, in seconds, the ndp-filter will cache
+        Neighbor Advertisements (NA).";
+    }
+
+    leaf station-isolation {
+      type boolean;
+      description
+        "Block Station peer to peer communication.";
+    }
+
+    leaf opmode {
+      type enumeration {
+        enum OPEN {
+          description
+            "Open authentication.";
+        }
+        enum WPA2_PERSONAL {
+          description
+            "WPA2-Personal with PSK authentication.";
+        }
+        enum WPA2_ENTERPRISE {
+          description
+            "WPA2-Enterprise with 802.1X authentication.";
+        }
+      }
+      default "OPEN";
+      description
+        "The type of Layer2 authentication in use.";
+    }
+    // Note, legacy 802.11 auth methods (ie Shared Key) explicitly absent here.
+    // It should never be used.
+
+    leaf wpa2-psk {
+      when "../opmode = 'WPA2_PERSONAL'";
+      type string {
+        length "8..63";
+      }
+      description
+        "The passphrase used on this WPA2-Personal SSID.";
+     }
+
+    leaf server-group {
+      when "../opmode = 'WPA2_ENTERPRISE' or ../opmode = 'WPA2_PERSONAL'";
+      type string;
+        description
+          "Specifies the RADIUS server-group to be used,
+          as defined in the openconfig-aaa.yang model.
+
+          Including WPA2_PERSONAL as it can be accompained by MAB.";
+    }
+
+    leaf dva {
+      type boolean;
+      description
+        "Enable/disable Dynamic VLAN Assignment,
+        using 'Tunnel-Private-Group-Id' RADIUS attribute.";
+    }
+
+    leaf dhcp-required {
+      type boolean;
+      description
+        "Allow a Station to access the network only if
+        a DHCP exchange has occurred.";
+    }
+
+    leaf qbss-load {
+      type boolean;
+      description
+        "Advertisement of the QBSS Load Information ELement.";
+    }
+
+    leaf advertise-apname {
+      type boolean;
+      description
+        "Advertise the AP hostname in Beacon and Probe Resp. frames.";
+    }
+
+    leaf csa {
+      type boolean;
+      default "true";
+      description
+        "Enable/Disable 802.11h channel-switch-announcement.";
+    }
+
+    leaf ptk-timeout {
+      type uint16;
+      units seconds;
+      description
+        "Time, in seconds, for the Pairwise Transient Key to be timed out.";
+    }
+
+    leaf gtk-timeout {
+      type uint16;
+      units seconds;
+      description
+        "TTL for the Group Temporal Key.";
+    }
+
+    leaf dot11k {
+      type boolean;
+      description
+        "802.11k neighbor-list enabled/disabled.";
+    }
+
+    leaf okc {
+      type boolean;
+      description
+        "Enable/disable Opportunistic Key Caching.";
+    }
+  }
+
+    grouping dot11v-config {
+      description
+        "802.11v configuration & state data.";
+
+      leaf dot11v-dms {
+        type boolean;
+        description
+          "802.11v Directed Multicast Service enabled/disabled.";
+      }
+
+      leaf dot11v-bssidle {
+        type boolean;
+        description
+          "802.11v BSS Max Idle enabled/disabled.";
+      }
+
+      leaf dot11v-bssidle-timeout {
+        type uint16;
+        units seconds;
+        description
+          "802.11v BSS Max Idle timeout.";
+      }
+
+      leaf dot11v-bsstransition {
+        type boolean;
+        description
+          "802.11v BSS Transition enabled/disabled.";
+      }
+    }
+
+  grouping dot11r-config {
+    description
+      "802.11r related configuration & state data.";
+
+    leaf dot11r {
+      type boolean;
+      description
+        "Enable/disable 802.11r FT.";
+    }
+
+    leaf dot11r-domainid {
+      type uint16;
+      description
+        "Mobility Domain ID.";
+    }
+
+    leaf dot11r-method {
+      type enumeration {
+        enum OVA {
+        description
+          "802.11r Over-the-AIR.";
+        }
+        enum ODS {
+        description
+          "802.11r Over-the-DS.";
+        }
+      }
+      default "OVA";
+      description
+        "The type of 802.11r FT in use.";
+    }
+
+    leaf dot11r-r1key-timeout {
+      type uint16;
+      units seconds;
+      description
+        "TTL for the Pairwise Master Key R1.";
+    }
+    // At present R1 Key distribution is left up to vendor. All APs in mgmnt
+    // subnet, all APs on WLC etc.
+  }
+
+  grouping dot1x-timers-config {
+    description
+      "Configurable 802.1X timers, per ESS.";
+
+    leaf max-auth-failures {
+      type uint8;
+      description
+        "Number of consecutive authentication failures,
+        via RADIUS Access-Reject, before Station
+        is blacklisted.";
+    }
+
+    leaf blacklist-time {
+      type uint16;
+      units seconds;
+      description
+        "Length of time, in seconds, a Station will be
+        blacklisted as a result of max-auth-failures.";
+    }
+  }
+
+  grouping wmm-config {
+    description
+      "WMM & QoS marking config, per BSS.";
+
+    leaf trust-dscp {
+      type boolean;
+      default "true";
+      description
+        "The AP should trust DSCP on 802.11 frames received
+        in this BSS.";
+    }
+
+    leaf-list wmm-vo-remark {
+      type uint8;
+      max-elements 8;
+      description
+        "Allowed DSCP markings for WMM AC_VO. Remark to lowest in this list
+        if DSCP marking falls outside of these allowed markings.
+
+        From 1 (min) to 8 (max) integers.";
+    }
+
+    leaf-list wmm-vi-remark {
+      type uint8;
+      max-elements 8;
+      description
+        "Allowed DSCP markings for WMM AC_VI. Remark to lowest in this list
+        if DSCP marking falls outside of these allowed markings.
+
+        From 1 (min) to 8 (max) integers.";
+    }
+
+    leaf-list wmm-be-remark {
+      type uint8;
+      max-elements 8;
+      description
+        "Allowed DSCP markings for WMM AC_BE. Remark to lowest in this list
+        if DSCP marking falls outside of these allowed markings.
+
+        From 1 (min) to 8 (max) integers.";
+    }
+
+    leaf-list wmm-bk-remark {
+      type uint8;
+      max-elements 8;
+      description
+        "Allowed DSCP markings for WMM AC_BK. Remark to lowest in this list
+        if DSCP marking falls outside of these allowed markings.
+
+        From 1 (min) to 8 (max) integers.";
+    }
+  }
+
+  grouping band-steering-config {
+    description
+      "Grouping for band-steering specific configuration.";
+
+    leaf band-steering {
+      type boolean;
+      description
+        "Enable/disable band-steering.";
+    }
+
+    leaf steering-rssi {
+      type int8;
+      description
+        "Minimum RSSI a dual-band Station's Probe Request
+         must be heard at on a 5GHz radio, in order for
+         band-steering to withhold 2.4GHz Probe Responses.";
+    }
+  }
+
+  grouping ssid-common-state {
+    description
+      "Grouping for defining ssid-specific operational state";
+
+    leaf bssid {
+      type oc-yang:mac-address;
+      description
+        "Represents the BSSID. Typically this is base-radio mac +/- in last
+        octet; though not strictly required.";
+    }
+
+    leaf bss-channel-utilization {
+     type oc-types:percentage;
+     description
+       "Total 802.11 channel utilization on this BSS. The total channel
+       utilization should include all time periods the AP spent actively
+       receiving and transmitting 802.11 frames on this BSS.";
+    }
+
+    leaf rx-bss-dot11-channel-utilization {
+      type oc-types:percentage;
+      description
+        "Rx channel utilization percent for this BSS.";
+    }
+
+    leaf tx-bss-dot11-channel-utilization {
+      type oc-types:percentage;
+      description
+        "Tx channel utilization percent for this BSS.";
+    }
+  }
+
+  grouping ssid-counters-state {
+    description
+      "SSID telemetry statistics.";
+
+    container counters {
+      description
+        "A collection of 802.11-related statistics.";
+
+      // Rx Counters
+      leaf rx-mgmt {
+        type oc-yang:counter64;
+        description
+          "Received 802.11 Management frames.";
+      }
+
+      leaf rx-control {
+        type oc-yang:counter64;
+        description
+          "Received 802.11 Control frames.";
+      }
+
+      container rx-data-dist {
+        description
+          "The distribution of Data frame sizes in bytes of successfully recieved
+          AMPDU, or MPDU for non-aggregated, frames.
+          The distribution should characterize frame sizes starting at 64 bytes
+          or less with the bin size doubling for each successive bin to a
+          maximum of 1MB or larger, as represented in the following table:
+
+          Lower Bound Upper Bound
+             0          64
+             65         128
+             129        256
+             257        512
+             513        1024
+             1025       2048
+             2049       4096
+             4097       8192
+             8193       16384
+             16385      32768
+             32769      65536
+             65537      131072
+             131073     262144
+             262145     524288
+             524289     1048576";
+
+        leaf rx-0-64 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 0 to 64 Bytes.";
+        }
+
+        leaf rx-65-128 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 65 to 128 Bytes.";
+        }
+
+        leaf rx-129-256 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 129 to 256 Bytes.";
+        }
+
+        leaf rx-257-512 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 257 to 512 Bytes.";
+        }
+
+        leaf rx-513-1024 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 513 to 1024 Bytes.";
+        }
+
+        leaf rx-1025-2048 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 1025 to 2048 Bytes.";
+        }
+
+        leaf rx-2049-4096 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 2049 to 4096 Bytes.";
+        }
+
+        leaf rx-4097-8192 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 4097 to 8192 Bytes.";
+        }
+
+        leaf rx-8193-16384 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 8193 to 16384 Bytes.";
+        }
+
+        leaf rx-16385-32768 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 16385 to 32768 Bytes.";
+        }
+
+        leaf rx-32769-65536 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 32769 to 65536 Bytes.";
+        }
+
+        leaf rx-65537-131072 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 65537 to 131072 Bytes.";
+        }
+
+        leaf rx-131073-262144 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 131073 to 262144 Bytes.";
+        }
+
+        leaf rx-262145-524288 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 262145 to 524288 Bytes.";
+        }
+
+        leaf rx-524289-1048576 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 524289 to 1048576 Bytes.";
+        }
+      }
+
+      container rx-data-wmm {
+        description
+          "Received 802.11 Data frames, per WMM Access Category.";
+
+        leaf vi {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames marked as Access Category Video.";
+        }
+
+        leaf vo {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames marked as Access Category Voice.";
+        }
+
+        leaf be {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames marked as Access Category Best Effort.";
+          }
+
+        leaf bk {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames marked as Access Category Background.";
+        }
+      }
+
+      container rx-mcs {
+       description
+         "Received Data frames, per MCS Index. It is expected that vendors
+          bucketize 802.11n MCS frames in their matching 802.11ac buckets.
+
+          Example, 802.11n MCS 15 = 802.11ac MCS 7.
+          802.11n MCS 20 = 802.11ac MCS 4.";
+
+        leaf mcs0 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 0.";
+         }
+
+        leaf mcs1 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 1.";
+        }
+
+        leaf mcs2 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 2.";
+        }
+
+        leaf mcs3 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 3.";
+        }
+
+        leaf mcs4 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 4.";
+        }
+
+        leaf mcs5 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 5.";
+        }
+
+        leaf mcs6 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 6.";
+        }
+
+        leaf mcs7 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 7.";
+        }
+
+        leaf mcs8 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 8.";
+        }
+
+        leaf mcs9 {
+          type oc-yang:counter64;
+          description
+            "Rx Data frames at MCS 9.";
+        }
+      }
+
+      leaf rx-retries {
+        type oc-yang:counter64;
+        description
+          "Total number of received frames with the Retry bit set, within this
+          BSS.";
+      }
+
+      leaf rx-retries-data {
+        type oc-yang:counter64;
+        description
+          "Number of received QoS Data frames with the Retry bit set";
+      }
+      leaf rx-retries-subframe {
+        type oc-yang:counter64;
+        description
+          "Aggregated MPDUs which had individual subframes that fail and require
+          retransmission.";
+      }
+
+      leaf rx-bytes-data {
+        type oc-yang:counter64;
+        description
+          "Bytes received from QoS Data frames";
+      }
+
+      // Tx Counters
+      leaf tx-mgmt {
+        type oc-yang:counter64;
+        description
+          "Transmitted 802.11 Management frames.";
+      }
+
+      leaf tx-control {
+        type oc-yang:counter64;
+        description
+          "Transmitted 802.11 Control frames.";
+      }
+
+      container tx-data-dist {
+        description
+          "The distribution of Data frame sizes in bytes of successfully transmitted
+          AMPDU, or MPDU for non-aggregated, frames.
+          The distribution should characterize frame sizes starting at 64 bytes
+          or less with the bin size doubling for each successive bin to a
+          maximum of 1MB or larger, as represented in the following table:
+
+          Lower Bound Upper Bound
+             0          64
+             65         128
+             129        256
+             257        512
+             513        1024
+             1025       2048
+             2049       4096
+             4097       8192
+             8193       16384
+             16385      32768
+             32769      65536
+             65537      131072
+             131073     262144
+             262145     524288
+             524289     1048576";
+
+        leaf tx-0-64 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 0 to 64 Bytes.";
+        }
+
+        leaf tx-65-128 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 65 to 128 Bytes.";
+        }
+
+        leaf tx-129-256 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 129 to 256 Bytes.";
+        }
+
+        leaf tx-257-512 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 257 to 512 Bytes.";
+        }
+
+        leaf tx-513-1024 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 513 to 1024 Bytes.";
+        }
+
+        leaf tx-1025-2048 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 1025 to 2048 Bytes.";
+        }
+
+        leaf tx-2049-4096 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 2049 to 4096 Bytes.";
+        }
+
+        leaf tx-4097-8192 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 4097 to 8192 Bytes.";
+        }
+
+        leaf tx-8193-16384 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 8193 to 16384 Bytes.";
+        }
+
+        leaf tx-16385-32768 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 16385 to 32768 Bytes.";
+        }
+
+        leaf tx-32769-65536 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU or MPDUs from 32769 to 65536 Bytes.";
+        }
+
+        leaf tx-65537-131072 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 65537 to 131072 Bytes.";
+        }
+
+        leaf tx-131073-262144 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 131073 to 262144 Bytes.";
+        }
+
+        leaf tx-262145-524288 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 262145 to 524288 Bytes.";
+        }
+
+        leaf tx-524289-1048576 {
+          type oc-yang:counter64;
+          description
+            "Transmitted AMPDU from 524289 to 1048576 Bytes.";
+        }
+      }
+
+      container tx-data-wmm {
+      description
+        "Transmitted QoS Data frames, per WMM AC.";
+        leaf vi {
+          type oc-yang:counter64;
+          description
+            "Tx Data frames marked as Access Category Video.";
+        }
+
+        leaf vo {
+          type oc-yang:counter64;
+          description
+            "Tx Data frames marked as Access Category Voice.";
+        }
+
+        leaf bk {
+          type oc-yang:counter64;
+          description
+            "Tx Data frames marked as Access Category Background.";
+        }
+
+        leaf be {
+          type oc-yang:counter64;
+          description
+            "Tx Data frames marked as Access Category Best Effort.";
+        }
+      }
+
+      container tx-mcs {
+        description
+          "Transmitted Data frames, per MCS Index. It is expected that vendors
+          bucketize 802.11n MCS frames in their matching 802.11ac buckets.
+
+          Example, 802.11n MCS 15 = 802.11ac MCS 7.
+          802.11n MCS 20 = 802.11ac MCS 4.";
+
+        leaf mcs0 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 0.";
+        }
+
+        leaf mcs1 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 1.";
+        }
+
+        leaf mcs2 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 2.";
+        }
+
+        leaf mcs3 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 3.";
+        }
+
+        leaf mcs4 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 4.";
+        }
+
+        leaf mcs5 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 5.";
+        }
+
+        leaf mcs6 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 6.";
+        }
+
+        leaf mcs7 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 7.";
+        }
+
+        leaf mcs8 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 8.";
+        }
+
+        leaf mcs9 {
+          type oc-yang:counter64;
+            description
+              "Tx Data frames at MCS 9.";
+        }
+      }
+
+      leaf tx-retries {
+        type oc-yang:counter64;
+        description
+          "Number of frames transmitted with the Retry bit set";
+      }
+
+      leaf tx-retries-data {
+        type oc-yang:counter64;
+        description
+          "Number of transmitted QoS Data frames with the Retry bit set";
+      }
+
+      leaf tx-retries-subframe {
+        type oc-yang:counter64;
+        description
+          "Aggregated MPDUs which had individual subframes that fail and require
+          retransmission.";
+      }
+
+      leaf tx-bytes-data {
+        type oc-yang:counter64;
+        description
+          "Bytes transmitted from QoS Data frames";
+      }
+
+      leaf num-associated-clients {
+        type uint8;
+        description
+          "Number of associated STAs to this BSS.";
+      }
+    }
+  }
+
+  grouping clients-state {
+    description
+      "List of clients; followed by state data, per client.";
+
+    leaf mac {
+      type oc-yang:mac-address;
+      description
+        "MAC address of the client.";
+    }
+
+    container counters {
+      description
+        "Per-client counters.";
+
+      leaf tx-bytes {
+        type oc-yang:counter64;
+        description
+          "Tx Bytes to this client.";
+      }
+
+      leaf rx-bytes {
+        type oc-yang:counter64;
+        description
+          "Rx Bytes from this client.";
+      }
+
+      leaf rx-retries {
+        type oc-yang:counter64;
+        description
+          "Rx retried frames from this client.";
+      }
+
+      leaf tx-retries {
+        type oc-yang:counter64;
+        description
+          "Tx retried frames to this client.";
+      }
+    }
+  }
+
+  grouping client-connect-state {
+    description
+      "Grouping for connection state related data, per client.";
+
+    container state {
+      description
+        "Container for connection state related data, per client.";
+
+      leaf client-state {
+        type identityref {
+          base oc-wifi-types:CLIENT_STATE;
+        }
+        description
+          "Various states a Client STA may be in.";
+      }
+
+      leaf connection-time {
+        type uint16;
+        units seconds;
+        description
+          "Time, in seconds, since Client Association.";
+      }
+
+      leaf username {
+        type string;
+        description
+          "Username of Client; can be outer-identity (if PEAP),
+          CN of certificate (if EAP-TLS) etc.";
+      }
+
+      leaf hostname {
+        type string;
+        description
+          "Hostname of the client, as discovered via DHCP, mDNS
+          or otherwise.";
+      }
+
+      leaf ipv4-address {
+        type oc-inet:ipv4-address;
+        description
+          "IPv4 address of the client.";
+      }
+
+      leaf ipv6-address {
+        type oc-inet:ipv6-address;
+        description
+          "IPv6 address of the client.";
+      }
+
+      leaf operating-system {
+        type string;
+        description
+          "Optional/if known; the OS of the client.";
+      }
+    }
+  }
+
+  grouping dot11k-neighbors-state {
+    description
+      "Grouping for Client beacon reports. Requires 802.11k enabled.
+      See Sec. 5.2.7.1 of 802.11k-2008 Standard.";
+    container state {
+      description
+        "Container for Client beacon reports. Requires 802.11k enabled.
+        See Sec. 5.2.7.1 of 802.11k-2008 Standard.";
+
+      leaf neighbor-bssid {
+        type oc-yang:mac-address;
+        description
+          "The BSSID of this neighbor.";
+      }
+
+      leaf neighbor-channel {
+        type uint8;
+        description
+          "The channel of this neighbor.";
+      }
+
+      leaf neighbor-rssi {
+        type int8;
+        description
+          "The RSSI of this neighbor in dBm, expressed as a negative number.";
+      }
+
+      leaf neighbor-antenna {
+        type uint8;
+        description
+          "Antenna details for this neighbor.";
+      }
+
+      leaf channel-load-report {
+        type uint8;
+        description
+          "Channel load, as reported by Client to AP
+          normalized to 255. See Sec. 10.11.9.3 of 802.11ac-2013 Spec.";
+      }
+    }
+  }
+
+  grouping client-capabilities-state {
+    description
+      "Groupig for Client capabilities, as reported by Assoc. Req. or
+      Probe Req. frames. Capability is supported, if present.";
+    container state {
+      description
+        "Container for Client capabilities, as reported by Assoc. Req. or
+        Probe Req. frames. Capability is supported, if present.";
+      leaf-list client-capabilities {
+        type identityref {
+          base oc-wifi-types:CLIENT_CAPABILITIES;
+        }
+        description
+          "Features supported by client that are Optional
+          within the 802.11 specifications.";
+      }
+
+      leaf-list channel-support {
+        type uint8;
+          description
+            "List of supported channels.";
+      }
+    }
+  }
+
+  grouping client-rf-state {
+    description
+      "Grouping for RF related client state data.";
+    container state {
+      description
+        "Container for RF related client state data.";
+
+      leaf rssi {
+        type int8;
+        description
+          "The RSSI of this client in dBm. Expressed as negative number";
+      }
+
+      leaf snr {
+        type uint8;
+        description
+          "The SNR of AP to Client, in dB.";
+      }
+
+      leaf ss {
+        type uint8;
+        description
+          "Number of Spatial Streams supported by the client.";
+      }
+
+      leaf phy-rate {
+        type uint16;
+        description
+          "Last used PHY rate of connected client.";
+      }
+
+      leaf connection-mode {
+        type enumeration {
+          enum A {
+            description
+              "Client connected using 802.11a.";
+          }
+          enum B {
+            description
+              "Client connected using 802.11b.";
+          }
+          enum G {
+            description
+              "Client connected using 802.11g.";
+          }
+          enum N {
+            description
+              "Client connected using 802.11n.";
+          }
+          enum AC {
+            description
+              "Client connected using 802.11ac.";
+          }
+        }
+        description
+          "802.11 protocol used for the client's connection.";
+      }
+
+      leaf frequency {
+        type uint8;
+        description
+          "Frequency the client is utilizing. Typically, 2.4 or 5[GHz].";
+      }
+    }
+  }
+
+  grouping clients-top {
+    description
+      "Top-level grouping for clients operational state data.";
+
+    container clients {
+      description
+        "Top-level container for clients operational state data.";
+      list client {
+        key "mac";
+        config false;
+        description
+          "List of clients per BSS.";
+        leaf mac {
+          type leafref {
+            path "../state/mac";
+          }
+          config false;
+          description
+            "The clients WiFi MAC address.";
+        }
+
+        container state {
+          config false;
+          description
+            "Client state data.";
+          uses clients-state;
+        }
+
+        container client-rf {
+          config false;
+          description
+            "RF radio-data per non-AP STA.";
+
+          uses client-rf-state;
+        }
+
+        container client-capabilities {
+          config false;
+          description
+            "Capabilites as advertised by the Client.";
+
+          uses client-capabilities-state;
+        }
+
+        container dot11k-neighbors {
+          config false;
+          description
+            "80211.k nieghbor information given from the Client to
+            the infrastructure.";
+
+          uses dot11k-neighbors-state;
+        }
+
+        container client-connection {
+          config false;
+          description
+            "Connection-state and meta-data associated with the Client.";
+
+          uses client-connect-state;
+        }
+      }
+    }
+  }
+
+  grouping wmm-top {
+    description
+      "Top-level grouping for WMM configuration and operational
+      state data.";
+
+    container wmm {
+      description
+        "Top-level container for WMM configuration and
+        state container.";
+      container config {
+        description
+          "Container for WMM configuration elements.";
+        uses wmm-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for WMM state elements.";
+        uses wmm-config;
+      }
+    }
+  }
+
+  grouping dot11r-top {
+    description
+      "Top-level grouping for 802.11r configuration and
+      operational state data.";
+
+    container dot11r {
+      description
+        "Top-level container for 802.11r configuration and
+        state container.";
+      container config {
+        description
+          "Container for 802.11r configuration elements.";
+        uses dot11r-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for 802.11r state elements.";
+        uses dot11r-config;
+      }
+    }
+  }
+
+  grouping dot11v-top {
+    description
+      "Top-level grouping for 802.11v configuration and
+      operational state data.";
+
+    container dot11v {
+      description
+        "Top-level container for 802.11v configuration and
+        operational state data.";
+      container config {
+        description
+          "Container for 802.11v configuration elements.";
+        uses dot11v-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for 802.11r state elements.";
+        uses dot11v-config;
+      }
+    }
+  }
+
+  grouping dot1x-timers-top {
+    description
+      "Top-level grouping for dot1x configuration and
+      operational state data.";
+
+    container dot1x-timers {
+      description
+        "Top-level container for dot1x configuration
+        and operational state data.";
+      container config {
+        description
+          "Container for dot1x configuration elements.";
+        uses dot1x-timers-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for dot1x state elements.";
+        uses dot1x-timers-config;
+      }
+    }
+  }
+
+  grouping band-steering-top {
+    description
+      "Top-level grouping for band-steering configuration
+      and operational state data.";
+
+    container band-steering {
+      description
+        "Top-level container for band-steering configuration
+        and operational state data.";
+      container config {
+        description
+          "Container for band-steering configuration elements.";
+        uses band-steering-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for band-steering state elements.";
+        uses band-steering-config;
+      }
+    }
+  }
+
+  grouping ssid-top {
+    description
+      "Top-level grouping for ssid configuration and operational state data.";
+
+    container ssids {
+      description
+        "Top level container for ssids, including configuration
+        and state data.";
+
+      list ssid {
+        key "name";
+        description
+          "The list of named ssids on the APs.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "References the configured name of the ssid";
+        }
+
+        container config {
+          description
+            "Configurable items at the global, ssid level";
+
+          uses ssid-common-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data at the ssid level";
+
+          uses ssid-common-config;
+          uses ssid-common-state;
+          uses ssid-counters-state;
+        }
+        uses wmm-top;
+        uses dot11r-top;
+        uses dot11v-top;
+        uses clients-top;
+        uses dot1x-timers-top;
+        uses band-steering-top;
+      }
+    }
+  }
+  uses ssid-top;
+}

--- a/release/models/wifi/phy/.spec.yml
+++ b/release/models/wifi/phy/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-wifi-phy
+  docs:
+    - wifi/openconfig-wifi-phy.yang
+    - wifi/types/openconfig-wifi-types.yang
+  build:
+    - wifi/openconfig-wifi-phy.yang
+  run-ci: true

--- a/release/models/wifi/phy/openconfig-wifi-phy.yang
+++ b/release/models/wifi/phy/openconfig-wifi-phy.yang
@@ -1,0 +1,365 @@
+module openconfig-wifi-phy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/wifi/phy";
+
+  // Assign this module a prefix to be used by other modules, when imported.
+  prefix "oc-wifi-phy";
+
+  // Imports
+  import openconfig-yang-types { prefix oc-yang; }
+  // OC-specific types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-wifi-types { prefix oc-wifi-types; }
+
+  // Some required meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Model for managing PHY layer configuration of Radio interfaces.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2017-07-25" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // Grouping statements
+  grouping radio-common-config {
+    description
+      "Configuration items common to all Radio interfaces, independent
+      of frequency";
+
+    leaf id {
+      type uint8;
+      description
+        "Unique ID of the radio.";
+    }
+
+    leaf operating-frequency {
+      type identityref {
+        base oc-wifi-types:OPERATING_FREQUENCY;
+      }
+      description
+        "Operating frequency of this radio.";
+    }
+
+    leaf enabled {
+      type boolean;
+      default "true";
+      description
+        "The desired operational state (up/down) of this radio interface.";
+    }
+
+    leaf transmit-power {
+      type uint8;
+      units dBm;
+      default 9;
+      description
+        "Transmit power of the radio, in dBm.";
+    }
+
+    leaf channel {
+      type uint8 {
+        range "1..165";
+        }
+      description
+        "Operating channel of this radio. If using channel-bonding this
+        will represent the Primary 20MHz channel of the 40,80,160MHz channel.";
+    }
+
+    leaf channel-width {
+      type uint8;
+      units MHz;
+      default 20;
+      description
+        "Operating channel-width of this radio.";
+    }
+
+    leaf dca {
+      type boolean;
+      default "true";
+      description
+        "Utilize Dynamic Channel Assignemnt on this Radio.";
+    }
+
+    leaf-list allowed-channels {
+      type oc-wifi-types:channels-type;
+      description
+        "Allowed channel list for this Radio to utilize.";
+    }
+
+    leaf dtp {
+      type boolean;
+      default "true";
+      description
+        "Utilize dynamic transmit-power on this Radio.";
+    }
+
+    leaf dtp-min {
+      when "../dtp = 'true'";
+      type uint8;
+      default '3';
+      description
+        "Minimum allowed transmit-power on this radio, if utilzing dtp.
+        Expressed in dBm.";
+    }
+
+    leaf dtp-max {
+      when "../dtp = 'true'";
+      type uint8;
+      default '15';
+      description
+        "Maximum allowed transmit-power on this radio, if utilzing dtp.
+        Expressed in dBm.";
+    }
+
+    leaf antenna-gain {
+      type int8;
+      description
+        "Antenna gain applied to this Radio; typically used when
+        external antennae connected.";
+    }
+
+    leaf scanning {
+      type boolean;
+      default "true";
+      description
+        "Whether the radio will perform off-channel scanning, to collect
+        neighboring RF information.";
+    }
+
+    leaf scanning-interval {
+      type uint8;
+      units seconds;
+      description
+        "How often, in seconds, the radio will go off-channel to perform
+        scanning.";
+    }
+
+    leaf scanning-dwell-time {
+      type uint16;
+      units milliseconds;
+      description
+        "Amount of time, in milliseconds, the radio will spend on a
+        channel during scanning-interval. If a Monitor-mode Radio, it will
+        cycle through scanning-allowed-channels spending this amount of time
+        on each.";
+    }
+
+    leaf scanning-defer-clients {
+      type uint8;
+      description
+        "Do not perform scanning if this amount of Stations are Associated
+        to the Radio.";
+    }
+
+    leaf scanning-defer-traffic {
+      type boolean;
+      description
+        "Do not perform scanning if any traffic recieved from an active Station
+        in the past 100ms marked as AC_VO or AC_VI.";
+    }
+  }
+
+  grouping radio-common-state {
+    description
+      "Grouping for defining radio-specific operational state";
+
+    leaf base-radio-mac {
+      type oc-yang:mac-address;
+      description
+        "Represents the 'burned-in' base-radio MAC
+        address for the a Radio interface.";
+    }
+
+    leaf dfs-hit-time {
+      type oc-types:timeticks64;
+      description
+        "Reports the time of the last DFS hit. The value is the timestamp
+        in seconds relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf channel-change-reason {
+      type identityref {
+        base oc-wifi-types:CHANGE_REASON_TYPE;
+      }
+      description
+        "When an Access Point changes channels, this will
+        provide the reason that led to the change.";
+    }
+
+    leaf total-channel-utilization {
+      type oc-types:percentage;
+      description
+        "Total 802.11 and non-802.11 channel utilization on this Radio. The
+        total channel utilization should include all time periods the AP
+        spent actively receiving and transmitting 802.11 frames, and also
+        include all time spent with clear channel assessment (CCA) in a
+        busy state";
+    }
+
+    leaf rx-dot11-channel-utilization {
+      type oc-types:percentage;
+      description
+        "Received channel-utilization due to 802.11 frames";
+    }
+
+    leaf rx-noise-channel-utilization {
+      type oc-types:percentage;
+         description
+           "Received channel-utilization percentage due to Noise.";
+    }
+
+    leaf tx-dot11-channel-utilization {
+      type oc-types:percentage;
+      description
+        "Transmit channel-utilization percentage.";
+    }
+  }
+
+  grouping radio-counters-state {
+    description
+      "Radio telemetry statistics.";
+    container counters {
+      description
+        "A collection of radio-related statistics objects.";
+
+      // Rx Counters
+      leaf failed-fcs-frames {
+        type oc-yang:counter64;
+        description
+          "Number of frames that failed the FCS";
+      }
+
+      // Tx Counters
+      leaf noise-floor {
+        type int8;
+        description
+          "Noise Floor, as measured by this radio.";
+      }
+    }
+  }
+
+  // neighbor BSSID | RSSI | Channel | Center Channel
+  grouping neighbor-list-state {
+    description
+      "Operational state data relating to neighboring
+       BSSIDs and their recieved signal strength.";
+    leaf bssid {
+      type oc-yang:mac-address;
+      description
+        "Neighboring BSSID.";
+    }
+
+    leaf rssi {
+      type int8;
+      description
+       "The RSSI of this neighboring BSSID.";
+    }
+
+    leaf channel {
+      type uint16;
+      description
+        "The channel of this neighboring BSSID. This is to utilize 802.11ac
+        nomenclature. For example, 40MHz channel 36-40 represented as
+        channel 38. primary-channel used to identifhy the primary
+        20MHz channel of the neighbor.";
+    }
+
+    leaf primary-channel {
+      type uint16;
+      description
+        "The primary 20MHz channel, if the neighbor is operating on bonded
+        channel.";
+    }
+  }
+
+  grouping neighbor-bssid-top {
+  description
+    "Top-level grouping for neigbhor table
+    operational state data.";
+
+    container neighbors {
+      description
+        "Top-level container for RF neighbors.";
+      list neighbor {
+        key "bssid";
+        config false;
+        description
+          "The mac address, or BSSID, of a neighbor, and
+          their corresponding RSSI.";
+
+        leaf bssid {
+          type leafref {
+            path "../state/bssid";
+          }
+          config false;
+          description "Reference to neighbor bssid.";
+        }
+
+        container state {
+          config false;
+          description
+            "State container for RF neighbors.";
+          uses neighbor-list-state;
+        }
+      }
+    }
+  }
+
+  grouping radio-top {
+    description
+      "Top-level grouping for radio configuration and
+      operational state data";
+
+    container radios {
+      description
+        "Top level container for radios, including configuration
+        and state data.";
+
+      list radio {
+        key "id";
+        description
+          "The list of radios on the device.";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "References the configured id of the radio";
+        }
+
+        container config {
+          description
+            "Configurable items at the global, radio interface
+            level";
+
+          uses radio-common-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data at the global radio level";
+
+          uses radio-common-config;
+          uses radio-common-state;
+          uses radio-counters-state;
+        }
+        uses neighbor-bssid-top;
+      }
+    }
+  }
+  uses radio-top;
+}

--- a/release/models/wifi/system/.spec.yml
+++ b/release/models/wifi/system/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-system-wifi-ext.yang
+  docs:
+    - wifi/system/openconfig-system-wifi-ext.yang
+    - system/openconfig-system.yang
+  build:
+    - wifi/system/openconfig-system-wifi-ext.yang
+  run-ci: true

--- a/release/models/wifi/system/openconfig-system-wifi-ext.yang
+++ b/release/models/wifi/system/openconfig-system-wifi-ext.yang
@@ -1,0 +1,250 @@
+module openconfig-system-wifi-ext {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/wifi";
+
+  // Assign this module a prefix to be used by other modules, when imported.
+  prefix "oc-system-wifi-ext";
+  // Imports
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
+  // WiFi types
+  import openconfig-wifi-types { prefix oc-wifi; }
+  // Original model this is augmenting
+  import openconfig-system { prefix "oc-sys"; }
+
+  // Some required meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Model for managing Controller-specific Config & State for
+    system-level elements. This explicitly excludes any 802.11
+    MAC/PHY layer elements.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2017-07-25" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // grouping statements
+
+  grouping assigned-controllers-config {
+    description
+      "Controller(s) an AP may join. If cloud controller, this will be
+      the cloud instance(s). This config is applied to APs, not Controllers,
+      which is in-line with APs being the top-level network element.";
+
+    leaf id {
+      type string;
+      description
+        "id serves as a reference point to the [1-n] Controller(s) this AP
+        is assigned to.";
+      }
+
+    leaf fqdn {
+      type oc-inet:domain-name;
+      description
+        "The FQDN of a Controller this AP is assigned to. The list should be
+        ordered, according to priority. eg Primary first,
+        Secondary second, Tertiary third etc.";
+    }
+
+    leaf controller-ipv4-address {
+      type oc-inet:ipv4-address;
+      description
+        "IPv4 address of Controller for this AP. The list should be
+        ordered, according to priority. eg. Primary first, Secondary second,
+        Tertiary third etc.";
+    }
+
+    leaf-list controller-ipv6-address {
+      type oc-inet:ipv6-address;
+      description
+        "IPv6 address of Controller for this AP. The list should be
+        ordered, according to priority. eg. Primary first, Secondary second,
+        Tertiary third etc.";
+    }
+  }
+
+  // Note, configuration of both AP & Controller system parameters, such as
+  // hostname & IP utilizes parent model (openconfig-system.yang)
+  grouping controller-aps-system-state {
+    description
+      "Grouping for a controllers AP state data.";
+
+    leaf hostname {
+      type oc-inet:domain-name;
+      description
+        "Unqualified hostname of the Access Point.";
+    }
+
+    leaf domain-name {
+      type oc-inet:domain-name;
+      description
+        "FQDN of the Access Point.";
+    }
+
+    leaf opstate {
+      type identityref {
+        base oc-wifi:AP_STATE;
+      }
+      description
+        "The current operational state of the AP.";
+    }
+
+    leaf uptime {
+      type uint32;
+      units seconds;
+      description
+        "Seconds this AP has been in the op-state of 'Up'.";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "Wheather the AP is enabled or disabled.";
+    }
+
+    leaf serial {
+      type string;
+      description
+        "Serial number of the Access Point.";
+    }
+
+    leaf model {
+      type string;
+      description
+        "Model number of the Access Point.";
+    }
+
+    leaf ipv4 {
+      type oc-inet:ipv4-address;
+      description
+        "The IPv4 address of the Access Point.";
+    }
+
+    leaf ipv6 {
+      type oc-inet:ipv6-address;
+      description
+        "The IPv6 address of the Access Point.";
+    }
+
+    leaf mac {
+      type oc-yang:mac-address;
+      description
+        "MAC address of the AP primary Ethernet interface. If AP
+        has multiple Ethernet interfaces, this would be the MAC printed
+        on the unit label.";
+    }
+
+    leaf power-source {
+      type enumeration {
+      enum AT {
+        description "Powered using 802.3at.";
+      }
+      enum AF {
+        description "Powered using 802.3af.";
+      }
+      enum PLUG {
+        description "Powered using local source, not PoE.";
+      }
+    }
+    description
+      "Enumerate how the AP is being powered.";
+    }
+  }
+
+  grouping controller-aps-system-top {
+    description
+      "Top-level grouping for APs assigned to controller(s).";
+
+    container joined-aps {
+      description
+        "Top most container for joined-aps.";
+
+      list joined-ap {
+        key "hostname";
+        config false;
+        description
+          "All AP hostnames joined to this Controller, or cloud instance.
+          Note, this may also be useful for architectures which utilize
+          APs as virtual-controllers.";
+
+        leaf hostname {
+          type leafref {
+            path "../state/hostname";
+          }
+          description
+            "FQDN of the AP.";
+        }
+
+        container state {
+          config false;
+          description
+            "State container for Joined APs.";
+
+          uses controller-aps-system-state;
+        }
+      }
+    }
+  }
+
+  grouping controller-ap-parameters-top {
+    description
+      "Top-level grouping for assigning AP's to Controller(s).";
+
+    container ap-assigned-controllers {
+      description
+        "Wireless Controller(s) this AP is assigned to. eg. Primary
+        Secondary, Tertiary etc. This is config & state applied to an AP;
+        not used for Controller state (eg 'joined-aps' are below).";
+
+      list controller {
+        key "id";
+        description
+          "Controller(s) this AP is assinged to, referenced by id.";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "id serves as a reference point to the [1-n] Controller(s) this AP
+            is assigned to.";
+        }
+
+        container config {
+          description
+            "Config. container for assigning APs to Controllers.";
+
+          uses assigned-controllers-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State container for APs to Controllers.";
+
+          uses assigned-controllers-config;
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+  description
+    "Augmentation to opeconfig-system.yang to include WiFi Controller.";
+
+  uses controller-ap-parameters-top;
+  uses controller-aps-system-top;
+  }
+}

--- a/release/models/wifi/types/.spec.yml
+++ b/release/models/wifi/types/.spec.yml
@@ -1,0 +1,6 @@
+- name: openconfig-wifi-types
+  docs:
+    - yang/wifi/openconfig-wifi-types.yang
+  build:
+    - yang/wifi/openconfig-wifi-types.yang
+  run-ci: false

--- a/release/models/wifi/types/openconfig-wifi-types.yang
+++ b/release/models/wifi/types/openconfig-wifi-types.yang
@@ -1,0 +1,295 @@
+module openconfig-wifi-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/wifi/types";
+
+  // Assign this module a prefix to be used by other modules, when imported.
+  prefix "oc-wifi-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // Some required meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains a set of WiFi-specific type definitions
+    that are used in the openconfig-wifi modules. It can be
+    imported by any module to make use of these types.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2017-07-25" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  //typdef statements
+  typedef channels-type {
+    type uint8 {
+      range "1..14 | 36 | 40 | 44| 48 | 52 | 56 | 60 | 64 | 100 | 104 | 108 | 112 | 116 | 120 | 124 | 128 | 132 | 136 | 140 | 144 | 149 | 153 | 157 | 161 | 165";
+    }
+    description
+      "Type to specify all the WiFi channels available for use. This is
+      a superset of what may be allowed by any one particular regulatory
+      domain.";
+  }
+
+  // identity statements
+  identity CLIENT_STATE {
+    description
+      "Base type to specify the current state of a Client.";
+  }
+
+  identity ASSOCIATED {
+    base CLIENT_STATE;
+    description
+      "Client has finished 802.11 Association phase. This implies 'Open' system,
+      or 802.11 Authentication complete.";
+  }
+
+  identity L2AUTH_REQD {
+    base CLIENT_STATE;
+    description
+      "Client has Assocated, but not L2 Authenticated (e.g. 802.1X)";
+  }
+
+  identity L3AUTH_REQD {
+    base CLIENT_STATE;
+    description
+      "Client has Assocated, but not L3 Authenticated (e.g. Captive Portal)";
+  }
+
+  identity DHCP_REQD {
+    base CLIENT_STATE;
+    description
+      "Client has Associated & Authenticated, but has not obtained IP address.";
+  }
+
+  identity AUTHENTICATED {
+    base CLIENT_STATE;
+    description
+      "Client has fully Authenticated & permitted to access network resources.";
+  }
+
+  identity L2AUTH_FAILURE_REJECT {
+    base CLIENT_STATE;
+    description
+      "L2 failure, due to RADIUS Access-Reject.";
+  }
+
+  identity L2AUTH_FAILURE_TIMEOUT {
+    base CLIENT_STATE;
+    description
+      "L2 failure, due to RADIUS timeout.";
+  }
+
+  identity L3AUTH_FAILURE {
+    base CLIENT_STATE;
+    description
+      "L3 failure. Could be incorrect CP credentials or higher layer
+      Captive Portal issues.";
+  }
+
+  identity DHCP_FAILURE {
+    base CLIENT_STATE;
+    description
+      "Client has Associated & Authenticated but has failed to recieve an IP
+      address, utilizing DHCP.";
+  }
+
+  identity POWERSAVE {
+    base CLIENT_STATE;
+    description
+      "AP has recieved a PS frame, indicating the client is currently in a
+      powersave state.";
+  }
+
+  identity BLACKLISTED {
+    base CLIENT_STATE;
+    description
+      "This client has been blacklisted, through either L2 (MAC) or higher-level
+      (signature) mechanisms.";
+  }
+
+  identity AP_STATE {
+    description "The Up/Down state of an AP.";
+  }
+
+  identity UP {
+    base AP_STATE;
+    description
+      "The AP is in the up state.";
+  }
+
+  identity DOWN {
+    base AP_STATE;
+    description
+      "The AP is in the down state.";
+  }
+
+  identity UPGRADING {
+    base AP_STATE;
+    description
+      "The AP is in the Downgrading firmware state.";
+  }
+
+  // Possible basic-rates are: 1, 2, 5.5, 6, 9, 11, 12, 18, 24, 36, 48, 54 //
+  identity DATA_RATE {
+    description "base type to specify available Data-rates.";
+  }
+
+  identity RATE_1MB {
+    base DATA_RATE;
+    description "1 Mbps DSSS PHY";
+  }
+
+  identity RATE_2MB {
+    base DATA_RATE;
+    description "2 Mbps DSSS PHY";
+  }
+
+  identity RATE_5.5MB {
+    base DATA_RATE;
+    description "5.5 Mbps DSSS PHY";
+  }
+
+  identity RATE_6MB {
+    base DATA_RATE;
+    description "6 Mbps OFDM PHY";
+  }
+
+  identity RATE_9MB {
+    base DATA_RATE;
+    description "9 Mbps OFDM PHY";
+  }
+
+  identity RATE_11MB {
+    base DATA_RATE;
+    description "11 Mbps DSSS PHY";
+  }
+
+  identity RATE_12MB {
+    base DATA_RATE;
+    description "12 Mbps OFDM PHY";
+  }
+
+  identity RATE_18MB {
+    base DATA_RATE;
+    description "18 Mbps OFDM PHY";
+  }
+
+  identity RATE_24MB {
+    base DATA_RATE;
+    description "24 Mbps OFDM PHY";
+  }
+
+  identity RATE_36MB {
+    base DATA_RATE;
+    description "36 Mbps OFDM PHY";
+  }
+
+  identity RATE_48MB {
+    base DATA_RATE;
+    description "48 Mbps OFDM PHY";
+  }
+
+  identity RATE_54MB {
+    base DATA_RATE;
+    description "54 Mbps OFDM PHY";
+  }
+
+  identity OPERATING_FREQUENCY {
+    description "Operating frequency of a Radio or SSID.";
+  }
+
+  identity FREQ_2GHZ {
+    base OPERATING_FREQUENCY;
+    description "The Radio or SSID will operate at 2.4GHz only.";
+  }
+
+  identity FREQ_5GHZ {
+  base OPERATING_FREQUENCY;
+  description "The Radio or SSID will operate at 5GHz only.";
+  }
+
+  identity FREQ_2_5_GHZ {
+    base OPERATING_FREQUENCY;
+    description
+      "The Radio or SSID will be dual-band; operating in
+      both 2.4 & 5GHz frequencies.
+
+      Dual-band Radio typically refers to a Monitor-mode radio, hopping
+      between frequencies, dwelling for a configurable amount of time on
+      each frequency.";
+  }
+
+  identity CLIENT_CAPABILITIES {
+    description
+      "Client capabilities, as reported by Assoc. Req. or
+      Probe Req. frames.";
+  }
+
+  identity MU_BEAMFORMER {
+    base CLIENT_CAPABILITIES;
+    description "Whether this STA can MU-MIMO Beamform.";
+  }
+
+    identity MU_BEAMFORMEE {
+    base CLIENT_CAPABILITIES;
+    description "Whether this STA can Rx MU-MIMO Beamformed frames.";
+  }
+
+  identity DOT_11R {
+    base CLIENT_CAPABILITIES;
+    description
+      "Whether this STA supports 802.11r. Note, must be
+      enabled on BSS for this to be accurate.";
+  }
+
+  identity DOT_11V {
+    base CLIENT_CAPABILITIES;
+    description
+      "Whether this STA supports 802.11v BSS Transition. Note, must
+      be enabled on BSS for this to be accurate; unless Probe Req.
+      are observied in addition to Assoc. Req.";
+  }
+
+  identity CHANGE_REASON_TYPE {
+    description
+      "Base type to specify the reason an Access Point
+      has changed channels.";
+  }
+  identity DFS {
+    base CHANGE_REASON_TYPE;
+    description
+      "DFS hit occured.";
+  }
+
+  identity NOISE {
+    base CHANGE_REASON_TYPE;
+    description
+      "Excessive amounts of non-802.11 Noise occured.";
+  }
+
+  identity ERRORS {
+    base CHANGE_REASON_TYPE;
+    description
+      "Excessive reception of frames which
+      failed the FCS occured.";
+  }
+
+  identity BETTER-CHANNEL {
+    base CHANGE_REASON_TYPE;
+    description
+      "A less utilized channel exists. eg CCI avoidance
+       led to this channel-change.";
+  }
+  // Extend channel-change reasons here, when applicable.
+}


### PR DESCRIPTION
- Left directory structure as it is in wifi-models private repo
- Specifically; yang/wifi/system/oc-sys-wifi-ext.yang now exists, in addition to yang/system/oc-sys.yang
- yang/wifi/types/oc-wifi-types.yang now exists, in addition to yang/types/...yang
- Modified .spec.yml files to match this directory structure.

LMK how that looks.