### PR TITLE
[MAC] Add mob domain & change counters. [PHY] Add nbr timestamp.

### DIFF
--- a/release/models/wifi/mac/openconfig-wifi-mac.yang
+++ b/release/models/wifi/mac/openconfig-wifi-mac.yang
@@ -26,7 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
 
   revision "2017-12-21" {
     description

--- a/release/models/wifi/phy/openconfig-wifi-phy.yang
+++ b/release/models/wifi/phy/openconfig-wifi-phy.yang
@@ -25,7 +25,13 @@ module openconfig-wifi-phy {
   description
     "Model for managing PHY layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2017-12-21" {
+    description
+      "Add last-seen to neighbor-table.";
+    reference "0.2.0";
+  }
 
   revision "2017-11-06" {
     description
@@ -256,7 +262,7 @@ module openconfig-wifi-phy {
     }
   }
 
-  // neighbor BSSID | SSID | RSSI | Channel | Center Channel
+  // neighbor BSSID | SSID | RSSI | Channel | Center Channel | Last-seen
   grouping neighbor-list-state {
     description
       "Operational state data relating to neighboring
@@ -293,6 +299,16 @@ module openconfig-wifi-phy {
       description
         "The primary 20MHz channel, if the neighbor is operating on bonded
         channel.";
+    }
+
+    leaf last-seen {
+      type oc-types:timeticks64;
+      description
+        "Reports the time this reading was taken, indicating when this neighbor
+        was last seen. If a cache is used, it MUST be updated instantly when a
+        neighbor BSS changes channels, or a new BSS is seen. The value is the
+        timestamp in seconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC).";
     }
   }
 

--- a/release/models/wifi/system/openconfig-system-wifi-ext.yang
+++ b/release/models/wifi/system/openconfig-system-wifi-ext.yang
@@ -27,7 +27,7 @@ module openconfig-system-wifi-ext {
     system-level elements. This explicitly excludes any 802.11
     MAC/PHY layer elements.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
 
   revision "2017-10-01" {
     description


### PR DESCRIPTION
(M) wifi/mac/openconfig-wifi-mac.yang
-Turn the counters container (which is below the root-level State container MAC model) into a list, key'd by BSSID.
-Repositioned the counters container, to be outside of the top-most SSID list.
-Add 'mobility-domain' to MAC model.

(M) wifi/phy/openconfig-wifi-phy.yang
-Add 'last-seen' timestamp to the neighbor table in the PHY model.