### PR TITLE
Common OSPFv2 and OSPFv3 Yang model.

### DIFF
--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -22,7 +22,7 @@ module openconfig-network-instance {
   import openconfig-bgp { prefix "oc-bgp"; }
   import openconfig-mpls { prefix "oc-mpls"; }
   import openconfig-vlan { prefix "oc-vlan"; }
-  import openconfig-ospfv2 { prefix "oc-ospfv2"; }
+  import openconfig-ospf { prefix "oc-ospf"; }
   import openconfig-policy-forwarding { prefix "oc-pf"; }
   import openconfig-segment-routing { prefix "oc-sr"; }
   import openconfig-isis { prefix "oc-isis"; }
@@ -48,6 +48,12 @@ module openconfig-network-instance {
     instances are also supported.";
 
   oc-ext:openconfig-version "0.13.0";
+
+  revision "2019-07-30" {
+    description
+      "Added support for OSPFv3.";
+    reference "0.14.0";
+  }
 
   revision "2019-05-14" {
     description
@@ -721,11 +727,19 @@ module openconfig-network-instance {
                 Border Gateway Protocol (BGP)";
             }
 
-            uses oc-ospfv2:ospfv2-top {
+            uses oc-ospf:ospfv2-top {
               when "config/identifier = 'OSPF'" {
                 description
                   "Include OSPFv2 parameters only when the protocol
                   is of type OSPFv2";
+              }
+            }
+
+            uses oc-ospf:ospfv3-top {
+              when "config/identifier = 'OSPFv3'" {
+                description
+                  "Include OSPFv3 parameters only when the protocol
+                  is of type OSPFv3";
               }
             }
 

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -1,0 +1,429 @@
+submodule openconfig-ospf-area-interface {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+
+  // include common submodule
+  include openconfig-ospf-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPF configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-07-31" {
+    description
+      "Add interface-transmission-delay and move lsdb to state";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospf-area-interface-config {
+    description
+      "Configuration parameters for an OSPF interface";
+
+    leaf id {
+      type string;
+      description
+        "An operator-specified string utilised to uniquely
+        reference this interface";
+    }
+
+    leaf network-type {
+      type identityref {
+        base "oc-ospf-types:OSPF_NETWORK_TYPE";
+      }
+      description
+        "The type of network that OSPF should use for the specified
+        interface.";
+    }
+
+    leaf priority {
+      type uint8;
+      default 1;
+      description
+        "The local system's priority to become the designated
+        router";
+    }
+
+    leaf multi-area-adjacency-primary {
+      type boolean;
+      default true;
+      description
+        "When the specified interface is included in more than one
+        area's configuration, this leaf marks whether the area should
+        be considered the primary (when the value is true). In the
+        case that this value is false, the area is considered a
+        secondary area.";
+    }
+
+    leaf authentication-type {
+      type string;
+      // rjs TODO: discuss with bogdanov@ what the approach for auth
+      // links should be.
+      description
+        "The type of authentication that should be used on this
+        interface";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      default 10;
+      description
+        "The metric for the interface";
+    }
+
+    leaf passive {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the interface should be
+        advertised within the OSPF area but OSPF adjacencies should
+        not be established over the interface";
+    }
+
+    leaf hide-network {
+      type boolean;
+      description
+        "When this leaf is set to true, the network connected to
+        the interface should be hidden from OSPF advertisements
+        per the procedure described in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSFF";
+    }
+
+  }
+
+  grouping ospf-area-interface-timers-config {
+    description
+      "Configuration parameters relating to per-interface OSPF
+      timers";
+
+    leaf dead-interval {
+      type uint32;
+      units seconds;
+      default 40;
+      description
+        "The number of seconds that the local system should let
+        elapse before declaring a silent router down";
+      reference "RFC2328";
+    }
+
+    leaf hello-interval {
+      type uint32;
+      units seconds;
+      default 10;
+      description
+        "The number of seconds the local system waits between the
+        transmission of subsequent Hello packets";
+    }
+
+    leaf retransmission-interval {
+      type uint32;
+      units seconds;
+      default 5;
+      description
+        "The number of seconds that the local system waits before
+        retransmitting an unacknowledged LSA.";
+    }
+
+    leaf interface-transmission-delay {
+      type uint32;
+      units seconds;
+      default 1;
+      description
+        "The estimated number of seconds it takes to transmit a Link State
+         Update packet over this interface.";
+    }
+  }
+
+  grouping ospf-area-interface-neighbor-config {
+    description
+      "Configuration parameters relating to an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "The router ID of the remote system.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric that should be considered to the remote neighbor
+        over this interface. This configuration is only applicable
+        for multiple-access networks";
+    }
+  }
+
+  grouping ospf-area-interface-neighbor-state {
+    description
+      "Operational state parameters relating an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf priority {
+      type uint8;
+      description
+        "The remote system's priority to become the designated
+        router";
+    }
+
+    leaf dead-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which this neighbor's adjacency will be
+        considered dead. The value is expressed relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf designated-router {
+      type yang:dotted-quad;
+      description
+        "The designated router for the adjacency. This device
+        advertises the Network LSA for broadcast and NBMA networks.";
+    }
+
+    leaf backup-designated-router {
+      type yang:dotted-quad;
+      description
+        "The backup designated router for the adjacency.";
+    }
+
+    leaf optional-capabilities {
+      // rjs TODO: should this be anything more than the hex-string
+      // this is currently what is shown in IOS/JUNOS
+      type yang:hex-string;
+      description
+        "The optional capabilities field received in the Hello
+        message from the neighbor";
+    }
+
+    leaf last-established-time {
+      type oc-types:timeticks64;
+      // rjs TODO: check implementations - is FULL considered 'up'
+      // since the adjacency is probably up since ExStart
+      description
+        "The time at which the adjacency was last established with
+        the neighbor. That is to say the time at which the
+        adjacency last transitioned into the FULL state. The
+        value is expressed relative to the Unix Epoch (Jan 1 1970
+        00:00:00 UTC).";
+    }
+
+    leaf adjacency-state {
+      type identityref {
+        base "oc-ospf-types:OSPF_NEIGHBOR_STATE";
+      }
+      description
+        "The state of the adjacency with the neighbor.";
+    }
+
+    leaf state-changes {
+      type uint32;
+      description
+        "The number of transitions out of the FULL state that this
+        neighbor has been through";
+    }
+
+    leaf retranmission-queue-length {
+      type uint32;
+      description
+        "The number of LSAs that are currently in the queue to be
+        retransmitted to the neighbor";
+    }
+  }
+
+  grouping ospf-area-interface-lsa-filter-config {
+    description
+      "Configuration options relating to filtering LSAs
+      on an interface.";
+
+    leaf all {
+      type boolean;
+      description
+        "When this leaf is set to true, all LSAs should be
+        filtered to the neighbours with whom adjacencies are
+        formed on the interface.";
+    }
+
+    // NB: this container can be augmented to add additional
+    // filtering options which exist in some implementations.
+  }
+
+  grouping ospf-area-interfaces-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an interface";
+
+    container interfaces {
+      description
+        "Enclosing container for a list of interfaces enabled within
+        this area";
+
+      list interface {
+        key "id";
+
+        description
+          "List of interfaces which are enabled within this area";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "A pointer to the identifier for the interface.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the interface on which
+            OSPF is enabled";
+
+          uses ospf-area-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the interface on which
+            OSPF is enabled";
+          uses ospf-area-interface-config;
+        }
+
+        uses oc-if:interface-ref;
+
+        container timers {
+          description
+            "Timers relating to OSPF on the interface";
+
+          container config {
+            description
+              "Configuration parameters for OSPF timers on the
+              interface";
+            uses ospf-area-interface-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for OSPF timers on
+              the interface";
+
+            uses ospf-area-interface-timers-config;
+          }
+        }
+
+        container lsa-filter {
+          description
+            "OSPF parameters relating to filtering of LSAs to
+            neighbors the specified interface.";
+
+          container config {
+            description
+              "Configuration parameters relating to filtering LSAs
+              on the specified interface.";
+            uses ospf-area-interface-lsa-filter-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to filtering
+              LSAs on the specified interface";
+            uses ospf-area-interface-lsa-filter-config;
+          }
+        }
+
+        container neighbors {
+          description
+            "Enclosing container for the list of neighbors that
+            an adjacency has been established with on the interface";
+
+          list neighbor {
+            key "router-id";
+
+            description
+              "A neighbor with which an OSPF adjacency has been
+              established within this area";
+
+            leaf router-id {
+              type leafref {
+                path "../config/router-id";
+              }
+              description
+                "Reference to the router ID of the adjacent system";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the adjacent
+                system";
+              uses ospf-area-interface-neighbor-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the adjacent
+                system";
+              uses ospf-area-interface-neighbor-config;
+              uses ospf-area-interface-neighbor-state;
+            }
+          }
+        }
+
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -5,6 +5,7 @@ submodule openconfig-ospf-area-interface {
   }
 
   import ietf-yang-types { prefix "yang"; }
+  import ietf-inet-types { prefix "inet"; }
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-types { prefix "oc-types"; }
   import openconfig-interfaces { prefix "oc-if"; }
@@ -187,15 +188,48 @@ submodule openconfig-ospf-area-interface {
     }
   }
 
+  grouping ospf-area-interface-state {
+    description
+      "Operation state parameters of an OSPF interface";
+
+    // TODO: Add the Interface state-machine state
+
+    leaf dr-router-id {
+      type yang:dotted-quad;
+      description
+        "The router-id of the designated router for this interface.";
+    }
+
+    leaf dr-ip-address {
+      type inet:ip-address;
+      description
+        "The IP address of the designated router for this interface.";
+    }
+
+    leaf bdr-router-id {
+      type yang:dotted-quad;
+      description
+        "The router-id of the backup designated router for this
+        interface.";
+    }
+
+    leaf bdr-ip-address {
+      type inet:ip-address;
+      description
+        "The IP address of the backup designated router for this
+        interface.";
+    }
+  }
+
   grouping ospf-area-interface-neighbor-config {
     description
       "Configuration parameters relating to an individual neighbor
       system on an interface within an OSPF area";
 
-    leaf router-id {
-      type yang:dotted-quad;
+    leaf neighbor-ip-address {
+      type inet:ip-address;
       description
-        "The router ID of the remote system.";
+        "The IP address of the configured neighbor.";
     }
 
     leaf metric {
@@ -205,12 +239,39 @@ submodule openconfig-ospf-area-interface {
         over this interface. This configuration is only applicable
         for multiple-access networks";
     }
+
+    leaf poll-interval {
+      type uint16;
+      description
+        "Neighbor poll interval (seconds) for sending OSPF Hello
+        packets to discover the neighbor on NBMA networks. Refer
+        Appendix C.5 in RFC 2328.";
+    }
+
+    leaf priority {
+      type uint8;
+      default 1;
+      description
+        "The local system's priority to become the designated router";
+    }
   }
 
   grouping ospf-area-interface-neighbor-state {
     description
       "Operational state parameters relating an individual neighbor
       system on an interface within an OSPF area";
+
+    leaf neighbor-router-id {
+      type yang:dotted-quad;
+      description
+        "The router ID of the remote system.";
+    }
+
+    leaf neighbor-ip-address {
+      type inet:ip-address;
+      description
+        "The IP address of the remote system.";
+    }
 
     leaf priority {
       type uint8;
@@ -227,17 +288,30 @@ submodule openconfig-ospf-area-interface {
         the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
     }
 
-    leaf designated-router {
+    leaf dr-router-id {
       type yang:dotted-quad;
       description
-        "The designated router for the adjacency. This device
+        "The router ID of designated router for the adjacency. This device
         advertises the Network LSA for broadcast and NBMA networks.";
     }
 
-    leaf backup-designated-router {
+    leaf dr-ip-address {
+      type inet:ip-address;
+      description
+        "The IP address of designated router for the adjacency. This device
+        advertises the Network LSA for broadcast and NBMA networks.";
+    }
+
+    leaf bdr-router-id {
       type yang:dotted-quad;
       description
-        "The backup designated router for the adjacency.";
+        "The router ID of backup designated router for the adjacency.";
+    }
+
+    leaf bdr-ip-address {
+      type inet:ip-address;
+      description
+        "The IP address of backup designated router for the adjacency.";
     }
 
     leaf optional-capabilities {
@@ -339,6 +413,7 @@ submodule openconfig-ospf-area-interface {
             "Operational state parameters for the interface on which
             OSPF is enabled";
           uses ospf-area-interface-config;
+          uses ospf-area-interface-state;
         }
 
         uses oc-if:interface-ref;
@@ -385,24 +460,24 @@ submodule openconfig-ospf-area-interface {
           }
         }
 
-        container neighbors {
+        container static-neighbors {
           description
-            "Enclosing container for the list of neighbors that
-            an adjacency has been established with on the interface";
+            "Enclosing container for the list of statically
+            configured neighbors";
 
-          list neighbor {
-            key "router-id";
+          list static-neighbor {
+            key "neighbor-ip-address";
 
             description
-              "A neighbor with which an OSPF adjacency has been
-              established within this area";
+              "A neighbor which has been statically configured on
+              this router";
 
-            leaf router-id {
+            leaf neighbor-ip-address {
               type leafref {
-                path "../config/router-id";
+                path "../config/neighbor-ip-address";
               }
               description
-                "Reference to the router ID of the adjacent system";
+                "The IP address of the static neighbor.";
             }
 
             container config {
@@ -411,18 +486,39 @@ submodule openconfig-ospf-area-interface {
                 system";
               uses ospf-area-interface-neighbor-config;
             }
+          }
+        }
+
+        container neighbors {
+          config false;
+          description
+            "Enclosing container for the list of neighbors that
+            an adjacency has been established with on the interface";
+
+          list neighbor {
+            key "neighbor-router-id";
+
+            description
+              "A neighbor with which an OSPF adjacency has been
+              established within this area";
+
+            leaf neighbor-router-id {
+              type leafref {
+                path "../state/neighbor-router-id";
+              }
+              description
+                "The router ID of the remote system.";
+            }
 
             container state {
               config false;
               description
                 "Operational state parameters relating to the adjacent
                 system";
-              uses ospf-area-interface-neighbor-config;
               uses ospf-area-interface-neighbor-state;
             }
           }
         }
-
       }
     }
   }

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -1,0 +1,267 @@
+submodule openconfig-ospf-area {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import ietf-inet-types { prefix "inet"; }
+
+  // include other required submodules
+  include openconfig-ospf-area-interface;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-07-31" {
+    description
+      "Add address-ranges, 
+       stub-default-cost, import-summaries under area/config and 
+       add global lsdb under area/state";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping address-range-config {
+    description
+      "Configuration data for static routes.";
+
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "IP address range";
+    }
+
+    leaf status {
+      type enumeration {
+        enum ADVERTISE {
+          description
+            "The route is advertised.";
+        }
+        enum DONOTADVERTISE {
+          description
+            "The route is not advertised.";
+        }
+      }
+      default ADVERTISE;
+      description
+        "Set to either Advertise or DoNotAdvertise.  Routing information
+         is condensed at area boundaries.  External to the area, at most
+         a single route is advertised (via a inter-area-prefix-LSA) for
+         each address range.  The route is advertised if and only if the
+         address range's Status is set to Advertise.  Unadvertised
+         ranges allow the existence of certain networks to be
+         intentionally hidden from other areas.";
+    }
+  }
+
+  grouping address-range-state {
+    description
+      "Operational state data for address range";
+  }
+
+  grouping ospf-area-config {
+    description
+      "Configuration parameters relating to an OSPF area";
+
+    leaf identifier {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "An identifier for the OSPFv2 area - described as either a
+        32-bit unsigned integer, or a dotted-quad";
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPF-AREA-TYPE";
+      }
+      default oc-ospf-types:NORMAL;
+      description
+        "OSPF area type.";
+    }
+
+    leaf stub-default-cost {
+      /* when "../area-type = 'STUB' or ../area-type = 'NSSA'" {
+        description
+          "Default cost for LSA advertised into stub or
+            NSSA area."
+      } */
+
+      type uint32 {
+        range "1..16777215";
+      }
+      description
+        "If the area has been configured as a stub area,
+         and the router itself is an area border router,
+         then the StubDefaultCost indicates the cost of
+         the default inter-area-prefix-LSA that the router
+         should advertise into the area.";
+    }
+
+    leaf import-summaries {
+      /* when "../area-type = 'STUB' or ../area-type = 'NSSA'" {
+        description
+          "Summary generation valid for stub/NSSA area." 
+      } */
+
+      type boolean;
+      default true;
+      description
+        "When set to enabled, prefixes external to the
+         area are imported into the area via the advertisement
+         of inter-area-prefix-LSAs. When set to disabled,
+         inter-area routes are not imported into the
+         area.";
+    }
+
+
+    list address-ranges {
+      key "prefix";
+      description
+        "List of IPv6 addresses contained in the address range";
+
+      leaf prefix {
+        type leafref {
+          path "../config/prefix";
+        }
+        description
+          "Reference to the destination prefix list key.";
+      }
+
+      container config {
+        description
+          "Configuration data for address range";
+
+        uses address-range-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for address range";
+
+        uses address-range-config;
+        uses address-range-state;
+      }
+    }
+  }
+
+  grouping ospf-area-virtual-link-config {
+    description
+      "Configuration parameters relating to a virtual-link within
+      the OSPF area";
+
+    leaf remote-router-id {
+      type inet:ipv4-address-no-zone;
+      description
+        "The router ID of the device which terminates the remote end
+        of the virtual link";
+    }
+  }
+
+  grouping ospf-area-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an individual area";
+
+    container config {
+      description
+        "Configuration parameters relating to an OSPFv2 area";
+
+      uses ospf-area-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to an OSPFv2 area";
+      uses ospf-area-config;
+    }
+
+    uses ospf-area-interfaces-structure;
+
+    container virtual-links {
+      description
+        "Configuration and state parameters relating to virtual
+        links from the source area to a remote router";
+
+      list virtual-link {
+        key "remote-router-id";
+
+        description
+          "Configuration and state parameters relating to a
+          virtual link";
+
+        leaf remote-router-id {
+          type leafref {
+            path "../config/remote-router-id";
+          }
+          description
+            "Reference to the remote router ID";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF virtual link";
+          uses ospf-area-virtual-link-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to the OSPF virtual link";
+          uses ospf-area-virtual-link-config;
+          uses ospf-area-interface-neighbor-state;
+        }
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -1,7 +1,7 @@
-submodule openconfig-ospfv2-common {
+submodule openconfig-ospf-common {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
   import openconfig-extensions { prefix "oc-ext"; }
@@ -55,30 +55,7 @@ submodule openconfig-ospfv2-common {
     reference "0.0.1";
   }
 
-  grouping ospfv2-common-mpls-igp-ldp-sync-config {
-    description
-      "Configuration parameters used for OSPFv2 MPLS/IGP
-      synchronization";
-
-    leaf enabled {
-      type boolean;
-      description
-        "When this leaf is set to true, do not utilise this link for
-        forwarding via the IGP until such time as LDP adjacencies to
-        the neighbor(s) over the link are established.";
-    }
-
-    leaf post-session-up-delay {
-      type uint32;
-      units milliseconds;
-      description
-        "This leaf specifies a delay, expressed in units of milliseconds,
-        between the LDP session to the IGP neighbor being established, and
-        it being considered synchronized by the IGP.";
-    }
-  }
-
-  grouping ospfv2-common-timers {
+  grouping ospf-common-timers {
     description
       "Common definition of the type of timers that the OSPFv2 implementation
       uses";
@@ -100,4 +77,5 @@ submodule openconfig-ospfv2-common {
         "The timer mode that is utilised by the implementation.";
     }
   }
+
 }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -1,0 +1,457 @@
+submodule openconfig-ospf-global {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-ospf-types { prefix "oc-ospft"; }
+
+  // Include common submodule
+  include openconfig-ospf-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPF configuration and operational
+    state parameters that are global to a particular OSPF instance";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-07-31" {
+    description
+      "Add abr capability";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospf-global-config {
+    description
+      "Global configuration for OSPF";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "A 32-bit number represented as a dotted quad assigned to
+        each router running the OSPF protocol. This number should
+        be unique within the autonomous system";
+      reference "rfc2828";
+    }
+
+    leaf log-adjacency-changes {
+      type boolean;
+      description
+        "When this leaf is set to true, a log message will be
+        generated when the state of an OSPF neighbour changes.";
+    }
+
+    leaf hide-transit-only-networks {
+      type boolean;
+      description
+        "When this leaf is set to true, do not advertise prefixes
+        into OSPF that correspond to transit interfaces, as per
+        the behaviour discussed in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSPF";
+    }
+
+    leaf abr-capability {
+      type identityref {
+        base "oc-ospft:OSPF-ABR-TYPE";
+      }
+      default oc-ospft:RFC3509-COMPATIBLE;
+      description
+        "When the leaf is set to RFC2328-COMPATIBLE, the router
+         acts as an ABR when it participates in multiple OSPF
+         areas. It does not matter whether the backbone area
+         exists or not. When the leaf is set to RFC3509-COMPATIBLE,
+         the router acts as an ABR when the router participates
+         in multiple OSPF areas, one of which must be backbone.";
+    }
+  }
+
+  grouping ospf-global-spf-timers-config {
+    description
+      "Configuration parameters relating to global SPF timer
+      parameters for OSPF";
+
+    leaf initial-delay {
+      // rjs TODO: IS-IS model has this as decimal64 - should it be
+      // that or uint32 msec?
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between a change
+        in topology being detected and the first run of the SPF
+        algorithm.";
+    }
+
+    leaf maximum-delay {
+      // rjs TODO: same question as above
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum delay between
+        a topology change being detected and the SPF algorithm
+        running. This value is used for implementations that support
+        increasing the wait time between SPF runs.";
+    }
+
+    // rjs TODO: some questions here around what we should specify:
+    // JUNOS has rapid-runs and holddown
+    // Cisco has maximum time between runs, and then a doubling of
+    // the wait interval up to that maximum.
+    // ALU has first-wait, second-wait, max-wait
+  }
+
+  grouping ospf-global-lsa-generation-timers-config {
+    description
+      "Configuration parameters relating to global LSA generation
+      parameters for OSPF";
+
+    leaf initial-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between the first
+        time an LSA is generated and advertised and the subsequent
+        generation of that LSA.";
+    }
+
+    leaf maximum-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum time between the
+        generation of an LSA and the subsequent re-generation of that
+        LSA. This value is used in implementations that support
+        increasing delay between generation of an LSA";
+    }
+  }
+
+  grouping ospf-global-spf-timers-state {
+    description
+      "Operational state parameters relating to OSPF global
+      timers";
+
+    uses ospf-common-timers;
+  }
+
+  grouping ospf-global-lsa-generation-timers-state {
+    description
+      "Operational state parameters relating to OSPF global
+      timers";
+
+    uses ospf-common-timers;
+  }
+
+  grouping ospf-global-graceful-restart-config {
+    description
+      "Configuration parameters relating to graceful restart for
+      OSPF";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When the value of this leaf is set to true, graceful restart
+        is enabled on the local system. In this case, the system will
+        use Grace-LSAs to signal that it is restarting to its
+        neighbors.";
+    }
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Operate graceful-restart only in helper mode. When this leaf
+        is set to true, the local system does not use Grace-LSAs to
+        indicate that it is restarting, but will accept Grace-LSAs
+        from remote systems, and suppress withdrawl of adjacencies
+        of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-inter-areapp-config {
+    description
+      "Configuration parameters for OSPF policies which propagate
+      prefixes between areas";
+
+    leaf src-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The area from which prefixes are to be exported.";
+    }
+
+    leaf dst-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The destination area to which prefixes are to be imported";
+    }
+
+    uses oc-rpol:apply-policy-import-config;
+  }
+
+  grouping ospf-global-max-metric-config {
+    description
+      "Configuration paramters relating to setting the OSPF
+      maximum metric.";
+
+    leaf set {
+      type boolean;
+      description
+        "When this leaf is set to true, all non-stub interfaces of
+        the local system are advertised with the maximum metric,
+        such that the router does not act as a transit system,
+        (similarly to the IS-IS overload functionality).";
+      reference
+        "RFC3137 - OSPF Stub Router Advertisement";
+    }
+
+    leaf timeout {
+      type uint64;
+      units "seconds";
+      description
+        "The delay, in seconds, after which the advertisement of
+        entities with the maximum metric should be cleared, and
+        the system reverts to the default, or configured, metrics.";
+    }
+
+    leaf-list include {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_INCLUDE";
+      }
+      description
+        "By default, the maximum metric is advertised for all
+        non-stub interfaces of a device. When identities are
+        specified within this leaf-list, additional entities
+        are also advertised with the maximum metric according
+        to the values within the list.";
+    }
+
+    leaf-list trigger {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_TRIGGER";
+      }
+      description
+        "By default, the maximum metric is only advertised
+        when the max-metric/set leaf is specified as true.
+        In the case that identities are specified within this
+        list, they provide additional triggers (e.g., system
+        boot) that may cause the max-metric to be set. In this
+        case, the system should still honour the timeout specified
+        by the max-metric/timeout leaf, and clear the max-metric
+        advertisements after the expiration of this timer.";
+    }
+  }
+
+  grouping ospf-global-structural {
+    description
+      "Top level structural grouping for OSPF global parameters";
+
+    container global {
+      description
+        "Configuration and operational state parameters for settings
+        that are global to the OSPF instance";
+
+      container config {
+        description
+          "Global configuration parameters for OSPF";
+        uses ospf-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for OSPF";
+        uses ospf-global-config;
+      }
+
+      container timers {
+        description
+          "Configuration and operational state parameters for OSPF
+          timers";
+
+        container spf {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the operation of SPF runs";
+
+          container config {
+            description
+              "Configuration parameters relating to global OSPF
+              SPF timers";
+            uses ospf-global-spf-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the global
+              OSPF SPF timers";
+            uses ospf-global-spf-timers-config;
+            uses ospf-global-spf-timers-state;
+          }
+        }
+
+        container max-metric {
+          description
+            "Configuration and operational state parameters relating
+            to setting the OSPF maximum metric.";
+
+          container config {
+            description
+              "Configuration parameters relating to setting the OSPF
+              maximum metric for a set of advertised entities.";
+            uses ospf-global-max-metric-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to setting the
+              OSPF maximum metric for a set of advertised entities.";
+            uses ospf-global-max-metric-config;
+          }
+        }
+
+        container lsa-generation {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the generation of LSAs by the local
+            system";
+
+          container config {
+            description
+              "Configuration parameters relating to the generation of
+              LSAs by the local system";
+            uses ospf-global-lsa-generation-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the generation
+              of LSAs by the local system";
+            uses ospf-global-lsa-generation-timers-config;
+            uses ospf-global-lsa-generation-timers-state;
+          }
+        }
+      }
+
+      container graceful-restart {
+        description
+          "Configuration and operational state parameters for OSPF
+          graceful restart";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPF graceful
+            restart";
+          uses ospf-global-graceful-restart-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPF graceful
+            restart";
+          uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container inter-area-propagation-policies {
+        description
+          "Policies defining how inter-area propagation should be performed
+          by the OSPF instance";
+
+        list inter-area-propagation-policy {
+          key "src-area dst-area";
+          description
+            "A list of connections between pairs of areas - routes are
+            propagated from the source (src) area to the destination (dst)
+            area according to the policy specified";
+
+          leaf src-area {
+            type leafref {
+              path "../config/src-area";
+            }
+            description
+              "Reference to the source area";
+          }
+
+          leaf dst-area {
+            type leafref {
+              path "../config/dst-area";
+            }
+            description
+              "Reference to the destination area";
+          }
+
+          container config {
+            description
+              "Configuration parameters relating to the inter-area
+              propagation policy";
+            uses ospf-global-inter-areapp-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the inter-area
+              propagation policy";
+            uses ospf-global-inter-areapp-config;
+          }
+        }
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf-types.yang
+++ b/release/models/ospf/openconfig-ospf-types.yang
@@ -21,7 +21,13 @@ module openconfig-ospf-types {
   description
     "Type definitions for OSPF";
 
-  oc-ext:openconfig-version "0.1.3";
+  oc-ext:openconfig-version "0.1.4";
+
+  revision "2019-07-31" {
+    description
+      "Add ospf area type and ABR mode.";
+    reference "0.1.4";
+  }
 
   revision "2018-11-21" {
     description
@@ -791,5 +797,47 @@ module openconfig-ospf-types {
     description
       "Include OSPF Type 2 external routes when advertising
       the maximum metric.";
+  }
+
+  identity OSPF-AREA-TYPE {
+    description 
+      "Base identity for OSPF area type.";
+  }
+
+  identity NORMAL {
+    base "OSPF-AREA-TYPE";
+    description 
+      "OSPF normal area.";
+  }
+
+  identity STUB {
+    base "OSPF-AREA-TYPE";
+    description 
+      "OSPF stub area.";
+  }
+
+  identity NSSA {
+    base "OSPF-AREA-TYPE";
+    description 
+      "OSPF NSSA area.";
+  }
+
+  identity OSPF-ABR-TYPE {
+    description 
+      "Base identity for OSPF area boarder router type.";
+  }
+
+  identity RFC3509-COMPATIBLE {
+    base "OSPF-ABR-TYPE";
+    description 
+      "OSPF ABR requires backbone area as one of the multiple
+       areas.";
+  }
+
+  identity RFC2328-COMPATIBLE {
+    base "OSPF-ABR-TYPE";
+    description
+      "OSPF ABR does not require backbone area as one of 
+       the multiple areas.";
   }
 }

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -1,11 +1,11 @@
-module openconfig-ospfv2 {
+module openconfig-ospf {
 
   yang-version "1";
 
   // namespace
-  namespace "http://openconfig.net/yang/ospfv2";
+  namespace "http://openconfig.net/yang/ospf";
 
-  prefix "oc-ospfv2";
+  prefix "oc-ospf";
 
   // import some basic types
   //import ietf-inet-types { prefix inet; }
@@ -13,15 +13,13 @@ module openconfig-ospfv2 {
 
   // Include submodules
   // Global:  All global context groupings;
-  include openconfig-ospfv2-global;
+  include openconfig-ospf-global;
   // Area:    Config/opstate for an area
-  include openconfig-ospfv2-area;
+  include openconfig-ospf-area;
   // Area Interface:  Config/opstate for an Interface
-  include openconfig-ospfv2-area-interface;
-  // LSDB: Operational state model covering the LSDB
-  include openconfig-ospfv2-lsdb;
+  include openconfig-ospf-area-interface;
   // Common:  Content included in >1 context
-  include openconfig-ospfv2-common;
+  include openconfig-ospf-common;
 
   // meta
   organization "OpenConfig working group";
@@ -34,7 +32,13 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2019-07-30" {
+    description
+      "Add support for OSPFv3.";
+    reference "0.3.0";
+  }
 
   revision "2019-07-09" {
     description
@@ -79,14 +83,14 @@ module openconfig-ospfv2 {
 
   grouping ospfv2-top {
     description
-      "Top-level OSPF configuration and operational state";
+      "Top-level OSPFv2 configuration and operational state";
 
-    container ospfv2 {
+    container ospf {
       description
         "Top-level configuration and operational state for
         Open Shortest Path First (OSPF) v2";
 
-      uses ospfv2-global-structural;
+      uses ospf-global-structural;
 
       container areas {
         description
@@ -107,7 +111,43 @@ module openconfig-ospfv2 {
               "A reference to the identifier for the area.";
           }
 
-          uses ospfv2-area-structure;
+          uses ospf-area-structure;
+        }
+      }
+    }
+  }
+
+  grouping ospfv3-top {
+    description
+      "Top-level OSPFv3 configuration and operational state";
+
+    container ospfv3 {
+      description
+        "Top-level configuration and operational state for
+        Open Shortest Path First (OSPF) v3";
+
+      uses ospf-global-structural;
+
+      container areas {
+        description
+          "Configuration and operational state relating to an
+          OSPFv3 area.";
+
+        list area {
+          key "identifier";
+
+          description
+            "The OSPFv3 areas within which the local system exists";
+
+          leaf identifier {
+            type leafref {
+              path "../config/identifier";
+            }
+            description
+              "A reference to the identifier for the area.";
+          }
+
+          uses ospf-area-structure;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -1,17 +1,15 @@
 submodule openconfig-ospfv2-area-interface {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
-  import ietf-yang-types { prefix "yang"; }
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-types { prefix "oc-types"; }
-  import openconfig-interfaces { prefix "oc-if"; }
-  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+  import openconfig-ospfv2-global { prefix "oc-ospfv2-g";}
 
   // include common submodule
-  include openconfig-ospfv2-common;
+  include openconfig-ospf-common;
 
   // meta
   organization "OpenConfig working group";
@@ -24,150 +22,18 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.0.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-16" {
     description
       "Initial revision";
     reference "0.0.1";
   }
 
-  grouping ospfv2-area-interface-config {
-    description
-      "Configuration parameters for an OSPF interface";
-
-    leaf id {
-      type string;
-      description
-        "An operator-specified string utilised to uniquely
-        reference this interface";
-    }
-
-    leaf network-type {
-      type identityref {
-        base "oc-ospf-types:OSPF_NETWORK_TYPE";
-      }
-      description
-        "The type of network that OSPFv2 should use for the specified
-        interface.";
-    }
-
-    leaf priority {
-      type uint8;
-      description
-        "The local system's priority to become the designated
-        router";
-    }
-
-    leaf multi-area-adjacency-primary {
-      type boolean;
-      default true;
-      description
-        "When the specified interface is included in more than one
-        area's configuration, this leaf marks whether the area should
-        be considered the primary (when the value is true). In the
-        case that this value is false, the area is considered a
-        secondary area.";
-    }
-
-    leaf authentication-type {
-      type string;
-      // rjs TODO: discuss with bogdanov@ what the approach for auth
-      // links should be.
-      description
-        "The type of authentication that should be used on this
-        interface";
-    }
-
-    leaf metric {
-      type oc-ospf-types:ospf-metric;
-      description
-        "The metric for the interface";
-    }
-
-    leaf passive {
-      type boolean;
-      description
-        "When this leaf is set to true, the interface should be
-        advertised within the OSPF area but OSPF adjacencies should
-        not be established over the interface";
-    }
-
-    leaf hide-network {
-      type boolean;
-      description
-        "When this leaf is set to true, the network connected to
-        the interface should be hidden from OSPFv2 advertisements
-        per the procedure described in RFC6860.";
-      reference
-        "RFC6860 - Hiding Transit-Only Networks in OSFF";
-    }
-  }
-
-  grouping ospfv2-area-interface-timers-config {
-    description
-      "Configuration parameters relating to per-interface OSPFv2
-      timers";
-
-    leaf dead-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds that the local system should let
-        elapse before declaring a silent router down";
-      reference "RFC2328";
-    }
-
-    leaf hello-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds the local system waits between the
-        transmission of subsequent Hello packets";
-    }
-
-    leaf retransmission-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds that the local system waits before
-        retransmitting an unacknowledged LSA.";
-    }
-  }
 
   grouping ospfv2-area-interface-mpls-config {
     description
-      "Configuration parameters relating to MPLS extensions for OSPF";
+      "Configuration parameters relating to MPLS extensions for OSPFv2";
 
     leaf traffic-engineering-metric {
       type uint32;
@@ -176,120 +42,6 @@ submodule openconfig-ospfv2-area-interface {
         engineering purposes.";
       reference "RFC3630, §2.5.5";
     }
-  }
-
-  grouping ospfv2-area-interface-neighbor-config {
-    description
-      "Configuration parameters relating to an individual neighbor
-      system on an interface within an OSPF area";
-
-    leaf router-id {
-      type yang:dotted-quad;
-      description
-        "The router ID of the remote system.";
-    }
-
-    leaf metric {
-      type oc-ospf-types:ospf-metric;
-      description
-        "The metric that should be considered to the remote neighbor
-        over this interface. This configuration is only applicable
-        for multiple-access networks";
-    }
-  }
-
-  grouping ospfv2-area-interface-neighbor-state {
-    description
-      "Operational state parameters relating an individual neighbor
-      system on an interface within an OSPF area";
-
-    leaf priority {
-      type uint8;
-      description
-        "The remote system's priority to become the designated
-        router";
-    }
-
-    leaf dead-time {
-      type oc-types:timeticks64;
-      description
-        "The time at which this neighbor's adjacency will be
-        considered dead. The value is expressed relative to
-        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
-    }
-
-    leaf designated-router {
-      type yang:dotted-quad;
-      description
-        "The designated router for the adjacency. This device
-        advertises the Network LSA for broadcast and NBMA networks.";
-    }
-
-    leaf backup-designated-router {
-      type yang:dotted-quad;
-      description
-        "The backup designated router for the adjacency.";
-    }
-
-    leaf optional-capabilities {
-      // rjs TODO: should this be anything more than the hex-string
-      // this is currently what is shown in IOS/JUNOS
-      type yang:hex-string;
-      description
-        "The optional capabilities field received in the Hello
-        message from the neighbor";
-    }
-
-    leaf last-established-time {
-      type oc-types:timeticks64;
-      // rjs TODO: check implementations - is FULL considered 'up'
-      // since the adjacency is probably up since ExStart
-      description
-        "The time at which the adjacency was last established with
-        the neighbor. That is to say the time at which the
-        adjacency last transitioned into the FULL state. The
-        value is expressed relative to the Unix Epoch (Jan 1 1970
-        00:00:00 UTC).";
-    }
-
-    leaf adjacency-state {
-      type identityref {
-        base "oc-ospf-types:OSPF_NEIGHBOR_STATE";
-      }
-      description
-        "The state of the adjacency with the neighbor.";
-    }
-
-    leaf state-changes {
-      type uint32;
-      description
-        "The number of transitions out of the FULL state that this
-        neighbor has been through";
-    }
-
-    leaf retranmission-queue-length {
-      type uint32;
-      description
-        "The number of LSAs that are currently in the queue to be
-        retransmitted to the neighbor";
-    }
-  }
-
-  grouping ospfv2-area-interface-lsa-filter-config {
-    description
-      "Configuration options relating to filtering LSAs
-      on an interface.";
-
-    leaf all {
-      type boolean;
-      description
-        "When this leaf is set to true, all LSAs should be
-        filtered to the neighbours with whom adjacencies are
-        formed on the interface.";
-    }
-
-    // NB: this container can be augmented to add additional
-    // filtering options which exist in some implementations.
   }
 
   grouping ospfv2-area-interface-mpls-igp-ldp-sync-state {
@@ -307,172 +59,61 @@ submodule openconfig-ospfv2-area-interface {
     }
   }
 
-  grouping ospfv2-area-interfaces-structure {
+  grouping ospfv2-mpls-interface {
     description
-      "Structural grouping for configuration and operational state
-      parameters that relate to an interface";
+      "Configuration and operational state parameters for
+       OSPFv2 extensions related to MPLS on the interface.";
 
-    container interfaces {
+    container mpls {
       description
-        "Enclosing container for a list of interfaces enabled within
-        this area";
+        "Configuration and operational state parameters for
+         OSPFv2 extensions related to MPLS on the interface.";
 
-      list interface {
-        key "id";
-
+      container config {
         description
-          "List of interfaces which are enabled within this area";
+          "Configuration parameters for OSPF extensions relating
+          to MPLS for the interface";
+        uses ospfv2-area-interface-mpls-config;
+      }
 
-        leaf id {
-          type leafref {
-            path "../config/id";
-          }
-          description
-            "A pointer to the identifier for the interface.";
-        }
+      container state {
+        config false;
+        description
+          "Operational state for OSPF extensions relating to
+          MPLS for the interface";
+        uses ospfv2-area-interface-mpls-config;
+      }
+
+      container igp-ldp-sync {
+        description
+          "OSPF parameters relating to LDP/IGP synchronization";
 
         container config {
           description
-            "Configuration parameters for the interface on which
-            OSPFv2 is enabled";
-
-          uses ospfv2-area-interface-config;
+            "Configuration parameters relating to LDP/IG
+            synchronization.";
+          uses oc-ospfv2-g:ospfv2-common-mpls-igp-ldp-sync-config;
         }
 
         container state {
           config false;
           description
-            "Operational state parameters for the interface on which
-            OSPFv2 is enabled";
-          uses ospfv2-area-interface-config;
+            "Operational state variables relating to LDP/IGP
+            synchronization";
+          uses oc-ospfv2-g:ospfv2-common-mpls-igp-ldp-sync-config;
+          uses ospfv2-area-interface-mpls-igp-ldp-sync-state;
         }
-
-        uses oc-if:interface-ref;
-
-        container timers {
-          description
-            "Timers relating to OSPFv2 on the interface";
-
-          container config {
-            description
-              "Configuration parameters for OSPFv2 timers on the
-              interface";
-            uses ospfv2-area-interface-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters for OSPFv2 timers on
-              the interface";
-
-            uses ospfv2-area-interface-timers-config;
-          }
-        }
-
-        container mpls {
-          description
-            "Configuration and operational state parameters for
-            OSPFv2 extensions related to MPLS on the interface.";
-
-          container config {
-            description
-              "Configuration parameters for OSPFv2 extensions relating
-              to MPLS for the interface";
-            uses ospfv2-area-interface-mpls-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state for OSPFv2 extensions relating to
-              MPLS for the interface";
-            uses ospfv2-area-interface-mpls-config;
-          }
-
-          container igp-ldp-sync {
-            description
-              "OSPFv2 parameters relating to LDP/IGP synchronization";
-
-            container config {
-              description
-                "Configuration parameters relating to LDP/IG
-                synchronization.";
-              uses ospfv2-common-mpls-igp-ldp-sync-config;
-            }
-
-            container state {
-              config false;
-              description
-                "Operational state variables relating to LDP/IGP
-                synchronization";
-              uses ospfv2-common-mpls-igp-ldp-sync-config;
-              uses ospfv2-area-interface-mpls-igp-ldp-sync-state;
-            }
-          }
-        }
-
-        container lsa-filter {
-          description
-            "OSPFv2 parameters relating to filtering of LSAs to
-            neighbors the specified interface.";
-
-          container config {
-            description
-              "Configuration parameters relating to filtering LSAs
-              on the specified interface.";
-            uses ospfv2-area-interface-lsa-filter-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to filtering
-              LSAs on the specified interface";
-            uses ospfv2-area-interface-lsa-filter-config;
-          }
-        }
-
-        container neighbors {
-          description
-            "Enclosing container for the list of neighbors that
-            an adjacency has been established with on the interface";
-
-          list neighbor {
-            key "router-id";
-
-            description
-              "A neighbor with which an OSPFv2 adjacency has been
-              established within this area";
-
-            leaf router-id {
-              type leafref {
-                path "../config/router-id";
-              }
-              description
-                "Reference to the router ID of the adjacent system";
-            }
-
-            container config {
-              description
-                "Configuration parameters relating to the adjacent
-                system";
-              uses ospfv2-area-interface-neighbor-config;
-            }
-
-            container state {
-              config false;
-              description
-                "Operational state parameters relating to the adjacent
-                system";
-              uses ospfv2-area-interface-neighbor-config;
-              uses ospfv2-area-interface-neighbor-state;
-            }
-          }
-        }
-
       }
     }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:areas/oc-ni:area/" +
+          "oc-ni:interfaces/oc-ni:interface" {
+    description
+      "MPLS on OSPFv2 interface";
+    uses ospfv2-mpls-interface;
   }
 
 }

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -1,16 +1,12 @@
-submodule openconfig-ospfv2-area {
+module openconfig-ospfv2-area {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
-  }
+  // namespace
+  namespace "http://openconfig.net/yang/ospfv2/area";
+
+  prefix "oc-ospf";
 
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-ospf-types { prefix "oc-ospf-types"; }
-  import ietf-inet-types { prefix "inet"; }
-
-  // include other required submodules
-  include openconfig-ospfv2-area-interface;
-  include openconfig-ospfv2-lsdb;
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   // meta
   organization "OpenConfig working group";
@@ -23,57 +19,15 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-17" {
     description
       "Initial revision";
     reference "0.0.1";
   }
 
-  grouping ospfv2-area-config {
-    description
-      "Configuration parameters relating to an OSPF area";
-
-    leaf identifier {
-      type oc-ospf-types:ospf-area-identifier;
-      description
-        "An identifier for the OSPFv2 area - described as either a
-        32-bit unsigned integer, or a dotted-quad";
-    }
-  }
-
-  grouping ospfv2-area-mpls-config {
+  grouping ospf-area-mpls-config {
     description
       "Configuration parameters relating to OSPFv2 extensions for
       MPLS";
@@ -86,37 +40,10 @@ submodule openconfig-ospfv2-area {
     }
   }
 
-  grouping ospfv2-area-virtual-link-config {
+  grouping ospfv2-mpls-area {
     description
-      "Configuration parameters relating to a virtual-link within
-      the OSPF area";
-
-    leaf remote-router-id {
-      type inet:ipv4-address-no-zone;
-      description
-        "The router ID of the device which terminates the remote end
-        of the virtual link";
-    }
-  }
-
-  grouping ospfv2-area-structure {
-    description
-      "Structural grouping for configuration and operational state
-      parameters that relate to an individual area";
-
-    container config {
-      description
-        "Configuration parameters relating to an OSPFv2 area";
-
-      uses ospfv2-area-config;
-    }
-
-    container state {
-      config false;
-      description
-        "Operational state parameters relating to an OSPFv2 area";
-      uses ospfv2-area-config;
-    }
+      "Configuration and operational state parameters for OSPFv2
+      extensions relating to MPLS";
 
     container mpls {
       description
@@ -127,7 +54,7 @@ submodule openconfig-ospfv2-area {
         description
           "Configuration parameters relating to MPLS extensions for
           OSPFv2";
-        uses ospfv2-area-mpls-config;
+        uses ospf-area-mpls-config;
       }
 
       container state {
@@ -135,47 +62,18 @@ submodule openconfig-ospfv2-area {
         description
           "Operational state parameters relating to MPLS extensions
           for OSPFv2";
-        uses ospfv2-area-mpls-config;
-      }
-    }
-
-    uses ospfv2-lsdb-structure;
-    uses ospfv2-area-interfaces-structure;
-
-    container virtual-links {
-      description
-        "Configuration and state parameters relating to virtual
-        links from the source area to a remote router";
-
-      list virtual-link {
-        key "remote-router-id";
-
-        description
-          "Configuration and state parameters relating to a
-          virtual link";
-
-        leaf remote-router-id {
-          type leafref {
-            path "../config/remote-router-id";
-          }
-          description
-            "Reference to the remote router ID";
-        }
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPF virtual link";
-          uses ospfv2-area-virtual-link-config;
-        }
-
-        container state {
-          config false;
-          description
-            "State parameters relating to the OSPF virtual link";
-          uses ospfv2-area-virtual-link-config;
-          uses ospfv2-area-interface-neighbor-state;
-        }
+        uses ospf-area-mpls-config;
       }
     }
   }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:areas/oc-ni:area" {
+    description
+      "MPLS configuration on OSPFv2 area";
+    uses ospfv2-mpls-area;
+  }
+
+
 }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -1,16 +1,13 @@
-submodule openconfig-ospfv2-global {
+module openconfig-ospfv2-global {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
-  }
+  // namespace
+  namespace "http://openconfig.net/yang/ospfv2/global";
 
-  import ietf-yang-types { prefix "yang"; }
+  prefix "oc-ospf";
+
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-routing-policy { prefix "oc-rpol"; }
-  import openconfig-ospf-types { prefix "oc-ospft"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
-  // Include common submodule
-  include openconfig-ospfv2-common;
 
   // meta
   organization "OpenConfig working group";
@@ -23,39 +20,9 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.0.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-16" {
     description
       "Initial revision";
     reference "0.0.1";
@@ -64,15 +31,6 @@ submodule openconfig-ospfv2-global {
   grouping ospfv2-global-config {
     description
       "Global configuration for OSPFv2";
-
-    leaf router-id {
-      type yang:dotted-quad;
-      description
-        "A 32-bit number represented as a dotted quad assigned to
-        each router running the OSPFv2 protocol. This number should
-        be unique within the autonomous system";
-      reference "rfc2828";
-    }
 
     leaf summary-route-cost-mode {
       type enumeration {
@@ -104,128 +62,60 @@ submodule openconfig-ospfv2-global {
         a remote system via any LSP to the system that is marked as
         shortcut eligible.";
     }
-
-    leaf log-adjacency-changes {
-      type boolean;
-      description
-        "When this leaf is set to true, a log message will be
-        generated when the state of an OSPFv2 neighbour changes.";
-    }
-
-    leaf hide-transit-only-networks {
-      type boolean;
-      description
-        "When this leaf is set to true, do not advertise prefixes
-        into OSPFv2 that correspond to transit interfaces, as per
-        the behaviour discussed in RFC6860.";
-      reference
-        "RFC6860 - Hiding Transit-Only Networks in OSPF";
-    }
   }
 
-  grouping ospfv2-global-spf-timers-config {
+  grouping ospfv2-common-mpls-igp-ldp-sync-config {
     description
-      "Configuration parameters relating to global SPF timer
-      parameters for OSPFv2";
-
-    leaf initial-delay {
-      // rjs TODO: IS-IS model has this as decimal64 - should it be
-      // that or uint32 msec?
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the time between a change
-        in topology being detected and the first run of the SPF
-        algorithm.";
-    }
-
-    leaf maximum-delay {
-      // rjs TODO: same question as above
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the maximum delay between
-        a topology change being detected and the SPF algorithm
-        running. This value is used for implementations that support
-        increasing the wait time between SPF runs.";
-    }
-
-    // rjs TODO: some questions here around what we should specify:
-    // JUNOS has rapid-runs and holddown
-    // Cisco has maximum time between runs, and then a doubling of
-    // the wait interval up to that maximum.
-    // ALU has first-wait, second-wait, max-wait
-  }
-
-  grouping ospfv2-global-lsa-generation-timers-config {
-    description
-      "Configuration parameters relating to global LSA generation
-      parameters for OSPFv2";
-
-    leaf initial-delay {
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the time between the first
-        time an LSA is generated and advertised and the subsequent
-        generation of that LSA.";
-    }
-
-    leaf maximum-delay {
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the maximum time between the
-        generation of an LSA and the subsequent re-generation of that
-        LSA. This value is used in implementations that support
-        increasing delay between generation of an LSA";
-    }
-  }
-
-  grouping ospfv2-global-spf-timers-state {
-    description
-      "Operational state parameters relating to OSPFv2 global
-      timers";
-
-    uses ospfv2-common-timers;
-  }
-
-  grouping ospfv2-global-lsa-generation-timers-state {
-    description
-      "Operational state parameters relating to OSPFv2 global
-      timers";
-
-    uses ospfv2-common-timers;
-  }
-
-  grouping ospfv2-global-graceful-restart-config {
-    description
-      "Configuration parameters relating to graceful restart for
-      OSPFv2";
+      "Configuration parameters used for OSPFv2 MPLS/IGP
+      synchronization";
 
     leaf enabled {
       type boolean;
       description
-        "When the value of this leaf is set to true, graceful restart
-        is enabled on the local system. In this case, the system will
-        use Grace-LSAs to signal that it is restarting to its
-        neighbors.";
+        "When this leaf is set to true, do not utilise this link for
+        forwarding via the IGP until such time as LDP adjacencies to
+        the neighbor(s) over the link are established.";
     }
 
-    leaf helper-only {
-      type boolean;
+    leaf post-session-up-delay {
+      type uint32;
+      units milliseconds;
       description
-        "Operate graceful-restart only in helper mode. When this leaf
-        is set to true, the local system does not use Grace-LSAs to
-        indicate that it is restarting, but will accept Grace-LSAs
-        from remote systems, and suppress withdrawl of adjacencies
-        of the system for the grace period specified";
+        "This leaf specifies a delay, expressed in units of milliseconds,
+        between the LDP session to the IGP neighbor being established, and
+        it being considered synchronized by the IGP.";
     }
   }
 
-  grouping ospfv2-global-mpls-config {
+
+  grouping ospfv2-igp-ldp-sync {
     description
-      "Configuration parameters for OSPFv2 options which
+      "Global configuration for OSPFv2 LGP LDP sync";
+
+    container igp-ldp-sync {
+      description
+        "OSPFv2 parameters relating to LDP/IGP synchronization";
+
+      container config {
+        description
+          "Configuration parameters relating to LDP/IG
+          synchronization.";
+        uses ospfv2-common-mpls-igp-ldp-sync-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state variables relating to LDP/IGP
+          synchronization";
+        uses ospfv2-common-mpls-igp-ldp-sync-config;
+      }
+    }
+  }
+
+  grouping ospf-global-mpls-config {
+    description
+      "Configuration parameters for OSPF options which
       relate to MPLS";
 
     leaf traffic-engineering-extensions {
@@ -237,285 +127,57 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-inter-areapp-config {
+  grouping ospfv2-mpls {
     description
-      "Configuration parameters for OSPFv2 policies which propagate
-      prefixes between areas";
+      "OSPFv2 parameters relating to MPLS";
 
-    leaf src-area {
-      type leafref {
-        // we are at ospf/global/inter-area-propagation-policies/...
-        // inter-area-propagation-policy/config/src-area
-        path "../../../../../areas/area/identifier";
-      }
+    container mpls {
       description
-        "The area from which prefixes are to be exported.";
-    }
-
-    leaf dst-area {
-      type leafref {
-        // we are at ospf/global/inter-area-propagation-policies/...
-        // inter-area-propagation-policy/config/src-area
-        path "../../../../../areas/area/identifier";
-      }
-      description
-        "The destination area to which prefixes are to be imported";
-    }
-
-    uses oc-rpol:apply-policy-import-config;
-  }
-
-  grouping ospfv2-global-max-metric-config {
-    description
-      "Configuration paramters relating to setting the OSPFv2
-      maximum metric.";
-
-    leaf set {
-      type boolean;
-      description
-        "When this leaf is set to true, all non-stub interfaces of
-        the local system are advertised with the maximum metric,
-        such that the router does not act as a transit system,
-        (similarly to the IS-IS overload functionality).";
-      reference
-        "RFC3137 - OSPF Stub Router Advertisement";
-    }
-
-    leaf timeout {
-      type uint64;
-      units "seconds";
-      description
-        "The delay, in seconds, after which the advertisement of
-        entities with the maximum metric should be cleared, and
-        the system reverts to the default, or configured, metrics.";
-    }
-
-    leaf-list include {
-      type identityref {
-        base "oc-ospft:MAX_METRIC_INCLUDE";
-      }
-      description
-        "By default, the maximum metric is advertised for all
-        non-stub interfaces of a device. When identities are
-        specified within this leaf-list, additional entities
-        are also advertised with the maximum metric according
-        to the values within the list.";
-    }
-
-    leaf-list trigger {
-      type identityref {
-        base "oc-ospft:MAX_METRIC_TRIGGER";
-      }
-      description
-        "By default, the maximum metric is only advertised
-        when the max-metric/set leaf is specified as true.
-        In the case that identities are specified within this
-        list, they provide additional triggers (e.g., system
-        boot) that may cause the max-metric to be set. In this
-        case, the system should still honour the timeout specified
-        by the max-metric/timeout leaf, and clear the max-metric
-        advertisements after the expiration of this timer.";
-    }
-  }
-
-  grouping ospfv2-global-structural {
-    description
-      "Top level structural grouping for OSPFv2 global parameters";
-
-    container global {
-      description
-        "Configuration and operational state parameters for settings
-        that are global to the OSPFv2 instance";
-
+        "OSPFv2 parameters relating to MPLS";
+   
       container config {
         description
-          "Global configuration parameters for OSPFv2";
-        uses ospfv2-global-config;
+          "Configuration parameters relating to MPLS for OSPF";
+        uses ospf-global-mpls-config;
       }
-
+   
       container state {
         config false;
         description
-          "Operational state parameters for OSPFv2";
-        uses ospfv2-global-config;
+          "Operational state parameters relating to MPLS for
+          OSPF";
+        uses ospf-global-mpls-config;
       }
-
-      container timers {
-        description
-          "Configuration and operational state parameters for OSPFv2
-          timers";
-
-        container spf {
-          description
-            "Configuration and operational state parameters relating
-            to timers governing the operation of SPF runs";
-
-          container config {
-            description
-              "Configuration parameters relating to global OSPFv2
-              SPF timers";
-            uses ospfv2-global-spf-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the global
-              OSPFv2 SPF timers";
-            uses ospfv2-global-spf-timers-config;
-            uses ospfv2-global-spf-timers-state;
-          }
-        }
-
-        container max-metric {
-          description
-            "Configuration and operational state parameters relating
-            to setting the OSPFv2 maximum metric.";
-
-          container config {
-            description
-              "Configuration parameters relating to setting the OSPFv2
-              maximum metric for a set of advertised entities.";
-            uses ospfv2-global-max-metric-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to setting the
-              OSPFv2 maximum metric for a set of advertised entities.";
-            uses ospfv2-global-max-metric-config;
-          }
-        }
-
-        container lsa-generation {
-          description
-            "Configuration and operational state parameters relating
-            to timers governing the generation of LSAs by the local
-            system";
-
-          container config {
-            description
-              "Configuration parameters relating to the generation of
-              LSAs by the local system";
-            uses ospfv2-global-lsa-generation-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the generation
-              of LSAs by the local system";
-            uses ospfv2-global-lsa-generation-timers-config;
-            uses ospfv2-global-lsa-generation-timers-state;
-          }
-        }
-      }
-
-      container graceful-restart {
-        description
-          "Configuration and operational state parameters for OSPFv2
-          graceful restart";
-
-        container config {
-          description
-            "Configuration parameters relating to OSPFv2 graceful
-            restart";
-          uses ospfv2-global-graceful-restart-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to OSPFv2 graceful
-            restart";
-          uses ospfv2-global-graceful-restart-config;
-        }
-      }
-
-      container mpls {
-        description
-          "OSPFv2 parameters relating to MPLS";
-
-        container config {
-          description
-            "Configuration parameters relating to MPLS for OSPFv2";
-          uses ospfv2-global-mpls-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to MPLS for
-            OSPFv2";
-          uses ospfv2-global-mpls-config;
-        }
-
-        container igp-ldp-sync {
-          description
-            "OSPFv2 parameters relating to LDP/IGP synchronization";
-
-          container config {
-            description
-              "Configuration parameters relating to LDP/IG
-              synchronization.";
-            uses ospfv2-common-mpls-igp-ldp-sync-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state variables relating to LDP/IGP
-              synchronization";
-            uses ospfv2-common-mpls-igp-ldp-sync-config;
-          }
-        }
-      }
-
-      container inter-area-propagation-policies {
-        description
-          "Policies defining how inter-area propagation should be performed
-          by the OSPF instance";
-
-        list inter-area-propagation-policy {
-          key "src-area dst-area";
-          description
-            "A list of connections between pairs of areas - routes are
-            propagated from the source (src) area to the destination (dst)
-            area according to the policy specified";
-
-          leaf src-area {
-            type leafref {
-              path "../config/src-area";
-            }
-            description
-              "Reference to the source area";
-          }
-
-          leaf dst-area {
-            type leafref {
-              path "../config/dst-area";
-            }
-            description
-              "Reference to the destination area";
-          }
-
-          container config {
-            description
-              "Configuration parameters relating to the inter-area
-              propagation policy";
-            uses ospfv2-global-inter-areapp-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the inter-area
-              propagation policy";
-            uses ospfv2-global-inter-areapp-config;
-          }
-        }
-      }
+   
+      uses ospfv2-igp-ldp-sync;
     }
   }
+
+
+  // augment the groupings into ospf model
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:global/oc-ni:config" {
+    description
+      "Global configuration for OSPFv2";
+    uses ospfv2-global-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:global/oc-ni:state" {
+    description
+      "Global state for OSPFv2";
+    uses ospfv2-global-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:global" {
+    description
+      "OSPFv2 parameters relating to MPLS";
+    uses ospfv2-mpls;
+  }
+
+
 }

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -1,15 +1,18 @@
-submodule openconfig-ospfv2-lsdb {
+module openconfig-ospfv2-lsdb {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
-  }
+  // namespace
+  namespace "http://openconfig.net/yang/ospfv2/lsdb";
+
+  prefix "oc-niv2-lsdb";
 
   // import some basic types
   import ietf-yang-types { prefix "yang"; }
   import ietf-inet-types { prefix "inet"; }
   import openconfig-types { prefix "oc-types"; }
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import openconfig-ospf-types { prefix "oc-ni-types"; }
+
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   // meta
   organization "OpenConfig working group";
@@ -22,12 +25,12 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.1.4";
 
-  revision "2019-07-09" {
+  revision "2018-11-21" {
     description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
+      "Separte ospfv2 lsdb between per-area and global.";
+    reference "0.1.4";
   }
 
   revision "2018-11-21" {
@@ -194,7 +197,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf metric {
-      type oc-ospf-types:ospf-metric;
+      type oc-ni-types:ospf-metric;
       description
         "The metric value to be used for the TOS specified. This value
         represents the cost of use of the link for the specific type
@@ -207,7 +210,7 @@ submodule openconfig-ospfv2-lsdb {
       "Re-usable specification of a segment routing SID";
 
     leaf sid-type {
-      type oc-ospf-types:sr-sid-type;
+      type oc-ni-types:sr-sid-type;
       description
         "The type of the value contained within the sub-TLV";
     }
@@ -225,7 +228,7 @@ submodule openconfig-ospfv2-lsdb {
       "Per-area operational state parameters for an OSPFv2 area";
 
     leaf identifier {
-      type oc-ospf-types:ospf-area-identifier;
+      type oc-ni-types:ospf-area-identifier;
       description
         "An identifier for the area, expressed as a dotted quad or
         an unsigned 32-bit integer";
@@ -238,7 +241,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPF_LSA_TYPE";
+        base "oc-ni-types:OSPF_LSA_TYPE";
       }
       description
         "The type of LSA being described. The type of the LSA is
@@ -263,6 +266,8 @@ submodule openconfig-ospfv2-lsdb {
       description
         "The router ID of the router that originated the LSA";
     }
+
+    uses ospfv2-lsdb-area-lsa-type-state;
 
     leaf sequence-number {
       type int32;
@@ -1109,7 +1114,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:ROUTER_LSA_TYPES";
+        base "oc-ni-types:ROUTER_LSA_TYPES";
       }
       description
         "The sub-type of the Router LSA.";
@@ -1118,7 +1123,7 @@ submodule openconfig-ospfv2-lsdb {
     uses ospfv2-lsdb-common-link-specification;
 
     leaf metric {
-      type oc-ospf-types:ospf-metric;
+      type oc-ni-types:ospf-metric;
       description
         "The cost of utilising the link specified independent of TOS";
     }
@@ -1229,7 +1234,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf metric {
-      type oc-ospf-types:ospf-metric;
+      type oc-ni-types:ospf-metric;
       description
         "The cost to reach the external network specified. The exact
         interpretation of this cost is dependent on the type of
@@ -1298,7 +1303,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPF_OPAQUE_LSA_TYPE";
+        base "oc-ni-types:OSPF_OPAQUE_LSA_TYPE";
       }
       description
         "The Opaque Type of the LSA. This value is used to
@@ -1312,7 +1317,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPF_TE_LSA_TLV_TYPE";
+        base "oc-ni-types:OSPF_TE_LSA_TLV_TYPE";
       }
       description
         "The type of TLV within the Traffic Engineering LSA";
@@ -1333,7 +1338,7 @@ submodule openconfig-ospfv2-lsdb {
     leaf type {
       type union {
         type identityref {
-          base "oc-ospf-types:OSPF_TE_LINK_TLV_TYPE";
+          base "oc-ni-types:OSPF_TE_LINK_TLV_TYPE";
         }
         type enumeration {
           enum UNKNOWN {
@@ -1542,7 +1547,7 @@ submodule openconfig-ospfv2-lsdb {
     leaf type {
       type union {
         type identityref {
-          base "oc-ospf-types:TE_NODE_ATTRIBUTE_TLV_TYPE";
+          base "oc-ni-types:TE_NODE_ATTRIBUTE_TLV_TYPE";
         }
         type enumeration {
           enum UNKNOWN {
@@ -1604,7 +1609,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:GRACE_LSA_TLV_TYPES";
+        base "oc-ni-types:GRACE_LSA_TLV_TYPES";
       }
       description
         "The type of the sub-TLV received within the Grace LSA";
@@ -1685,7 +1690,7 @@ submodule openconfig-ospfv2-lsdb {
     leaf type {
       type union {
         type identityref {
-          base "oc-ospf-types:RI_LSA_TLV_TYPES";
+          base "oc-ni-types:RI_LSA_TLV_TYPES";
         }
         type enumeration {
           enum UNKNOWN {
@@ -1783,7 +1788,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf-list supported-algorithms {
       type identityref {
-        base "oc-ospf-types:SR_ALGORITHM";
+        base "oc-ni-types:SR_ALGORITHM";
       }
       description
         "A list of the algorithms that are supported for segment routing
@@ -1799,7 +1804,7 @@ submodule openconfig-ospfv2-lsdb {
     leaf type {
       type union {
         type identityref {
-          base "oc-ospf-types:OSPF_RI_SR_SID_LABEL_TLV_TYPES";
+          base "oc-ni-types:OSPF_RI_SR_SID_LABEL_TLV_TYPES";
         }
         type enumeration {
           enum UNKNOWN {
@@ -1830,7 +1835,7 @@ submodule openconfig-ospfv2-lsdb {
       range TLV of the RI LSA";
 
     leaf entry-type {
-      type oc-ospf-types:sr-sid-type;
+      type oc-ni-types:sr-sid-type;
       description
         "The type of entry that is contained within the sub-TLV. The range may
         be represented as either a range of MPLS labels, or numeric segment
@@ -1923,7 +1928,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf link-type {
       type identityref {
-        base "oc-ospf-types:OSPFV2_ROUTER_LINK_TYPE";
+        base "oc-ni-types:OSPFV2_ROUTER_LINK_TYPE";
       }
       description
         "The type of link with which extended attributes are associated";
@@ -1939,7 +1944,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPFV2_EXTENDED_LINK_SUBTLV_TYPE";
+        base "oc-ni-types:OSPFV2_EXTENDED_LINK_SUBTLV_TYPE";
       }
       description
         "The type of the sub-TLV contained within the extended link TLV";
@@ -1952,7 +1957,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
+        base "oc-ni-types:OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
       }
       description
         "The type of sub-TLV as indicated by the Extended Prefix LSA";
@@ -2115,7 +2120,7 @@ submodule openconfig-ospfv2-lsdb {
     leaf type {
       type identityref {
         base
-         "oc-ospf-types:OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
+         "oc-ni-types:OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
       }
       description
         "The type of sub-TLV that is being contained within the SID/Label
@@ -2151,7 +2156,7 @@ submodule openconfig-ospfv2-lsdb {
 
     leaf type {
       type identityref {
-        base "oc-ospf-types:OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE";
+        base "oc-ni-types:OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE";
       }
       description
         "The type of the segment being specified as part of the ERO";
@@ -2232,7 +2237,7 @@ submodule openconfig-ospfv2-lsdb {
     }
   }
 
-  grouping ospfv2-lsdb-structure {
+  grouping ospfv2-link-lsdb-structure {
     description
       "Structural grouping for per-area LSDB contents";
 
@@ -2285,7 +2290,7 @@ submodule openconfig-ospfv2-lsdb {
               the specified type received by the system";
 
             list lsa {
-              key "link-state-id";
+              key "link-state-id advertising-router type";
 
               description
                 "List of the LSAs of a specified type in the
@@ -2297,6 +2302,129 @@ submodule openconfig-ospfv2-lsdb {
                 }
                 description
                   "Reference to the Link State ID of the LSA";
+              }
+
+              leaf advertising-router {
+                type leafref {
+                  path "../state/advertising-router";
+                }
+
+                description
+                  "Reference to the router ID of the router that originated the LSA";
+              }
+
+              leaf type {
+                type leafref {
+                  path "../state/type";
+                }
+                description
+                  "Reference to the LSA type";
+              }
+
+              container state {
+                description
+                  "Operational state parameters relating to all
+                  LSA types";
+                uses ospfv2-lsdb-area-lsa-state;
+              }
+
+              uses ospfv2-lsdb-opaque-lsa-structure {
+                when "../../state/type = 'OSPFV2_LINK_SCOPE_OPAQUE_LSA'" {
+                  description
+                    "Include the Opaque LSA structure when type of entry
+                    being described in an opaque LSA";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  grouping ospfv2-area-lsdb-structure {
+    description
+      "Structural grouping for per-area LSDB contents";
+
+    container lsdb {
+      // Top-level RO, if this were ever to become writeable then
+      // the state containers lower down need config false added
+      config false;
+      description
+        "The link-state database for the OSPFv2 area";
+
+      container state {
+        description
+          "Operational state parameters relating to the OSPFv2
+          area";
+
+        uses ospfv2-lsdb-area-state;
+      }
+
+      container lsa-types {
+        description
+          "Enclosing container for a list of LSA types that are
+          in the LSDB for the specified area";
+
+        list lsa-type {
+          key "type";
+
+          description
+            "List of LSA types in the LSDB for the specified
+            area";
+
+          leaf type {
+            type leafref {
+              path "../state/type";
+            }
+            description
+              "A reference for the LSA type being described within
+              the LSDB";
+          }
+
+          container state {
+            description
+              "Top-level operational state parameters relating to
+              an LSA within the area";
+            uses ospfv2-lsdb-area-lsa-type-state;
+          }
+
+          container lsas {
+            description
+              "Enclosing container for a list of the LSAs of
+              the specified type received by the system";
+
+            list lsa {
+              key "link-state-id advertising-router type";
+
+              description
+                "List of the LSAs of a specified type in the
+                LSDB for the specified area";
+
+              leaf link-state-id {
+                type leafref {
+                  path "../state/link-state-id";
+                }
+                description
+                  "Reference to the Link State ID of the LSA";
+              }
+
+              leaf advertising-router {
+                type leafref {
+                  path "../state/advertising-router";
+                }
+
+                description
+                  "Reference to the router ID of the router that originated the LSA";
+              }
+
+              leaf type {
+                type leafref {
+                  path "../state/type";
+                }
+                description
+                  "Reference to the LSA type";
               }
 
               container state {
@@ -2333,14 +2461,6 @@ submodule openconfig-ospfv2-lsdb {
                 }
               }
 
-              uses ospfv2-lsdb-asexternal-lsa-structure {
-                when "../../state/type = 'AS_EXTERNAL_LSA'" {
-                  description
-                    "Include the AS external LSA hierarchy solely when
-                    that LSA type is being described";
-                }
-              }
-
               uses ospfv2-lsdb-nssa-external-lsa-structure {
                 when "../../state/type = 'NSSA_AS_EXTERNAL_LSA'" {
                   description
@@ -2350,9 +2470,7 @@ submodule openconfig-ospfv2-lsdb {
               }
 
               uses ospfv2-lsdb-opaque-lsa-structure {
-                when "../../state/type = 'OSPFV2_LINK_SCOPE_OPAQUE_LSA'
-                  or ../../state/type = 'OSPFV2_AREA_SCOPE_OPAQUE_LSA'
-                  or ../../state/type = 'OSPFV2_AS_SCOPE_OPAQUE_LSA'" {
+                when "../../state/type = 'OSPFV2_AREA_SCOPE_OPAQUE_LSA'" {
                   description
                     "Include the Opaque LSA structure when type of entry
                     being described in an opaque LSA";
@@ -2364,4 +2482,146 @@ submodule openconfig-ospfv2-lsdb {
       }
     }
   }
+
+  grouping ospfv2-global-lsdb-structure {
+    description
+      "Structural grouping for per-area LSDB contents";
+
+    container lsdb {
+      // Top-level RO, if this were ever to become writeable then
+      // the state containers lower down need config false added
+      config false;
+      description
+        "The link-state database for the OSPFv2 area";
+
+      container state {
+        description
+          "Operational state parameters relating to the OSPFv2
+          area";
+
+        uses ospfv2-lsdb-area-state;
+      }
+
+      container lsa-types {
+        description
+          "Enclosing container for a list of LSA types that are
+          in the LSDB for the specified area";
+
+        list lsa-type {
+          key "type";
+
+          description
+            "List of LSA types in the LSDB for the specified
+            area";
+
+          leaf type {
+            type leafref {
+              path "../state/type";
+            }
+            description
+              "A reference for the LSA type being described within
+              the LSDB";
+          }
+
+          container state {
+            description
+              "Top-level operational state parameters relating to
+              an LSA within the area";
+            uses ospfv2-lsdb-area-lsa-type-state;
+          }
+
+          container lsas {
+            description
+              "Enclosing container for a list of the LSAs of
+              the specified type received by the system";
+
+            list lsa {
+              key "link-state-id advertising-router type";
+
+              description
+                "List of the LSAs of a specified type in the
+                LSDB for the specified area";
+
+              leaf link-state-id {
+                type leafref {
+                  path "../state/link-state-id";
+                }
+                description
+                  "Reference to the Link State ID of the LSA";
+              }
+
+              leaf advertising-router {
+                type leafref {
+                  path "../state/advertising-router";
+                }
+
+                description
+                  "Reference to the router ID of the router that originated the LSA";
+              }
+
+              leaf type {
+                type leafref {
+                  path "../state/type";
+                }
+                description
+                  "Reference to the LSA type";
+              }
+
+              container state {
+                description
+                  "Operational state parameters relating to all
+                  LSA types";
+                uses ospfv2-lsdb-area-lsa-state;
+              }
+
+              uses ospfv2-lsdb-asexternal-lsa-structure {
+                when "../../state/type = 'AS_EXTERNAL_LSA'" {
+                  description
+                    "Include the AS external LSA hierarchy solely when
+                    that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-opaque-lsa-structure {
+                when "../../state/type = 'OSPFV2_AS_SCOPE_OPAQUE_LSA'" {
+                  description
+                    "Include the Opaque LSA structure when type of entry
+                    being described in an opaque LSA";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  // augment the groupings into ospfv2 model
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:global" {
+    description
+      "OSPFv2 gloabl LSA database";
+    uses ospfv2-global-lsdb-structure;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:areas/oc-ni:area" {
+    description
+      "OSPFv2 area LSA database";
+    uses ospfv2-area-lsdb-structure;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospf/" +
+          "oc-ni:areas/oc-ni:area/" +
+          "oc-ni:interfaces/oc-ni:interface" {
+    description
+      "OSPFv2 link LSA database";
+    uses ospfv2-link-lsdb-structure;
+  } 
+
+
 }

--- a/release/models/ospf/openconfig-ospfv3-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv3-area-interface.yang
@@ -1,0 +1,73 @@
+submodule openconfig-ospfv3-area-interface {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  // include common submodule
+  include openconfig-ospf-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision "2019-08-16" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+
+  grouping ospfv3-area-interface-config {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an interface";
+
+    leaf instance-id {
+      type uint8;
+      default 0;
+      description
+        "The OSPF protocol instance associated with this OSPF interface.";
+    }
+
+    leaf interface-id {
+      type uint32;
+      description
+        "32-bit number uniquely identifying this interface among the
+         collection of this router's interface. If it is not specified, the
+         interface index can be used.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv3/" +
+          "oc-ni:areas/oc-ni:area/" +
+          "oc-ni:interfaces/oc-ni:interface/oc-ni:config" {
+    description
+      "OSPFv3 interface paramaters";
+    uses ospfv3-area-interface-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv3/" +
+          "oc-ni:areas/oc-ni:area/" +
+          "oc-ni:interfaces/oc-ni:interface/oc-ni:state" {
+    description
+      "OSPFv3 interface paramaters";
+    uses ospfv3-area-interface-config;
+  }
+
+
+}


### PR DESCRIPTION
Change the current Yang modules from ospfv2 to ospf in order to have
common modules supporting both OSPFv2 and OSPFv3. The idea is to create
OSPF common files supporting the core functionality of both OSPFv2 and
OSPFv3. Then use augment statement to augment the core model to form
OSPFv2 and OSPFv3 model. Both OSPFv2 and OSPFv3 are under protocol with
the name ospf and ospfv3. Although the model is split to core and
ospfv2/v3 spcific, the produced OSPFv2 Yang model maintains high
similarity to the original openconfig OSPF Yang model except adding
missing fields and fixing the location of the LSDB on the original tree.
File has been changed to OSPF core.

openconfig-ospfv2-area-interface.yang ->
openconfig-ospf-area-interface.yang
openconfig-ospfv2-area.yang -> openconfig-ospf-area.yang
openconfig-ospfv2-common.yang -> openconfig-ospf-common.yang
openconfig-ospfv2-global.yang -> openconfig-ospf-global.yang
openconfig-ospfv2.yang -> openconfig-ospf.yang
Add OSPFv2 specific files to augment ospf core model to form OSPFv2
model. All MPLS definitions are move to the following OSPFv2 specific
files.

openconfig-ospfv2-area-interface.yang
openconfig-ospfv2-global.yang
openconfig-ospfv2-lsdb.yang
Add OSPFv3 specific files to augment ospf core model to form OSPFv3
model.

openconfig-ospfv3-area-interface.yang
In openconfig-network-instance.yang file a) Change openconfig-ospfv2 to
openconfig-ospf b) Add reference to ospfv3-top container

In openconfig-ospf.yang file a) Add ospfv3-top grouping which is
referenced by openconfig-network-instance.yang

In openconfig-ospf-global.yang file a) Add abr-capability under
ospf-global-config. Rational behind: the ABR in RFC2328 defines a router
to be ABR when it participats multiple OSPF areas and it does not matter
whether it connects to backbone area or not. The RFC3509 provides an
alternate implementation where the ABR is required to participate
backbone area. Cisco supports the latter implementation while the
Juniper supports the former. Ciena supports both. We think it is
important for an operator to understand the ABR definition used by
different vendors to come out a peroper network design. b) Change ospfv2
to ospf c) In the ospf-global-structural, add
ospfv2-global-lsdb-structure which contains OSPFv2 LSA database for the
AS flooding scope.
d) Move summary-route-cost-mode and igp-shortcuts to
openconfig-ospfv2-global.yang and uses these two parameters only for
OSPFv2.

In openconfig-ospf-types.yang file a) Add OSPF-AREA-TYPE definition
including NORMAL, STUB, and NSSA b) Add OSPF-ABR-TYPE definition
including RFC3509-COMPATIBLE and RFC2328-COMPATIBLE

In openconfig-ospf-common.yang file a) Change ospfv2 to ospf b) Move
MPLS related definition to openconfig-ospfv2-global.yang

In openconfig-ospf-area.yang file a) Change ospfv2 to ospf b) Add
address-ranges, stub-default-cost and import-summaries under area/config
c) Add ospfv2-area-lsdb-structure under area for OSPFv2

In openconfig-ospf-area-interface.yang a) Add ospfv2-link-lsdb-structure
under interface for OSPFv2.

In openconfig-ospfv2-lsdb.yang file a) Split the current single
definition into ospfv2-global-lsdb-structure, ospfv2-area-lsdb-structure
and ospfv2-link-lsdb-structure

In openconfig-ospf-area-interface.yang a) Change ospfv2 to ospf b) Add
interface-transmission-delay under ospf-area-interface-timers-config c)
Add reference to ospfv3-area-interface-config which contains OSPFv3
specific configuration d) Add default value to hello-interval,
dead-interval, retransmission-interval, priority, passive, and metric.

Add openconfig-ospfv2-global.yang a) This submodule contains the OSPFv2
specific parameters including summary-route-cost-mode and igp-shortcuts.

Add openconfig-ospfv2-area-interface.yang a) Move mpls container from
openconfig-ospf-area-interface.yang b) Move
ospfv2-area-interface-mpls-config container from
openconfig-ospf-area-interface.yang

Add openconfig-ospfv3-area-interface.yang a) Add instance-id under
ospfv3-area-interface-config, which is required by OSPFv3 b) Add
interface-id under ospfv3-area-interface-config, which is a 32-bit
numbered uniquely identifying the interface. c) Define
ospfv3-area-interface-config which contains OSPFv3 specific
configuration

To-DO list:

The OSPFv2 LSDB: still have definition errors
The OSPFv3 LDDB is not defined yet.