### PR TITLE
Wrong 'parent' definition in openconfig-platform

### DIFF
--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -410,7 +410,7 @@ module openconfig-platform {
 
     leaf parent {
       type leafref {
-        path "../../config/name";
+        path "../../../component/config/name";
       }
       description
         "Reference to the name of the parent component.  Note that


### PR DESCRIPTION
The definiton of the parent in the platform points to the reference of it self.
```
type leafref {
        path "../../config/name";
      }
```
But it should point to an other component.
```
type leafref {
        path "../../../component/config/name";
      }
```