### PR TITLE
LACP fallback mode feature

### DIFF
--- a/release/models/interfaces/openconfig-if-aggregate.yang
+++ b/release/models/interfaces/openconfig-if-aggregate.yang
@@ -110,6 +110,23 @@ module openconfig-if-aggregate {
       defined and managed";
   }
 
+  typedef lacp-fallback-type {
+    type enumeration {
+      enum INDIVIDUAL {
+        description
+          "Fallback to individual ports.  All LAG members
+           will be forwarding when all the members stop
+           receiving LACP PDUs";
+      }
+      enum STATIC {
+        description
+          "Fallback to static LAG mode";
+      }
+    }
+    description
+      "Type to define the LACP fallback mode";
+  }
+
   // grouping statements
 
 
@@ -159,6 +176,62 @@ module openconfig-if-aggregate {
     }
   }
 
+  grouping aggregation-fallback-config {
+    description
+      "Configuration data for LACP fallback";
+
+    leaf mode {
+      type lacp-fallback-type;
+      description
+        "LACP fallback mode type";
+    }
+
+    leaf timeout {
+      type uint16;
+      description
+        "LACP fallback timeout";
+    }
+  }
+
+  grouping aggregation-fallback-top {
+    description
+      "Top-level data definitions for LACP fallback";
+
+    container fallback {
+      description
+        "Top-level container for LACP fallback settings";
+
+      container config {
+        description
+          "Configuration data for LACP fallback settings";
+
+        uses aggregation-fallback-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for LACP fallback";
+
+        uses aggregation-fallback-config;
+      }
+    }
+  }
+
+  grouping aggregation-lacp-top {
+    description
+      "Top-level grouping for LACP specific aggregation
+       definitions";
+
+    container lacp {
+      description
+        "Top-level container for LACP specific aggregation
+         definitions";
+
+      uses aggregation-fallback-top;
+    }
+  }
+
   grouping aggregation-logical-top {
     description "Top-level data definitions for LAGs";
 
@@ -187,6 +260,8 @@ module openconfig-if-aggregate {
         uses aggregation-logical-state;
 
       }
+
+      uses aggregation-lacp-top;
     }
   }
 


### PR DESCRIPTION
Proposal for support of LACP fallback feature

```module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-lag:aggregation
           +--rw oc-lag:lacp
              +--rw oc-lag:fallback
                 +--rw oc-lag:config
                 |  +--rw oc-lag:mode?      lacp-fallback-type
                 |  +--rw oc-lag:timeout?   uint16
                 +--ro oc-lag:state
                    +--ro oc-lag:mode?      lacp-fallback-type
                    +--ro oc-lag:timeout?   uint16
```

Various implementations:

EOS: https://www.arista.com/assets/data/pdf/user-manual/um-eos/Chapters/Port%20Channels%20and%20LACP.pdf
IOS-XR: https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5000/interfaces/61x/b-ncs5000-interfaces-configuration-guide-61x/b-ncs5000-interfaces-configuration-guide-61x_chapter_0101.html#task_844BB227554D4C42A96F1AF8D5AC477C
Junos: https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/force-up-edit-interfaces-qfx-series.html