### PR TITLE
Update openconfig-qos-interfaces.yang.

### DIFF
--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -235,6 +235,25 @@ submodule openconfig-qos-interfaces {
         the system.";
     }
   }
+  
+  typedef packet-type {
+    description
+      "This type defines type of packets that flow through a queue within an interface.";
+    type enumeration {
+      enum UC {
+        description
+          "This enum describes unicast packet type.";
+      }
+      enum MC {
+        description
+          "This enum describes multicast packet type.";
+      }
+      enum MIXEDUCMC {
+        description
+          "This enum describes either unicast or multicast packet type.";
+      }
+    }
+  }
 
   grouping qos-interface-queue-state {
     description
@@ -272,6 +291,18 @@ submodule openconfig-qos-interfaces {
       type oc-yang:counter64;
       description
         "Number of packets dropped by the queue due to overrun";
+    }
+    
+    leaf dropped-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets dropped by the queue due to overrun.";
+    }
+    
+    leaf queue-type {
+      type packet-type;
+      description
+        "Indicates the type of packets that are currently flowing through the queue.";
     }
   }
 


### PR DESCRIPTION
Augment 2 leafs  dropped-octets count  and queue-type.
1. dropped-octets  indicates counts of octets dropped by interface queue due to overrun.
2. queue-type will indicate type of packets flowing through interface queue.