### PR TITLE
Typographic error before "level-1-2"

### DIFF
--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -164,7 +164,7 @@ module openconfig-isis {
       type oc-isis-types:level-type;
       default "LEVEL_1_2";
       description
-        "ISIS level capability(level-1, level-2,vlevel-1-2).";
+        "ISIS level capability(level-1, level-2, level-1-2).";
     }
 
     leaf max-ecmp-paths {


### PR DESCRIPTION
Line 1644 has third item in the list "vlevel-1-2", without a space before it.  Seems like a typographical error.  "level-1-2" is the usual name for the type of IS-IS adjacency.