### PR TITLE
Adding Explicit NULL label configuration for SRTE policies.

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-srte.yang
+++ b/release/models/policy-forwarding/openconfig-pf-srte.yang
@@ -159,7 +159,10 @@ module openconfig-pf-srte {
       type explicit-null-label-type;
       description
         "Type of explicit null label that is being pushed on an unlabeled
-        IP packet. If leaf is unspecified, null label is not added."
+        IP packet. If unspecified, the behaviour of the system is undefined,
+        and is subject to local implementation choice.";
+      reference
+        "draft-ietf-idr-segment-routing-te-policy - Section 2.4.4";
     }
   }
 

--- a/release/models/policy-forwarding/openconfig-pf-srte.yang
+++ b/release/models/policy-forwarding/openconfig-pf-srte.yang
@@ -63,23 +63,23 @@ module openconfig-pf-srte {
   typedef explicit-null-label-type {
     type enumeration {
       enum IPV4 {
-        description "Push an IPv4 Explicit NULL label on an unlabeled 
-                    IPv4 packet";
+        description
+          "Push an IPv4 Explicit NULL label on an unlabeled IPv4 packet";
       }
       enum IPV6 {
-        description "Push an IPv6 Explicit NULL label on an unlabeled 
-                    IPv6 packet";
+        description
+          "Push an IPv6 Explicit NULL label on an unlabeled IPv6 packet";
       }
       enum IPV4_IPV6 {
-        description "Push an IPv4 Explicit NULL label on an unlabeled 
-                    IPv4 packet; 
-                    Push an IPv6 Explicit NULL label on an unlabeled 
-                    IPv6 packet";
+        description
+          "Push an IPv4 Explicit NULL label on an unlabeled IPv4 packet;
+          Push an IPv6 Explicit NULL label on an unlabeled IPv6 packet";
       }
       enum NONE {
-        description "No Explicit NULL label will be pushed for both 
-                    IPv4 and IPv6 unlabeled packets";
-      } 
+        description
+          "No Explicit NULL label will be pushed for both IPv4 and IPv6
+          unlabeled packets";
+      }
     }
   }
 
@@ -158,8 +158,8 @@ module openconfig-pf-srte {
     leaf explicit-null-label {
       type explicit-null-label-type;
       description
-        "Indicates type of explicit null label that is being pushed on 
-        an unlabeled IP packet"
+        "Type of explicit null label that is being pushed on an unlabeled
+        IP packet. If leaf is unspecified, null label is not added."
     }
   }
 

--- a/release/models/policy-forwarding/openconfig-pf-srte.yang
+++ b/release/models/policy-forwarding/openconfig-pf-srte.yang
@@ -36,6 +36,12 @@ module openconfig-pf-srte {
 
   oc-ext:openconfig-version "0.1.1";
 
+  revision "2019-06-26" {
+    description
+      "Add explicit-null-label leaf under SR-TE policy rules.";
+    reference "0.1.1";
+  }
+
   revision "2018-11-21" {
     description
       "Add OpenConfig module metadata extensions.";
@@ -52,6 +58,30 @@ module openconfig-pf-srte {
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+
+  typedef explicit-null-label-type {
+    type enumeration {
+      enum IPV4 {
+        description "Push an IPv4 Explicit NULL label on an unlabeled 
+                    IPv4 packet";
+      }
+      enum IPV6 {
+        description "Push an IPv6 Explicit NULL label on an unlabeled 
+                    IPv6 packet";
+      }
+      enum IPV4_IPV6 {
+        description "Push an IPv4 Explicit NULL label on an unlabeled 
+                    IPv4 packet; 
+                    Push an IPv6 Explicit NULL label on an unlabeled 
+                    IPv6 packet";
+      }
+      enum NONE {
+        description "No Explicit NULL label will be pushed for both 
+                    IPv4 and IPv6 unlabeled packets";
+      } 
+    }
+  }
 
   grouping oc-pf-srte-match-top {
     description
@@ -123,6 +153,13 @@ module openconfig-pf-srte {
         between them. These rules may be learnt from a dynamic routing
         protocol, or interface to the device, or from other static
         entries configured on the system.";
+    }
+
+    leaf explicit-null-label {
+      type explicit-null-label-type;
+      description
+        "Indicates type of explicit null label that is being pushed on 
+        an unlabeled IP packet"
     }
   }
 


### PR DESCRIPTION
Also adding a new ENUM type called explicit-null-label-type.

This new leaf node resides in the SRTE config container under
the policy rules container.