### PR TITLE
Fix OPTICAL_CHANNEL prefix in openconfig-terminal-device.yang

### DIFF
--- a/release/models/optical-transport/openconfig-terminal-device.yang
+++ b/release/models/optical-transport/openconfig-terminal-device.yang
@@ -648,7 +648,7 @@ module openconfig-terminal-device {
         path "/oc-platform:components/oc-platform:component/" +
           "oc-platform:name";
       }
-      must "../assignment-type = 'OPTICAL_CHANNEL'" {
+      must "../assignment-type = 'oc-opt-types:OPTICAL_CHANNEL'" {
         description
           "The assignment-type must be set to OPTICAL_CHANNEL for
           this leaf to be valid";
@@ -1386,7 +1386,7 @@ module openconfig-terminal-device {
 
   augment "/oc-platform:components/oc-platform:component" {
     when "/oc-platform:components/oc-platform:component/" +
-      "oc-platform:state/oc-platform:type = 'OPTICAL_CHANNEL'" {
+      "oc-platform:state/oc-platform:type = 'oc-opt-types:OPTICAL_CHANNEL'" {
       description
         "Augment is active when component is of type
         OPTICAL_CHANNEL";


### PR DESCRIPTION
  * (M) release/models/optical-transport/openconfig-terminal-device.yang

This Pull Request closes #40