### PR TITLE
[MAC] Add mob domain & change counters. [PHY] Add nbr timestamp.

### DIFF
--- a/release/models/wifi/mac/openconfig-wifi-mac.yang
+++ b/release/models/wifi/mac/openconfig-wifi-mac.yang
@@ -28,6 +28,13 @@ module openconfig-wifi-mac {
 
   oc-ext:openconfig-version "0.1.0";
 
+  revision "2017-12-21" {
+    description
+      "Add mobility-domain and move/create bssid-state list for 
+      counters.";
+    reference "0.2.0";
+  }
+
   revision "2017-07-25" {
     description
       "Initial revision";
@@ -179,6 +186,13 @@ module openconfig-wifi-mac {
       description
         "Enable/disable Dynamic VLAN Assignment,
         using 'Tunnel-Private-Group-Id' RADIUS attribute.";
+    }
+
+    leaf mobility-domain {
+      type string;
+      description
+        "Specify the mobility domain where PMK-R0 distribution will occur.
+        Specifically, which APs will recieve PMK-R0 if using 802.11r (FT)."; 
     }
 
     leaf dhcp-required {
@@ -431,13 +445,39 @@ module openconfig-wifi-mac {
     }
   }
 
-  grouping ssid-counters-state {
+  grouping bss-common-state {
     description
-      "SSID telemetry statistics.";
+      "Grouping for defining bss-specific operational state.";
+
+    leaf ess {
+      type leafref {
+        path "../../../../ssids/ssid/name";
+      }
+      description
+        "Name of the ESS this BSS is utilizing.";
+    }
+
+    leaf num-associated-clients {
+      type uint8;
+      description
+        "Number of associated STAs to this BSS.";
+    }
+  }
+
+  grouping bssid-counters-state {
+    description
+      "BSSID telemetry statistics.";
+
+    leaf bssid {
+      type oc-yang:mac-address;
+      description
+        "MAC of the BSS.";
+    }
 
     container counters {
+      config false;
       description
-        "A collection of 802.11-related statistics.";
+        "BSS Counters.";
 
       // Rx Counters
       leaf rx-mgmt {
@@ -454,8 +494,8 @@ module openconfig-wifi-mac {
 
       container rx-data-dist {
         description
-          "The distribution of Data frame sizes in bytes of successfully recieved
-          AMPDU, or MPDU for non-aggregated, frames.
+          "The distribution of Data frame sizes in bytes of successfully
+          recieved AMPDU, or MPDU for non-aggregated, frames.
           The distribution should characterize frame sizes starting at 64 bytes
           or less with the bin size doubling for each successive bin to a
           maximum of 1MB or larger, as represented in the following table:
@@ -941,12 +981,6 @@ module openconfig-wifi-mac {
         description
           "Bytes transmitted from QoS Data frames";
       }
-
-      leaf num-associated-clients {
-        type uint8;
-        description
-          "Number of associated STAs to this BSS.";
-      }
     }
   }
 
@@ -1364,6 +1398,39 @@ module openconfig-wifi-mac {
     }
   }
 
+  grouping bssid-counters-top {
+    description
+      "Top-level grouping for BSSID operational state data.";
+
+    container bssids {
+      description
+        "Top-level container for BSSID operational state data.";
+      list bssid {
+        key "bssid";
+        config false;
+        description
+          "List of BSSIDs.";
+        leaf bssid {
+          type leafref {
+            path "../state/bssid";
+          }
+          config false;
+          description
+            "The BSSID MAC address.";
+        }
+
+        container state {
+          config false;
+          description
+            "BSSID state data.";
+
+          uses bss-common-state;
+          uses bssid-counters-state;
+        }
+      }
+    }
+  }
+
   grouping ssid-top {
     description
       "Top-level grouping for ssid configuration and operational state data.";
@@ -1400,7 +1467,6 @@ module openconfig-wifi-mac {
 
           uses ssid-common-config;
           uses ssid-common-state;
-          uses ssid-counters-state;
         }
         uses wmm-top;
         uses dot11r-top;
@@ -1412,4 +1478,5 @@ module openconfig-wifi-mac {
     }
   }
   uses ssid-top;
+  uses bssid-counters-top;
 }

--- a/release/models/wifi/phy/openconfig-wifi-phy.yang
+++ b/release/models/wifi/phy/openconfig-wifi-phy.yang
@@ -25,7 +25,13 @@ module openconfig-wifi-phy {
   description
     "Model for managing PHY layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2017-11-06" {
+    description
+      "Add SSID to neighbor-table.";
+    reference "0.1.1";
+  }
 
   revision "2017-07-25" {
     description
@@ -89,7 +95,7 @@ module openconfig-wifi-phy {
       type boolean;
       default "true";
       description
-        "Utilize Dynamic Channel Assignemnt on this Radio.";
+        "Utilize Dynamic Channel Assignment on this Radio.";
     }
 
     leaf-list allowed-channels {
@@ -110,7 +116,7 @@ module openconfig-wifi-phy {
       type uint8;
       default '3';
       description
-        "Minimum allowed transmit-power on this radio, if utilzing dtp.
+        "Minimum allowed transmit-power on this radio, if utilizing dtp.
         Expressed in dBm.";
     }
 
@@ -119,7 +125,7 @@ module openconfig-wifi-phy {
       type uint8;
       default '15';
       description
-        "Maximum allowed transmit-power on this radio, if utilzing dtp.
+        "Maximum allowed transmit-power on this radio, if utilizing dtp.
         Expressed in dBm.";
     }
 
@@ -166,7 +172,7 @@ module openconfig-wifi-phy {
     leaf scanning-defer-traffic {
       type boolean;
       description
-        "Do not perform scanning if any traffic recieved from an active Station
+        "Do not perform scanning if any traffic received from an active Station
         in the past 100ms marked as AC_VO or AC_VI.";
     }
   }
@@ -250,15 +256,21 @@ module openconfig-wifi-phy {
     }
   }
 
-  // neighbor BSSID | RSSI | Channel | Center Channel
+  // neighbor BSSID | SSID | RSSI | Channel | Center Channel
   grouping neighbor-list-state {
     description
       "Operational state data relating to neighboring
-       BSSIDs and their recieved signal strength.";
+       BSSIDs and their received signal strength.";
     leaf bssid {
       type oc-yang:mac-address;
       description
         "Neighboring BSSID.";
+    }
+
+    leaf ssid {
+      type string;
+      description
+       "The SSID of this neighboring BSSID.";
     }
 
     leaf rssi {
@@ -272,7 +284,7 @@ module openconfig-wifi-phy {
       description
         "The channel of this neighboring BSSID. This is to utilize 802.11ac
         nomenclature. For example, 40MHz channel 36-40 represented as
-        channel 38. primary-channel used to identifhy the primary
+        channel 38. primary-channel used to identify the primary
         20MHz channel of the neighbor.";
     }
 
@@ -286,7 +298,7 @@ module openconfig-wifi-phy {
 
   grouping neighbor-bssid-top {
   description
-    "Top-level grouping for neigbhor table
+    "Top-level grouping for neighbor table
     operational state data.";
 
     container neighbors {


### PR DESCRIPTION
(M) wifi/mac/openconfig-wifi-mac.yang
-Turn the counters container (which is below the root-level State container MAC model) into a list, key'd by BSSID.
-Repositioned the counters container, to be outside of the top-most SSID list.
-Add 'mobility-domain' to MAC model.

(M) wifi/phy/openconfig-wifi-phy.yang
-Add 'last-seen' timestamp to the neighbor table in the PHY model.