### PR TITLE
network-instance have invalid identifier OSPF2

### DIFF
--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -672,7 +672,7 @@ module openconfig-network-instance {
             }
 
             uses oc-ospfv2:ospfv2-top {
-              when "config/identifier = 'OSPF2'" {
+              when "config/identifier = 'OSPF'" {
                 description
                   "Include OSPFv2 parameters only when the protocol
                   is of type OSPFv2";


### PR DESCRIPTION
https://github.com/openconfig/public/issues/144

identityref has OSPF and OSPF3 (but not OSPF2) in openconfig-policy-types protocol definition.