### PR TITLE
Common OSPF modules

### DIFF
--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -22,7 +22,7 @@ module openconfig-network-instance {
   import openconfig-bgp { prefix "oc-bgp"; }
   import openconfig-mpls { prefix "oc-mpls"; }
   import openconfig-vlan { prefix "oc-vlan"; }
-  import openconfig-ospfv2 { prefix "oc-ospfv2"; }
+  import openconfig-ospf { prefix "oc-ospf"; }
   import openconfig-policy-forwarding { prefix "oc-pf"; }
   import openconfig-segment-routing { prefix "oc-sr"; }
   import openconfig-isis { prefix "oc-isis"; }
@@ -47,7 +47,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "0.13.0";
+  oc-ext:openconfig-version "0.13.1";
+
+  revision "2019-11-15" {
+    description
+      "Uses OSPF common model.";
+    reference "0.13.1";
+  }
+
 
   revision "2019-05-14" {
     description
@@ -721,7 +728,7 @@ module openconfig-network-instance {
                 Border Gateway Protocol (BGP)";
             }
 
-            uses oc-ospfv2:ospfv2-top {
+            uses oc-ospf:ospf-top {
               when "config/identifier = 'OSPF'" {
                 description
                   "Include OSPFv2 parameters only when the protocol

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -728,7 +728,7 @@ module openconfig-network-instance {
                 Border Gateway Protocol (BGP)";
             }
 
-            uses oc-ospf:ospf-top {
+            uses oc-ospf:ospfv2-top {
               when "config/identifier = 'OSPF'" {
                 description
                   "Include OSPFv2 parameters only when the protocol

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -1,0 +1,414 @@
+submodule openconfig-ospf-area-interface {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+
+  // include common submodule
+  include openconfig-ospf-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPF configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Change ospfv2 to ospf";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospf-area-interface-config {
+    description
+      "Configuration parameters for an OSPF interface";
+
+    leaf id {
+      type string;
+      description
+        "An operator-specified string utilised to uniquely
+        reference this interface";
+    }
+
+    leaf network-type {
+      type identityref {
+        base "oc-ospf-types:OSPF_NETWORK_TYPE";
+      }
+      description
+        "The type of network that OSPF should use for the specified
+        interface.";
+    }
+
+    leaf priority {
+      type uint8;
+      description
+        "The local system's priority to become the designated
+        router";
+    }
+
+    leaf multi-area-adjacency-primary {
+      type boolean;
+      default true;
+      description
+        "When the specified interface is included in more than one
+        area's configuration, this leaf marks whether the area should
+        be considered the primary (when the value is true). In the
+        case that this value is false, the area is considered a
+        secondary area.";
+    }
+
+    leaf authentication-type {
+      type string;
+      // rjs TODO: discuss with bogdanov@ what the approach for auth
+      // links should be.
+      description
+        "The type of authentication that should be used on this
+        interface";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric for the interface";
+    }
+
+    leaf passive {
+      type boolean;
+      description
+        "When this leaf is set to true, the interface should be
+        advertised within the OSPF area but OSPF adjacencies should
+        not be established over the interface";
+    }
+
+    leaf hide-network {
+      type boolean;
+      description
+        "When this leaf is set to true, the network connected to
+        the interface should be hidden from OSPF advertisements
+        per the procedure described in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSFF";
+    }
+
+  }
+
+  grouping ospf-area-interface-timers-config {
+    description
+      "Configuration parameters relating to per-interface OSPF
+      timers";
+
+    leaf dead-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds that the local system should let
+        elapse before declaring a silent router down";
+      reference "RFC2328";
+    }
+
+    leaf hello-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds the local system waits between the
+        transmission of subsequent Hello packets";
+    }
+
+    leaf retransmission-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds that the local system waits before
+        retransmitting an unacknowledged LSA.";
+    }
+
+  }
+
+  grouping ospf-area-interface-neighbor-config {
+    description
+      "Configuration parameters relating to an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "The router ID of the remote system.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric that should be considered to the remote neighbor
+        over this interface. This configuration is only applicable
+        for multiple-access networks";
+    }
+  }
+
+  grouping ospf-area-interface-neighbor-state {
+    description
+      "Operational state parameters relating an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf priority {
+      type uint8;
+      description
+        "The remote system's priority to become the designated
+        router";
+    }
+
+    leaf dead-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which this neighbor's adjacency will be
+        considered dead. The value is expressed relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf designated-router {
+      type yang:dotted-quad;
+      description
+        "The designated router for the adjacency. This device
+        advertises the Network LSA for broadcast and NBMA networks.";
+    }
+
+    leaf backup-designated-router {
+      type yang:dotted-quad;
+      description
+        "The backup designated router for the adjacency.";
+    }
+
+    leaf optional-capabilities {
+      // rjs TODO: should this be anything more than the hex-string
+      // this is currently what is shown in IOS/JUNOS
+      type yang:hex-string;
+      description
+        "The optional capabilities field received in the Hello
+        message from the neighbor";
+    }
+
+    leaf last-established-time {
+      type oc-types:timeticks64;
+      // rjs TODO: check implementations - is FULL considered 'up'
+      // since the adjacency is probably up since ExStart
+      description
+        "The time at which the adjacency was last established with
+        the neighbor. That is to say the time at which the
+        adjacency last transitioned into the FULL state. The
+        value is expressed relative to the Unix Epoch (Jan 1 1970
+        00:00:00 UTC).";
+    }
+
+    leaf adjacency-state {
+      type identityref {
+        base "oc-ospf-types:OSPF_NEIGHBOR_STATE";
+      }
+      description
+        "The state of the adjacency with the neighbor.";
+    }
+
+    leaf state-changes {
+      type uint32;
+      description
+        "The number of transitions out of the FULL state that this
+        neighbor has been through";
+    }
+
+    leaf retranmission-queue-length {
+      type uint32;
+      description
+        "The number of LSAs that are currently in the queue to be
+        retransmitted to the neighbor";
+    }
+  }
+
+  grouping ospf-area-interface-lsa-filter-config {
+    description
+      "Configuration options relating to filtering LSAs
+      on an interface.";
+
+    leaf all {
+      type boolean;
+      description
+        "When this leaf is set to true, all LSAs should be
+        filtered to the neighbours with whom adjacencies are
+        formed on the interface.";
+    }
+
+    // NB: this container can be augmented to add additional
+    // filtering options which exist in some implementations.
+  }
+
+  grouping ospf-area-interfaces-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an interface";
+
+    container interfaces {
+      description
+        "Enclosing container for a list of interfaces enabled within
+        this area";
+
+      list interface {
+        key "id";
+
+        description
+          "List of interfaces which are enabled within this area";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "A pointer to the identifier for the interface.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the interface on which
+            OSPF is enabled";
+
+          uses ospf-area-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the interface on which
+            OSPF is enabled";
+          uses ospf-area-interface-config;
+        }
+
+        uses oc-if:interface-ref;
+
+        container timers {
+          description
+            "Timers relating to OSPF on the interface";
+
+          container config {
+            description
+              "Configuration parameters for OSPF timers on the
+              interface";
+            uses ospf-area-interface-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for OSPF timers on
+              the interface";
+
+            uses ospf-area-interface-timers-config;
+          }
+        }
+
+        container lsa-filter {
+          description
+            "OSPFv2 parameters relating to filtering of LSAs to
+            neighbors the specified interface.";
+
+          container config {
+            description
+              "Configuration parameters relating to filtering LSAs
+              on the specified interface.";
+            uses ospf-area-interface-lsa-filter-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to filtering
+              LSAs on the specified interface";
+            uses ospf-area-interface-lsa-filter-config;
+          }
+        }
+
+        container neighbors {
+          description
+            "Enclosing container for the list of neighbors that
+            an adjacency has been established with on the interface";
+
+          list neighbor {
+            key "router-id";
+
+            description
+              "A neighbor with which an OSPFv2 adjacency has been
+              established within this area";
+
+            leaf router-id {
+              type leafref {
+                path "../config/router-id";
+              }
+              description
+                "Reference to the router ID of the adjacent system";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the adjacent
+                system";
+              uses ospf-area-interface-neighbor-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the adjacent
+                system";
+              uses ospf-area-interface-neighbor-config;
+              uses ospf-area-interface-neighbor-state;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -1,0 +1,151 @@
+submodule openconfig-ospf-area {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import ietf-inet-types { prefix "inet"; }
+
+  // include other required submodules
+  include openconfig-ospf-area-interface;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Change ospfv2 to ospf"; 
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospf-area-config {
+    description
+      "Configuration parameters relating to an OSPF area";
+
+    leaf identifier {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "An identifier for the OSPFv2 area - described as either a
+        32-bit unsigned integer, or a dotted-quad";
+    }
+  }
+
+  grouping ospf-area-virtual-link-config {
+    description
+      "Configuration parameters relating to a virtual-link within
+      the OSPF area";
+
+    leaf remote-router-id {
+      type inet:ipv4-address-no-zone;
+      description
+        "The router ID of the device which terminates the remote end
+        of the virtual link";
+    }
+  }
+
+  grouping ospf-area-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an individual area";
+
+    container config {
+      description
+        "Configuration parameters relating to an OSPFv2 area";
+
+      uses ospf-area-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to an OSPFv2 area";
+      uses ospf-area-config;
+    }
+
+    uses ospf-area-interfaces-structure;
+
+    container virtual-links {
+      description
+        "Configuration and state parameters relating to virtual
+        links from the source area to a remote router";
+
+      list virtual-link {
+        key "remote-router-id";
+
+        description
+          "Configuration and state parameters relating to a
+          virtual link";
+
+        leaf remote-router-id {
+          type leafref {
+            path "../config/remote-router-id";
+          }
+          description
+            "Reference to the remote router ID";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF virtual link";
+          uses ospf-area-virtual-link-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to the OSPF virtual link";
+          uses ospf-area-virtual-link-config;
+          uses ospf-area-interface-neighbor-state;
+        }
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -1,7 +1,7 @@
-submodule openconfig-ospfv2-common {
+submodule openconfig-ospf-common {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
   import openconfig-extensions { prefix "oc-ext"; }
@@ -17,7 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Change ospfv2 to ospf";
+    reference "0.2.1";
+  }
 
   revision "2019-07-09" {
     description
@@ -55,30 +61,7 @@ submodule openconfig-ospfv2-common {
     reference "0.0.1";
   }
 
-  grouping ospfv2-common-mpls-igp-ldp-sync-config {
-    description
-      "Configuration parameters used for OSPFv2 MPLS/IGP
-      synchronization";
-
-    leaf enabled {
-      type boolean;
-      description
-        "When this leaf is set to true, do not utilise this link for
-        forwarding via the IGP until such time as LDP adjacencies to
-        the neighbor(s) over the link are established.";
-    }
-
-    leaf post-session-up-delay {
-      type uint32;
-      units milliseconds;
-      description
-        "This leaf specifies a delay, expressed in units of milliseconds,
-        between the LDP session to the IGP neighbor being established, and
-        it being considered synchronized by the IGP.";
-    }
-  }
-
-  grouping ospfv2-common-timers {
+  grouping ospf-common-timers {
     description
       "Common definition of the type of timers that the OSPFv2 implementation
       uses";
@@ -100,4 +83,5 @@ submodule openconfig-ospfv2-common {
         "The timer mode that is utilised by the implementation.";
     }
   }
+
 }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -1,0 +1,444 @@
+submodule openconfig-ospf-global {
+
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-ospf-types { prefix "oc-ospft"; }
+
+  // Include common submodule
+  include openconfig-ospf-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPF configuration and operational
+    state parameters that are global to a particular OSPF instance";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Change ospfv2 to ospf";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospf-global-config {
+    description
+      "Global configuration for OSPF";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "A 32-bit number represented as a dotted quad assigned to
+        each router running the OSPF protocol. This number should
+        be unique within the autonomous system";
+      reference "rfc2828";
+    }
+
+    leaf log-adjacency-changes {
+      type boolean;
+      description
+        "When this leaf is set to true, a log message will be
+        generated when the state of an OSPF neighbour changes.";
+    }
+
+    leaf hide-transit-only-networks {
+      type boolean;
+      description
+        "When this leaf is set to true, do not advertise prefixes
+        into OSPF that correspond to transit interfaces, as per
+        the behaviour discussed in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSPF";
+    }
+
+  }
+
+  grouping ospf-global-spf-timers-config {
+    description
+      "Configuration parameters relating to global SPF timer
+      parameters for OSPF";
+
+    leaf initial-delay {
+      // rjs TODO: IS-IS model has this as decimal64 - should it be
+      // that or uint32 msec?
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between a change
+        in topology being detected and the first run of the SPF
+        algorithm.";
+    }
+
+    leaf maximum-delay {
+      // rjs TODO: same question as above
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum delay between
+        a topology change being detected and the SPF algorithm
+        running. This value is used for implementations that support
+        increasing the wait time between SPF runs.";
+    }
+
+    // rjs TODO: some questions here around what we should specify:
+    // JUNOS has rapid-runs and holddown
+    // Cisco has maximum time between runs, and then a doubling of
+    // the wait interval up to that maximum.
+    // ALU has first-wait, second-wait, max-wait
+  }
+
+  grouping ospf-global-lsa-generation-timers-config {
+    description
+      "Configuration parameters relating to global LSA generation
+      parameters for OSPF";
+
+    leaf initial-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between the first
+        time an LSA is generated and advertised and the subsequent
+        generation of that LSA.";
+    }
+
+    leaf maximum-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum time between the
+        generation of an LSA and the subsequent re-generation of that
+        LSA. This value is used in implementations that support
+        increasing delay between generation of an LSA";
+    }
+  }
+
+  grouping ospf-global-spf-timers-state {
+    description
+      "Operational state parameters relating to OSPF global
+      timers";
+
+    uses ospf-common-timers;
+  }
+
+  grouping ospf-global-lsa-generation-timers-state {
+    description
+      "Operational state parameters relating to OSPF global
+      timers";
+
+    uses ospf-common-timers;
+  }
+
+  grouping ospf-global-graceful-restart-config {
+    description
+      "Configuration parameters relating to graceful restart for
+      OSPF";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When the value of this leaf is set to true, graceful restart
+        is enabled on the local system. In this case, the system will
+        use Grace-LSAs to signal that it is restarting to its
+        neighbors.";
+    }
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Operate graceful-restart only in helper mode. When this leaf
+        is set to true, the local system does not use Grace-LSAs to
+        indicate that it is restarting, but will accept Grace-LSAs
+        from remote systems, and suppress withdrawl of adjacencies
+        of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-inter-areapp-config {
+    description
+      "Configuration parameters for OSPF policies which propagate
+      prefixes between areas";
+
+    leaf src-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The area from which prefixes are to be exported.";
+    }
+
+    leaf dst-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The destination area to which prefixes are to be imported";
+    }
+
+    uses oc-rpol:apply-policy-import-config;
+  }
+
+  grouping ospf-global-max-metric-config {
+    description
+      "Configuration paramters relating to setting the OSPF
+      maximum metric.";
+
+    leaf set {
+      type boolean;
+      description
+        "When this leaf is set to true, all non-stub interfaces of
+        the local system are advertised with the maximum metric,
+        such that the router does not act as a transit system,
+        (similarly to the IS-IS overload functionality).";
+      reference
+        "RFC3137 - OSPF Stub Router Advertisement";
+    }
+
+    leaf timeout {
+      type uint64;
+      units "seconds";
+      description
+        "The delay, in seconds, after which the advertisement of
+        entities with the maximum metric should be cleared, and
+        the system reverts to the default, or configured, metrics.";
+    }
+
+    leaf-list include {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_INCLUDE";
+      }
+      description
+        "By default, the maximum metric is advertised for all
+        non-stub interfaces of a device. When identities are
+        specified within this leaf-list, additional entities
+        are also advertised with the maximum metric according
+        to the values within the list.";
+    }
+
+    leaf-list trigger {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_TRIGGER";
+      }
+      description
+        "By default, the maximum metric is only advertised
+        when the max-metric/set leaf is specified as true.
+        In the case that identities are specified within this
+        list, they provide additional triggers (e.g., system
+        boot) that may cause the max-metric to be set. In this
+        case, the system should still honour the timeout specified
+        by the max-metric/timeout leaf, and clear the max-metric
+        advertisements after the expiration of this timer.";
+    }
+  }
+
+  grouping ospf-global-structural {
+    description
+      "Top level structural grouping for OSPF global parameters";
+
+    container global {
+      description
+        "Configuration and operational state parameters for settings
+        that are global to the OSPF instance";
+
+      container config {
+        description
+          "Global configuration parameters for OSPF";
+        uses ospf-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for OSPF";
+        uses ospf-global-config;
+      }
+
+      container timers {
+        description
+          "Configuration and operational state parameters for OSPF
+          timers";
+
+        container spf {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the operation of SPF runs";
+
+          container config {
+            description
+              "Configuration parameters relating to global OSPF
+              SPF timers";
+            uses ospf-global-spf-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the global
+              OSPF SPF timers";
+            uses ospf-global-spf-timers-config;
+            uses ospf-global-spf-timers-state;
+          }
+        }
+
+        container max-metric {
+          description
+            "Configuration and operational state parameters relating
+            to setting the OSPF maximum metric.";
+
+          container config {
+            description
+              "Configuration parameters relating to setting the OSPF
+              maximum metric for a set of advertised entities.";
+            uses ospf-global-max-metric-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to setting the
+              OSPF maximum metric for a set of advertised entities.";
+            uses ospf-global-max-metric-config;
+          }
+        }
+
+        container lsa-generation {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the generation of LSAs by the local
+            system";
+
+          container config {
+            description
+              "Configuration parameters relating to the generation of
+              LSAs by the local system";
+            uses ospf-global-lsa-generation-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the generation
+              of LSAs by the local system";
+            uses ospf-global-lsa-generation-timers-config;
+            uses ospf-global-lsa-generation-timers-state;
+          }
+        }
+      }
+
+      container graceful-restart {
+        description
+          "Configuration and operational state parameters for OSPF
+          graceful restart";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPF graceful
+            restart";
+          uses ospf-global-graceful-restart-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPF graceful
+            restart";
+          uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container inter-area-propagation-policies {
+        description
+          "Policies defining how inter-area propagation should be performed
+          by the OSPF instance";
+
+        list inter-area-propagation-policy {
+          key "src-area dst-area";
+          description
+            "A list of connections between pairs of areas - routes are
+            propagated from the source (src) area to the destination (dst)
+            area according to the policy specified";
+
+          leaf src-area {
+            type leafref {
+              path "../config/src-area";
+            }
+            description
+              "Reference to the source area";
+          }
+
+          leaf dst-area {
+            type leafref {
+              path "../config/dst-area";
+            }
+            description
+              "Reference to the destination area";
+          }
+
+          container config {
+            description
+              "Configuration parameters relating to the inter-area
+              propagation policy";
+            uses ospf-global-inter-areapp-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the inter-area
+              propagation policy";
+            uses ospf-global-inter-areapp-config;
+          }
+        }
+      }
+    }
+  }
+}

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -81,7 +81,7 @@ module openconfig-ospf {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  grouping ospf-top {
+  grouping ospfv2-top {
     description
       "Top-level OSPF configuration and operational state for
        both OSPFv2 and OSPFv3";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -1,11 +1,11 @@
-module openconfig-ospfv2 {
+module openconfig-ospf {
 
   yang-version "1";
 
   // namespace
-  namespace "http://openconfig.net/yang/ospfv2";
+  namespace "http://openconfig.net/yang/ospf";
 
-  prefix "oc-ospfv2";
+  prefix "oc-ospf";
 
   // import some basic types
   //import ietf-inet-types { prefix inet; }
@@ -13,15 +13,13 @@ module openconfig-ospfv2 {
 
   // Include submodules
   // Global:  All global context groupings;
-  include openconfig-ospfv2-global;
+  include openconfig-ospf-global;
   // Area:    Config/opstate for an area
-  include openconfig-ospfv2-area;
+  include openconfig-ospf-area;
   // Area Interface:  Config/opstate for an Interface
-  include openconfig-ospfv2-area-interface;
-  // LSDB: Operational state model covering the LSDB
-  include openconfig-ospfv2-lsdb;
+  include openconfig-ospf-area-interface;
   // Common:  Content included in >1 context
-  include openconfig-ospfv2-common;
+  include openconfig-ospf-common;
 
   // meta
   organization "OpenConfig working group";
@@ -34,7 +32,13 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Change ospfv2 to ospf";
+    reference "0.2.1";
+  }
 
   revision "2019-07-09" {
     description
@@ -77,16 +81,17 @@ module openconfig-ospfv2 {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  grouping ospfv2-top {
+  grouping ospf-top {
     description
-      "Top-level OSPF configuration and operational state";
+      "Top-level OSPF configuration and operational state for
+       both OSPFv2 and OSPFv3";
 
     container ospfv2 {
       description
         "Top-level configuration and operational state for
         Open Shortest Path First (OSPF) v2";
 
-      uses ospfv2-global-structural;
+      uses ospf-global-structural;
 
       container areas {
         description
@@ -107,9 +112,10 @@ module openconfig-ospfv2 {
               "A reference to the identifier for the area.";
           }
 
-          uses ospfv2-area-structure;
+          uses ospf-area-structure;
         }
       }
     }
   }
+
 }

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -1,17 +1,15 @@
 submodule openconfig-ospfv2-area-interface {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
-  import ietf-yang-types { prefix "yang"; }
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-types { prefix "oc-types"; }
-  import openconfig-interfaces { prefix "oc-if"; }
-  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   // include common submodule
-  include openconfig-ospfv2-common;
+  include openconfig-ospf-common;
+  include openconfig-ospfv2-global;
 
   // meta
   organization "OpenConfig working group";
@@ -24,150 +22,18 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.0.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-16" {
     description
       "Initial revision";
     reference "0.0.1";
   }
 
-  grouping ospfv2-area-interface-config {
-    description
-      "Configuration parameters for an OSPF interface";
-
-    leaf id {
-      type string;
-      description
-        "An operator-specified string utilised to uniquely
-        reference this interface";
-    }
-
-    leaf network-type {
-      type identityref {
-        base "oc-ospf-types:OSPF_NETWORK_TYPE";
-      }
-      description
-        "The type of network that OSPFv2 should use for the specified
-        interface.";
-    }
-
-    leaf priority {
-      type uint8;
-      description
-        "The local system's priority to become the designated
-        router";
-    }
-
-    leaf multi-area-adjacency-primary {
-      type boolean;
-      default true;
-      description
-        "When the specified interface is included in more than one
-        area's configuration, this leaf marks whether the area should
-        be considered the primary (when the value is true). In the
-        case that this value is false, the area is considered a
-        secondary area.";
-    }
-
-    leaf authentication-type {
-      type string;
-      // rjs TODO: discuss with bogdanov@ what the approach for auth
-      // links should be.
-      description
-        "The type of authentication that should be used on this
-        interface";
-    }
-
-    leaf metric {
-      type oc-ospf-types:ospf-metric;
-      description
-        "The metric for the interface";
-    }
-
-    leaf passive {
-      type boolean;
-      description
-        "When this leaf is set to true, the interface should be
-        advertised within the OSPF area but OSPF adjacencies should
-        not be established over the interface";
-    }
-
-    leaf hide-network {
-      type boolean;
-      description
-        "When this leaf is set to true, the network connected to
-        the interface should be hidden from OSPFv2 advertisements
-        per the procedure described in RFC6860.";
-      reference
-        "RFC6860 - Hiding Transit-Only Networks in OSFF";
-    }
-  }
-
-  grouping ospfv2-area-interface-timers-config {
-    description
-      "Configuration parameters relating to per-interface OSPFv2
-      timers";
-
-    leaf dead-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds that the local system should let
-        elapse before declaring a silent router down";
-      reference "RFC2328";
-    }
-
-    leaf hello-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds the local system waits between the
-        transmission of subsequent Hello packets";
-    }
-
-    leaf retransmission-interval {
-      type uint32;
-      units seconds;
-      description
-        "The number of seconds that the local system waits before
-        retransmitting an unacknowledged LSA.";
-    }
-  }
 
   grouping ospfv2-area-interface-mpls-config {
     description
-      "Configuration parameters relating to MPLS extensions for OSPF";
+      "Configuration parameters relating to MPLS extensions for OSPFv2";
 
     leaf traffic-engineering-metric {
       type uint32;
@@ -176,120 +42,6 @@ submodule openconfig-ospfv2-area-interface {
         engineering purposes.";
       reference "RFC3630, §2.5.5";
     }
-  }
-
-  grouping ospfv2-area-interface-neighbor-config {
-    description
-      "Configuration parameters relating to an individual neighbor
-      system on an interface within an OSPF area";
-
-    leaf router-id {
-      type yang:dotted-quad;
-      description
-        "The router ID of the remote system.";
-    }
-
-    leaf metric {
-      type oc-ospf-types:ospf-metric;
-      description
-        "The metric that should be considered to the remote neighbor
-        over this interface. This configuration is only applicable
-        for multiple-access networks";
-    }
-  }
-
-  grouping ospfv2-area-interface-neighbor-state {
-    description
-      "Operational state parameters relating an individual neighbor
-      system on an interface within an OSPF area";
-
-    leaf priority {
-      type uint8;
-      description
-        "The remote system's priority to become the designated
-        router";
-    }
-
-    leaf dead-time {
-      type oc-types:timeticks64;
-      description
-        "The time at which this neighbor's adjacency will be
-        considered dead. The value is expressed relative to
-        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
-    }
-
-    leaf designated-router {
-      type yang:dotted-quad;
-      description
-        "The designated router for the adjacency. This device
-        advertises the Network LSA for broadcast and NBMA networks.";
-    }
-
-    leaf backup-designated-router {
-      type yang:dotted-quad;
-      description
-        "The backup designated router for the adjacency.";
-    }
-
-    leaf optional-capabilities {
-      // rjs TODO: should this be anything more than the hex-string
-      // this is currently what is shown in IOS/JUNOS
-      type yang:hex-string;
-      description
-        "The optional capabilities field received in the Hello
-        message from the neighbor";
-    }
-
-    leaf last-established-time {
-      type oc-types:timeticks64;
-      // rjs TODO: check implementations - is FULL considered 'up'
-      // since the adjacency is probably up since ExStart
-      description
-        "The time at which the adjacency was last established with
-        the neighbor. That is to say the time at which the
-        adjacency last transitioned into the FULL state. The
-        value is expressed relative to the Unix Epoch (Jan 1 1970
-        00:00:00 UTC).";
-    }
-
-    leaf adjacency-state {
-      type identityref {
-        base "oc-ospf-types:OSPF_NEIGHBOR_STATE";
-      }
-      description
-        "The state of the adjacency with the neighbor.";
-    }
-
-    leaf state-changes {
-      type uint32;
-      description
-        "The number of transitions out of the FULL state that this
-        neighbor has been through";
-    }
-
-    leaf retranmission-queue-length {
-      type uint32;
-      description
-        "The number of LSAs that are currently in the queue to be
-        retransmitted to the neighbor";
-    }
-  }
-
-  grouping ospfv2-area-interface-lsa-filter-config {
-    description
-      "Configuration options relating to filtering LSAs
-      on an interface.";
-
-    leaf all {
-      type boolean;
-      description
-        "When this leaf is set to true, all LSAs should be
-        filtered to the neighbours with whom adjacencies are
-        formed on the interface.";
-    }
-
-    // NB: this container can be augmented to add additional
-    // filtering options which exist in some implementations.
   }
 
   grouping ospfv2-area-interface-mpls-igp-ldp-sync-state {
@@ -307,172 +59,61 @@ submodule openconfig-ospfv2-area-interface {
     }
   }
 
-  grouping ospfv2-area-interfaces-structure {
+  grouping ospfv2-mpls-interface {
     description
-      "Structural grouping for configuration and operational state
-      parameters that relate to an interface";
+      "Configuration and operational state parameters for
+       OSPFv2 extensions related to MPLS on the interface.";
 
-    container interfaces {
+    container mpls {
       description
-        "Enclosing container for a list of interfaces enabled within
-        this area";
+        "Configuration and operational state parameters for
+         OSPFv2 extensions related to MPLS on the interface.";
 
-      list interface {
-        key "id";
-
+      container config {
         description
-          "List of interfaces which are enabled within this area";
+          "Configuration parameters for OSPF extensions relating
+          to MPLS for the interface";
+        uses ospfv2-area-interface-mpls-config;
+      }
 
-        leaf id {
-          type leafref {
-            path "../config/id";
-          }
-          description
-            "A pointer to the identifier for the interface.";
-        }
+      container state {
+        config false;
+        description
+          "Operational state for OSPF extensions relating to
+          MPLS for the interface";
+        uses ospfv2-area-interface-mpls-config;
+      }
+
+      container igp-ldp-sync {
+        description
+          "OSPF parameters relating to LDP/IGP synchronization";
 
         container config {
           description
-            "Configuration parameters for the interface on which
-            OSPFv2 is enabled";
-
-          uses ospfv2-area-interface-config;
+            "Configuration parameters relating to LDP/IG
+            synchronization.";
+          uses ospfv2-common-mpls-igp-ldp-sync-config;
         }
 
         container state {
           config false;
           description
-            "Operational state parameters for the interface on which
-            OSPFv2 is enabled";
-          uses ospfv2-area-interface-config;
+            "Operational state variables relating to LDP/IGP
+            synchronization";
+          uses ospfv2-common-mpls-igp-ldp-sync-config;
+          uses ospfv2-area-interface-mpls-igp-ldp-sync-state;
         }
-
-        uses oc-if:interface-ref;
-
-        container timers {
-          description
-            "Timers relating to OSPFv2 on the interface";
-
-          container config {
-            description
-              "Configuration parameters for OSPFv2 timers on the
-              interface";
-            uses ospfv2-area-interface-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters for OSPFv2 timers on
-              the interface";
-
-            uses ospfv2-area-interface-timers-config;
-          }
-        }
-
-        container mpls {
-          description
-            "Configuration and operational state parameters for
-            OSPFv2 extensions related to MPLS on the interface.";
-
-          container config {
-            description
-              "Configuration parameters for OSPFv2 extensions relating
-              to MPLS for the interface";
-            uses ospfv2-area-interface-mpls-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state for OSPFv2 extensions relating to
-              MPLS for the interface";
-            uses ospfv2-area-interface-mpls-config;
-          }
-
-          container igp-ldp-sync {
-            description
-              "OSPFv2 parameters relating to LDP/IGP synchronization";
-
-            container config {
-              description
-                "Configuration parameters relating to LDP/IG
-                synchronization.";
-              uses ospfv2-common-mpls-igp-ldp-sync-config;
-            }
-
-            container state {
-              config false;
-              description
-                "Operational state variables relating to LDP/IGP
-                synchronization";
-              uses ospfv2-common-mpls-igp-ldp-sync-config;
-              uses ospfv2-area-interface-mpls-igp-ldp-sync-state;
-            }
-          }
-        }
-
-        container lsa-filter {
-          description
-            "OSPFv2 parameters relating to filtering of LSAs to
-            neighbors the specified interface.";
-
-          container config {
-            description
-              "Configuration parameters relating to filtering LSAs
-              on the specified interface.";
-            uses ospfv2-area-interface-lsa-filter-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to filtering
-              LSAs on the specified interface";
-            uses ospfv2-area-interface-lsa-filter-config;
-          }
-        }
-
-        container neighbors {
-          description
-            "Enclosing container for the list of neighbors that
-            an adjacency has been established with on the interface";
-
-          list neighbor {
-            key "router-id";
-
-            description
-              "A neighbor with which an OSPFv2 adjacency has been
-              established within this area";
-
-            leaf router-id {
-              type leafref {
-                path "../config/router-id";
-              }
-              description
-                "Reference to the router ID of the adjacent system";
-            }
-
-            container config {
-              description
-                "Configuration parameters relating to the adjacent
-                system";
-              uses ospfv2-area-interface-neighbor-config;
-            }
-
-            container state {
-              config false;
-              description
-                "Operational state parameters relating to the adjacent
-                system";
-              uses ospfv2-area-interface-neighbor-config;
-              uses ospfv2-area-interface-neighbor-state;
-            }
-          }
-        }
-
       }
     }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:areas/oc-ni:area/" +
+          "oc-ni:interfaces/oc-ni:interface" {
+    description
+      "MPLS on OSPFv2 interface";
+    uses ospfv2-mpls-interface;
   }
 
 }

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -1,16 +1,11 @@
 submodule openconfig-ospfv2-area {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-ospf-types { prefix "oc-ospf-types"; }
-  import ietf-inet-types { prefix "inet"; }
-
-  // include other required submodules
-  include openconfig-ospfv2-area-interface;
-  include openconfig-ospfv2-lsdb;
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   // meta
   organization "OpenConfig working group";
@@ -20,60 +15,18 @@ submodule openconfig-ospfv2-area {
     www.openconfig.net";
 
   description
-    "This submodule provides OSPFv2 configuration and operational
+    "This module provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.0.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-17" {
     description
       "Initial revision";
     reference "0.0.1";
   }
 
-  grouping ospfv2-area-config {
-    description
-      "Configuration parameters relating to an OSPF area";
-
-    leaf identifier {
-      type oc-ospf-types:ospf-area-identifier;
-      description
-        "An identifier for the OSPFv2 area - described as either a
-        32-bit unsigned integer, or a dotted-quad";
-    }
-  }
-
-  grouping ospfv2-area-mpls-config {
+  grouping ospf-area-mpls-config {
     description
       "Configuration parameters relating to OSPFv2 extensions for
       MPLS";
@@ -86,37 +39,10 @@ submodule openconfig-ospfv2-area {
     }
   }
 
-  grouping ospfv2-area-virtual-link-config {
+  grouping ospfv2-mpls-area {
     description
-      "Configuration parameters relating to a virtual-link within
-      the OSPF area";
-
-    leaf remote-router-id {
-      type inet:ipv4-address-no-zone;
-      description
-        "The router ID of the device which terminates the remote end
-        of the virtual link";
-    }
-  }
-
-  grouping ospfv2-area-structure {
-    description
-      "Structural grouping for configuration and operational state
-      parameters that relate to an individual area";
-
-    container config {
-      description
-        "Configuration parameters relating to an OSPFv2 area";
-
-      uses ospfv2-area-config;
-    }
-
-    container state {
-      config false;
-      description
-        "Operational state parameters relating to an OSPFv2 area";
-      uses ospfv2-area-config;
-    }
+      "Configuration and operational state parameters for OSPFv2
+      extensions relating to MPLS";
 
     container mpls {
       description
@@ -127,7 +53,7 @@ submodule openconfig-ospfv2-area {
         description
           "Configuration parameters relating to MPLS extensions for
           OSPFv2";
-        uses ospfv2-area-mpls-config;
+        uses ospf-area-mpls-config;
       }
 
       container state {
@@ -135,47 +61,18 @@ submodule openconfig-ospfv2-area {
         description
           "Operational state parameters relating to MPLS extensions
           for OSPFv2";
-        uses ospfv2-area-mpls-config;
-      }
-    }
-
-    uses ospfv2-lsdb-structure;
-    uses ospfv2-area-interfaces-structure;
-
-    container virtual-links {
-      description
-        "Configuration and state parameters relating to virtual
-        links from the source area to a remote router";
-
-      list virtual-link {
-        key "remote-router-id";
-
-        description
-          "Configuration and state parameters relating to a
-          virtual link";
-
-        leaf remote-router-id {
-          type leafref {
-            path "../config/remote-router-id";
-          }
-          description
-            "Reference to the remote router ID";
-        }
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPF virtual link";
-          uses ospfv2-area-virtual-link-config;
-        }
-
-        container state {
-          config false;
-          description
-            "State parameters relating to the OSPF virtual link";
-          uses ospfv2-area-virtual-link-config;
-          uses ospfv2-area-interface-neighbor-state;
-        }
+        uses ospf-area-mpls-config;
       }
     }
   }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:areas/oc-ni:area" {
+    description
+      "MPLS configuration on OSPFv2 area";
+    uses ospfv2-mpls-area;
+  }
+
+
 }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -1,16 +1,12 @@
 submodule openconfig-ospfv2-global {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
-  import ietf-yang-types { prefix "yang"; }
   import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-routing-policy { prefix "oc-rpol"; }
-  import openconfig-ospf-types { prefix "oc-ospft"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
-  // Include common submodule
-  include openconfig-ospfv2-common;
 
   // meta
   organization "OpenConfig working group";
@@ -23,39 +19,9 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.0.1";
 
-  revision "2019-07-09" {
-    description
-      "Normalise all timeticks64 to be expressed in nanoseconds.";
-    reference "0.2.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.1.3";
-  }
-
-  revision "2018-06-05" {
-    description
-      "Bug fixes in when statements in lsdb";
-    reference "0.1.2";
-  }
-
-  revision "2017-08-24" {
-    description
-      "Minor formatting fixes.";
-    reference "0.1.1";
-  }
-
-  revision "2017-02-28"{
-    description
-      "Initial public release of OSPFv2";
-    reference "0.1.0";
-  }
-
-  revision "2016-06-24" {
+  revision "2019-08-16" {
     description
       "Initial revision";
     reference "0.0.1";
@@ -64,15 +30,6 @@ submodule openconfig-ospfv2-global {
   grouping ospfv2-global-config {
     description
       "Global configuration for OSPFv2";
-
-    leaf router-id {
-      type yang:dotted-quad;
-      description
-        "A 32-bit number represented as a dotted quad assigned to
-        each router running the OSPFv2 protocol. This number should
-        be unique within the autonomous system";
-      reference "rfc2828";
-    }
 
     leaf summary-route-cost-mode {
       type enumeration {
@@ -104,128 +61,60 @@ submodule openconfig-ospfv2-global {
         a remote system via any LSP to the system that is marked as
         shortcut eligible.";
     }
-
-    leaf log-adjacency-changes {
-      type boolean;
-      description
-        "When this leaf is set to true, a log message will be
-        generated when the state of an OSPFv2 neighbour changes.";
-    }
-
-    leaf hide-transit-only-networks {
-      type boolean;
-      description
-        "When this leaf is set to true, do not advertise prefixes
-        into OSPFv2 that correspond to transit interfaces, as per
-        the behaviour discussed in RFC6860.";
-      reference
-        "RFC6860 - Hiding Transit-Only Networks in OSPF";
-    }
   }
 
-  grouping ospfv2-global-spf-timers-config {
+  grouping ospfv2-common-mpls-igp-ldp-sync-config {
     description
-      "Configuration parameters relating to global SPF timer
-      parameters for OSPFv2";
-
-    leaf initial-delay {
-      // rjs TODO: IS-IS model has this as decimal64 - should it be
-      // that or uint32 msec?
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the time between a change
-        in topology being detected and the first run of the SPF
-        algorithm.";
-    }
-
-    leaf maximum-delay {
-      // rjs TODO: same question as above
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the maximum delay between
-        a topology change being detected and the SPF algorithm
-        running. This value is used for implementations that support
-        increasing the wait time between SPF runs.";
-    }
-
-    // rjs TODO: some questions here around what we should specify:
-    // JUNOS has rapid-runs and holddown
-    // Cisco has maximum time between runs, and then a doubling of
-    // the wait interval up to that maximum.
-    // ALU has first-wait, second-wait, max-wait
-  }
-
-  grouping ospfv2-global-lsa-generation-timers-config {
-    description
-      "Configuration parameters relating to global LSA generation
-      parameters for OSPFv2";
-
-    leaf initial-delay {
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the time between the first
-        time an LSA is generated and advertised and the subsequent
-        generation of that LSA.";
-    }
-
-    leaf maximum-delay {
-      type uint32;
-      units msec;
-      description
-        "The value of this leaf specifies the maximum time between the
-        generation of an LSA and the subsequent re-generation of that
-        LSA. This value is used in implementations that support
-        increasing delay between generation of an LSA";
-    }
-  }
-
-  grouping ospfv2-global-spf-timers-state {
-    description
-      "Operational state parameters relating to OSPFv2 global
-      timers";
-
-    uses ospfv2-common-timers;
-  }
-
-  grouping ospfv2-global-lsa-generation-timers-state {
-    description
-      "Operational state parameters relating to OSPFv2 global
-      timers";
-
-    uses ospfv2-common-timers;
-  }
-
-  grouping ospfv2-global-graceful-restart-config {
-    description
-      "Configuration parameters relating to graceful restart for
-      OSPFv2";
+      "Configuration parameters used for OSPFv2 MPLS/IGP
+      synchronization";
 
     leaf enabled {
       type boolean;
       description
-        "When the value of this leaf is set to true, graceful restart
-        is enabled on the local system. In this case, the system will
-        use Grace-LSAs to signal that it is restarting to its
-        neighbors.";
+        "When this leaf is set to true, do not utilise this link for
+        forwarding via the IGP until such time as LDP adjacencies to
+        the neighbor(s) over the link are established.";
     }
 
-    leaf helper-only {
-      type boolean;
+    leaf post-session-up-delay {
+      type uint32;
+      units milliseconds;
       description
-        "Operate graceful-restart only in helper mode. When this leaf
-        is set to true, the local system does not use Grace-LSAs to
-        indicate that it is restarting, but will accept Grace-LSAs
-        from remote systems, and suppress withdrawl of adjacencies
-        of the system for the grace period specified";
+        "This leaf specifies a delay, expressed in units of milliseconds,
+        between the LDP session to the IGP neighbor being established, and
+        it being considered synchronized by the IGP.";
     }
   }
 
-  grouping ospfv2-global-mpls-config {
+
+  grouping ospfv2-igp-ldp-sync {
     description
-      "Configuration parameters for OSPFv2 options which
+      "Global configuration for OSPFv2 LGP LDP sync";
+
+    container igp-ldp-sync {
+      description
+        "OSPFv2 parameters relating to LDP/IGP synchronization";
+
+      container config {
+        description
+          "Configuration parameters relating to LDP/IG
+          synchronization.";
+        uses ospfv2-common-mpls-igp-ldp-sync-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state variables relating to LDP/IGP
+          synchronization";
+        uses ospfv2-common-mpls-igp-ldp-sync-config;
+      }
+    }
+  }
+
+  grouping ospf-global-mpls-config {
+    description
+      "Configuration parameters for OSPF options which
       relate to MPLS";
 
     leaf traffic-engineering-extensions {
@@ -237,285 +126,57 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-inter-areapp-config {
+  grouping ospfv2-mpls {
     description
-      "Configuration parameters for OSPFv2 policies which propagate
-      prefixes between areas";
+      "OSPFv2 parameters relating to MPLS";
 
-    leaf src-area {
-      type leafref {
-        // we are at ospf/global/inter-area-propagation-policies/...
-        // inter-area-propagation-policy/config/src-area
-        path "../../../../../areas/area/identifier";
-      }
+    container mpls {
       description
-        "The area from which prefixes are to be exported.";
-    }
-
-    leaf dst-area {
-      type leafref {
-        // we are at ospf/global/inter-area-propagation-policies/...
-        // inter-area-propagation-policy/config/src-area
-        path "../../../../../areas/area/identifier";
-      }
-      description
-        "The destination area to which prefixes are to be imported";
-    }
-
-    uses oc-rpol:apply-policy-import-config;
-  }
-
-  grouping ospfv2-global-max-metric-config {
-    description
-      "Configuration paramters relating to setting the OSPFv2
-      maximum metric.";
-
-    leaf set {
-      type boolean;
-      description
-        "When this leaf is set to true, all non-stub interfaces of
-        the local system are advertised with the maximum metric,
-        such that the router does not act as a transit system,
-        (similarly to the IS-IS overload functionality).";
-      reference
-        "RFC3137 - OSPF Stub Router Advertisement";
-    }
-
-    leaf timeout {
-      type uint64;
-      units "seconds";
-      description
-        "The delay, in seconds, after which the advertisement of
-        entities with the maximum metric should be cleared, and
-        the system reverts to the default, or configured, metrics.";
-    }
-
-    leaf-list include {
-      type identityref {
-        base "oc-ospft:MAX_METRIC_INCLUDE";
-      }
-      description
-        "By default, the maximum metric is advertised for all
-        non-stub interfaces of a device. When identities are
-        specified within this leaf-list, additional entities
-        are also advertised with the maximum metric according
-        to the values within the list.";
-    }
-
-    leaf-list trigger {
-      type identityref {
-        base "oc-ospft:MAX_METRIC_TRIGGER";
-      }
-      description
-        "By default, the maximum metric is only advertised
-        when the max-metric/set leaf is specified as true.
-        In the case that identities are specified within this
-        list, they provide additional triggers (e.g., system
-        boot) that may cause the max-metric to be set. In this
-        case, the system should still honour the timeout specified
-        by the max-metric/timeout leaf, and clear the max-metric
-        advertisements after the expiration of this timer.";
-    }
-  }
-
-  grouping ospfv2-global-structural {
-    description
-      "Top level structural grouping for OSPFv2 global parameters";
-
-    container global {
-      description
-        "Configuration and operational state parameters for settings
-        that are global to the OSPFv2 instance";
-
+        "OSPFv2 parameters relating to MPLS";
+   
       container config {
         description
-          "Global configuration parameters for OSPFv2";
-        uses ospfv2-global-config;
+          "Configuration parameters relating to MPLS for OSPF";
+        uses ospf-global-mpls-config;
       }
-
+   
       container state {
         config false;
         description
-          "Operational state parameters for OSPFv2";
-        uses ospfv2-global-config;
+          "Operational state parameters relating to MPLS for
+          OSPF";
+        uses ospf-global-mpls-config;
       }
-
-      container timers {
-        description
-          "Configuration and operational state parameters for OSPFv2
-          timers";
-
-        container spf {
-          description
-            "Configuration and operational state parameters relating
-            to timers governing the operation of SPF runs";
-
-          container config {
-            description
-              "Configuration parameters relating to global OSPFv2
-              SPF timers";
-            uses ospfv2-global-spf-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the global
-              OSPFv2 SPF timers";
-            uses ospfv2-global-spf-timers-config;
-            uses ospfv2-global-spf-timers-state;
-          }
-        }
-
-        container max-metric {
-          description
-            "Configuration and operational state parameters relating
-            to setting the OSPFv2 maximum metric.";
-
-          container config {
-            description
-              "Configuration parameters relating to setting the OSPFv2
-              maximum metric for a set of advertised entities.";
-            uses ospfv2-global-max-metric-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to setting the
-              OSPFv2 maximum metric for a set of advertised entities.";
-            uses ospfv2-global-max-metric-config;
-          }
-        }
-
-        container lsa-generation {
-          description
-            "Configuration and operational state parameters relating
-            to timers governing the generation of LSAs by the local
-            system";
-
-          container config {
-            description
-              "Configuration parameters relating to the generation of
-              LSAs by the local system";
-            uses ospfv2-global-lsa-generation-timers-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the generation
-              of LSAs by the local system";
-            uses ospfv2-global-lsa-generation-timers-config;
-            uses ospfv2-global-lsa-generation-timers-state;
-          }
-        }
-      }
-
-      container graceful-restart {
-        description
-          "Configuration and operational state parameters for OSPFv2
-          graceful restart";
-
-        container config {
-          description
-            "Configuration parameters relating to OSPFv2 graceful
-            restart";
-          uses ospfv2-global-graceful-restart-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to OSPFv2 graceful
-            restart";
-          uses ospfv2-global-graceful-restart-config;
-        }
-      }
-
-      container mpls {
-        description
-          "OSPFv2 parameters relating to MPLS";
-
-        container config {
-          description
-            "Configuration parameters relating to MPLS for OSPFv2";
-          uses ospfv2-global-mpls-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to MPLS for
-            OSPFv2";
-          uses ospfv2-global-mpls-config;
-        }
-
-        container igp-ldp-sync {
-          description
-            "OSPFv2 parameters relating to LDP/IGP synchronization";
-
-          container config {
-            description
-              "Configuration parameters relating to LDP/IG
-              synchronization.";
-            uses ospfv2-common-mpls-igp-ldp-sync-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state variables relating to LDP/IGP
-              synchronization";
-            uses ospfv2-common-mpls-igp-ldp-sync-config;
-          }
-        }
-      }
-
-      container inter-area-propagation-policies {
-        description
-          "Policies defining how inter-area propagation should be performed
-          by the OSPF instance";
-
-        list inter-area-propagation-policy {
-          key "src-area dst-area";
-          description
-            "A list of connections between pairs of areas - routes are
-            propagated from the source (src) area to the destination (dst)
-            area according to the policy specified";
-
-          leaf src-area {
-            type leafref {
-              path "../config/src-area";
-            }
-            description
-              "Reference to the source area";
-          }
-
-          leaf dst-area {
-            type leafref {
-              path "../config/dst-area";
-            }
-            description
-              "Reference to the destination area";
-          }
-
-          container config {
-            description
-              "Configuration parameters relating to the inter-area
-              propagation policy";
-            uses ospfv2-global-inter-areapp-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state parameters relating to the inter-area
-              propagation policy";
-            uses ospfv2-global-inter-areapp-config;
-          }
-        }
-      }
+   
+      uses ospfv2-igp-ldp-sync;
     }
   }
+
+
+  // augment the groupings into ospf model
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:global/oc-ni:config" {
+    description
+      "Global configuration for OSPFv2";
+    uses ospfv2-global-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:global/oc-ni:state" {
+    description
+      "Global state for OSPFv2";
+    uses ospfv2-global-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:global" {
+    description
+      "OSPFv2 parameters relating to MPLS";
+    uses ospfv2-mpls;
+  }
+
+
 }

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -1,7 +1,7 @@
 submodule openconfig-ospfv2-lsdb {
 
-  belongs-to openconfig-ospfv2 {
-    prefix "oc-ospfv2";
+  belongs-to openconfig-ospf {
+    prefix "oc-ospf";
   }
 
   // import some basic types
@@ -10,6 +10,7 @@ submodule openconfig-ospfv2-lsdb {
   import openconfig-types { prefix "oc-types"; }
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   // meta
   organization "OpenConfig working group";
@@ -22,7 +23,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2019-11-15" {
+    description
+      "Augment ospfv2-lsdb-structure under ospf/area.";
+    reference "0.2.1";
+  }
 
   revision "2019-07-09" {
     description
@@ -2364,4 +2371,13 @@ submodule openconfig-ospfv2-lsdb {
       }
     }
   }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:protocols/oc-ni:protocol/oc-ni:ospfv2/" +
+          "oc-ni:areas/oc-ni:area" {
+    description
+      "LSDB augmentation on OSPFv2 area";
+    uses ospfv2-lsdb-structure;
+  }
 }
+


### PR DESCRIPTION
This pull request modifies the current OSPF Yang model and splits the
current model into two group of modules - the common OSPF modules that
can support both OSPFv2 and OSPFv3 as well as OSPFv2 specific modules.

Naming convention: The module/submodule with "ospf" in the name denotes
the common OSPF module while the module/submodule with "ospfv2" in the
name denotes the OSPFv2 specific module. The OSPFv2 specific submodules
augment the common OSPF module to form OSPFv2 Yang branch under network
instance.

In this activity, the OSPFv2 specific containers and/or leaves are moved
to OSPFv2 specific modules.

After pyang compiling, the Yang tree produced by the comms OSPF modules
proposed by this pull request maintains the same tree hierarchy and
container/leaf names.