### PR TITLE
Modify some containers in AFT model to read-only.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,7 +22,14 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.3.3";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-09-15" {
+    description
+      "Change next-hop-groups and next-hops to read-only and remove 
+       config";
+    reference "0.4.0";
+  }
 
   revision "2019-08-01" {
     description
@@ -53,6 +60,7 @@ submodule openconfig-aft-common {
       "Structural grouping describing a next-hop entry.";
 
     container next-hops {
+      config false;
       description
         "The list of next-hops that are to be used for entry within
         the AFT table. The structure of each next-hop is address
@@ -68,27 +76,21 @@ submodule openconfig-aft-common {
           indicated).";
 
       list next-hop {
+        config false;
         key "index";
 
         description
           "A next-hop associated with the forwarding instance.";
 
         leaf index {
+          config false;
           type leafref {
-            path "../config/index";
+            path "../state/index";
           }
           description
             "A unique index identifying the next-hop entry for the
             AFT entry";
 
-        }
-
-        container config {
-          description
-            "Configuration parameters relating to the AFT next-hop
-            entry";
-
-          uses aft-common-entry-nexthop-config;
         }
 
         container state {
@@ -235,10 +237,12 @@ submodule openconfig-aft-common {
       "Logical grouping for groups of next-hops.";
 
     container next-hop-groups {
+      config false;
       description
         "Surrounding container for groups of next-hops.";
 
       list next-hop-group {
+        config false;
         key "id";
 
         description
@@ -257,14 +261,8 @@ submodule openconfig-aft-common {
             "A reference to a unique identifier for the next-hop-group.";
 
           type leafref {
-            path "../config/id";
+            path "../state/id";
           }
-        }
-
-        container config {
-          description
-            "Configuration parameters related to the next-hop-group.";
-          uses aft-nhg-config;
         }
 
         container state {
@@ -276,11 +274,13 @@ submodule openconfig-aft-common {
         }
 
         container next-hops {
+          config false;
           description
             "Surrounding container for the list of next-hops within
             the next-hop-group.";
 
           list next-hop {
+            config false;
             key "index";
 
             description
@@ -289,19 +289,13 @@ submodule openconfig-aft-common {
               list.";
 
             leaf index {
+              config false;
               description
                 "A reference to the index for the next-hop within the
                 the next-hop-group.";
               type leafref {
-                path "../config/index";
+                path "../state/index";
               }
-            }
-
-            container config {
-              description
-                "Configuration parameters related to a next-hop within
-                the next-hop-group.";
-              uses aft-nhg-nh-config;
             }
 
             container state {
@@ -309,7 +303,6 @@ submodule openconfig-aft-common {
               description
                 "Operational state parameters related to a next-hop
                 within the next-hop-group.";
-              uses aft-nhg-nh-config;
               uses aft-nhg-nh-state;
             }
           }
@@ -373,26 +366,20 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-nhg-nh-config {
+  grouping aft-nhg-nh-state {
     description
-      "Configuration parameters relating to an individual next-hop within
-      a next-hop-group.";
+      "Operational state parameters relating to an individual next-hop
+      within the next-hop-group.";
 
     leaf index {
       type leafref {
         // We are at afts/next-hop-groups/next-hop-group/next-hops/next-hop/config/id
-        path "../../../../../../next-hops/next-hop/config/index";
+        path "../../../../../../next-hops/next-hop/state/index";
       }
       description
         "A reference to the identifier for the next-hop to which
         the entry in the next-hop group corresponds.";
     }
-  }
-
-  grouping aft-nhg-nh-state {
-    description
-      "Operational state parameters relating to an individual next-hop
-      within the next-hop-group.";
 
     leaf weight {
       type uint64;

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.3.3";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-09-15" {
+    description
+      "Change ipv4-unicast to read-only and remove config.";
+    reference "0.4.0";
+  }
 
   revision "2019-08-01" {
     description
@@ -52,6 +58,7 @@ submodule openconfig-aft-ipv4 {
       abstract forwarding table.";
 
     list ipv4-entry {
+      config false;
       key "prefix";
 
       description
@@ -60,18 +67,13 @@ submodule openconfig-aft-ipv4 {
         prefix.";
 
       leaf prefix {
+        config false;
         type leafref {
-          path "../config/prefix";
+          path "../state/prefix";
         }
         description
           "Reference to the IPv4 unicast destination prefix which
           must be matched to utilise the AFT entry.";
-      }
-
-      container config {
-        description
-          "Configuration parameters for the IPv4 unicast AFT entry.";
-        uses aft-ipv4-unicast-entry-config;
       }
 
       container state {

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.3.3";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-09-05" {
+    description
+      "Change ipv6-unicast to read-only and remove config.";
+    reference "0.4.0";
+  }
 
   revision "2019-08-01" {
     description
@@ -52,6 +58,7 @@ submodule openconfig-aft-ipv6 {
       abstract forwarding table.";
 
     list ipv6-entry {
+      config false;
       key "prefix";
 
       description
@@ -60,18 +67,13 @@ submodule openconfig-aft-ipv6 {
         prefix.";
 
       leaf prefix {
+        config false;
         type leafref {
-          path "../config/prefix";
+          path "../state/prefix";
         }
         description
           "Reference to the IPv6 unicast destination prefix which
           must be matched to utilise the AFT entry.";
-      }
-
-      container config {
-        description
-          "Configuration parameters for the IPv6 unicast AFT entry.";
-        uses aft-ipv6-unicast-entry-config;
       }
 
       container state {

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.3.3";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-09-05" {
+    description
+      "Change ipv4-unicast and ipv6-unicast to read-only.";
+    reference "0.4.0";
+  }
 
   revision "2019-08-01" {
     description
@@ -92,6 +98,7 @@ module openconfig-aft {
         forwarding entry.";
 
       container ipv4-unicast {
+        config false;
         description
           "The abstract forwarding table for IPv4 unicast. Entries
           within this table are uniquely keyed on the IPv4 unicast
@@ -106,6 +113,7 @@ module openconfig-aft {
       }
 
       container ipv6-unicast {
+        config false;
         description
           "The abstract forwarding table for IPv6 unicast. Entries
           within this table are uniquely keyed on the IPv6 unicast


### PR DESCRIPTION
Modify ipv4-unicast, ipv6-unicast, next-hop-groups and next-hops to
read-only and remove the config from the above containers. The key of
the list then points to the state instead of config.