### PR TITLE
Fix PROT_OTN/ETHERNET prefix in openconfig-terminal-device.yang

### DIFF
--- a/release/models/optical-transport/openconfig-terminal-device.yang
+++ b/release/models/optical-transport/openconfig-terminal-device.yang
@@ -994,14 +994,14 @@ module openconfig-terminal-device {
         }
 
         uses terminal-otn-protocol-top {
-          when "config/logical-channel-type = 'PROT_OTN'" {
+          when "config/logical-channel-type = 'oc-opt-types:PROT_OTN'" {
             description
               "Include the OTN protocol data only when the
               channel is using OTN framing.";
           }
         }
         uses terminal-ethernet-protocol-top {
-          when "config/logical-channel-type = 'PROT_ETHERNET'" {
+          when "config/logical-channel-type = 'oc-opt-types:PROT_ETHERNET'" {
             description
               "Include the Ethernet protocol statistics only when the
               protocol used by the link is Ethernet.";


### PR DESCRIPTION
  * (M) release/models/optical-transport/openconfig-terminal-device.yang

This Pull Request closes #39 