### PR TITLE
Proposal for extensions to BGP and BGP RIB config models

### DIFF
--- a/release/models/bgp/.spec.yml
+++ b/release/models/bgp/.spec.yml
@@ -2,6 +2,12 @@
   docs:
     - yang/bgp/openconfig-bgp-types.yang
     - yang/bgp/openconfig-bgp.yang
+    - yang/bgp/openconfig-bgp-ext.yang
+    - yang/bgp/openconfig-bgp-policy-ext.yang
+    - yang/bgp/openconfig-bgp-evpn-ext.yang
   build:
     - yang/bgp/openconfig-bgp.yang
+    - yang/bgp/openconfig-bgp-ext.yang
+    - yang/bgp/openconfig-bgp-policy-ext.yang
+    - yang/bgp/openconfig-bgp-evpn-ext.yang
   run-ci: true

--- a/release/models/bgp/openconfig-bgp-evpn-ext.yang
+++ b/release/models/bgp/openconfig-bgp-evpn-ext.yang
@@ -475,7 +475,6 @@ module openconfig-bgp-evpn-ext {
           }
 
           uses oc-rib-bgp:bgp-adj-rib-attr-state;
-          uses oc-rib-bgp:bgp-adj-rib-common-attr-refs;
           uses oc-rib-bgp:bgp-common-route-annotations-state;
         }
 
@@ -528,7 +527,6 @@ module openconfig-bgp-evpn-ext {
             }
 
             uses oc-rib-bgp:bgp-loc-rib-common-keys;
-            uses oc-rib-bgp:bgp-loc-rib-common-attr-refs;
             uses oc-rib-bgp:bgp-loc-rib-attr-state;
             uses oc-rib-bgp:bgp-common-route-annotations-state;
             uses oc-rib-bgp:bgp-loc-rib-route-annotations-state;

--- a/release/models/bgp/openconfig-bgp-evpn-ext.yang
+++ b/release/models/bgp/openconfig-bgp-evpn-ext.yang
@@ -1,0 +1,749 @@
+module openconfig-bgp-evpn-ext {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/bgp-evpn/extension";
+
+  prefix "oc-bgp-evpn-ext";
+
+  import openconfig-network-instance { prefix oc-netinst; }
+  import openconfig-network-instance-types { prefix "oc-ni-types"; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-rib-bgp { prefix oc-rib-bgp; }
+  import openconfig-bgp-ext { prefix oc-bgp-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Model for managing BGP EVPN config.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2019-10-03 {
+    description
+      "Initial augment file.";
+    reference "0.1.0";
+  }
+
+  grouping bgp-evpn-ext-l2vpn-evpn-vni-common-config {
+
+    description 
+      "Grouping for data common to EVPN global and VNI configs";
+
+    leaf advertise-default-gw {
+      type boolean;
+      description
+        "If set to true, advertise default gateway";
+    }
+
+    leaf advertise-svi-ip {
+      type boolean;
+      description
+        "If set to true, advertise SVI MACIP routes";
+    }
+
+    leaf route-distinguisher {
+      type oc-ni-types:route-distinguisher;
+      description
+        "The route distinguisher that should be used for the local
+        VRF or VSI instance when it is signalled via BGP.";
+    }
+
+    leaf-list import-rts {
+      type string;
+      description 
+        "Route-targets to be imported";
+    }
+
+    leaf-list export-rts {
+      type string;
+      description 
+        "Route-targets to be exported";
+    }
+  }
+
+  grouping bgp-evpn-ext-l2vpn-evpn-vni-config {
+
+    description
+      "Configuration parameters relating to evpn";
+
+    leaf vni-number {
+      type uint32 {
+        range "1..16777215";
+      }
+      description
+        "VNI number";
+    }
+
+    uses bgp-evpn-ext-l2vpn-evpn-vni-common-config;
+
+  }
+
+  grouping bgp-evpn-ext-l2vpn-evpn-vni-state {
+
+    description 
+      "Grouping for operational state data for a VNI";
+
+    leaf type {
+      type string;
+      description 
+        "Holds info whether the VNI is L2 or L3";
+    }
+
+    leaf is-live {
+      type boolean;
+      description 
+        "true, if VNI is programmed";
+    }
+
+    leaf originator {
+      type string;
+      description 
+        "IP address of the originator";
+    }
+
+    leaf mcast-group {
+      type string;
+      description 
+        "Multicast-group";
+    }
+
+    leaf advertise-gw-mac {
+      type boolean;
+      description 
+        "true, if Gateway MAC is advertised";
+    }
+
+    leaf router-mac {
+      type string;
+      description
+        "Router MAC associated with the VNI";
+    }
+    
+  }
+
+  grouping bgp-evpn-ext-l2vpn-evpn-list {
+    
+    description
+      "List of VNIs in EVPN";
+
+    list vni {
+      key "vni-number";
+
+      description
+        "VNI configuration available for the
+        EVPN";
+
+      leaf vni-number {
+        type leafref {
+          path "../config/vni-number";
+        }
+        description
+          "VNI number";
+      }
+
+      container config {
+        
+        description 
+          "Configuration data for a VNI";
+        
+        uses bgp-evpn-ext-l2vpn-evpn-vni-config;
+
+      }
+
+      container state {
+
+        config false;
+        description 
+          "Operational state data for a VNI";
+        
+        uses bgp-evpn-ext-l2vpn-evpn-vni-config;
+        uses bgp-evpn-ext-l2vpn-evpn-vni-state;
+
+      } 
+    }//end list
+  }
+
+  grouping bgp-evpn-ext-vnis-top {
+
+    description 
+      "Top level grouping for list of VNIs";
+
+    container vnis {
+
+      description
+        "VNI configuration";
+
+      uses bgp-evpn-ext-l2vpn-evpn-list;
+
+    }
+  }
+
+  grouping bgp-evpn-ext-default-originate-config {
+
+    description 
+      "Grouping for default originate configuration";
+    
+    leaf ipv4 {
+      type boolean;
+      description 
+        "enable IPv4 default route origination";
+    }
+      
+    leaf ipv6 {
+      type boolean;
+      description 
+        "enable IPv6 default route origination";
+    }
+  }
+
+  grouping bgp-evpn-ext-default-originate-top {
+
+    description 
+      "Top level grouping for default originate";
+    
+    container default-originate {
+      
+      description 
+        "Specify whether to originate default routes";
+      
+      container config {
+
+        description 
+          "configuration data for default originate";
+        
+        uses bgp-evpn-ext-default-originate-config;
+      }
+
+      container state {
+
+        config false;
+        description 
+          "operational state data for default originate";
+
+        uses bgp-evpn-ext-default-originate-config;
+      }   
+    }
+  }
+
+  grouping bgp-evpn-ext-dup-addr-detection-config {
+    
+    description 
+      "Grouping for duplicate address detection configuration";
+    
+    leaf enabled {
+      type boolean;
+      description 
+        "Specify whether duplicate address detection is enabled";
+    }
+
+    leaf max-moves {
+      type uint32;
+      description 
+        "Specify maximum allowed moves before address declared as duplicate";
+    }
+
+    leaf time {
+      type uint32;
+      description 
+        "Dulplicate address detection time";
+    }
+
+    leaf freeze {
+      type union {
+        type uint32;
+        type string;
+      }
+      description 
+        "Duplicate address detection freeze, time (30-3600) or permanent";
+    }
+  }
+
+  grouping bgp-evpn-ext-dup-addr-detection-top {
+
+    description
+      "Top level grouping for duplicate address detection";
+
+    container dup-addr-detection {
+
+      description 
+        "Specify duplicate address detection parameters";
+
+      container config {
+
+        description
+          "Configuration data for duplicate address detection";
+
+        uses bgp-evpn-ext-dup-addr-detection-config;
+      }
+
+      container state {
+
+        config false;
+        description 
+          "Operational state data for duplicate address detection";
+
+        uses bgp-evpn-ext-dup-addr-detection-config;
+      } 
+    }
+  }
+
+  grouping bgp-evpn-ext-config {
+
+    description
+      "Grouping for configuration data for top level L2vpn evpn address-family";
+
+    leaf advertise-all-vni {
+      type boolean;
+      description 
+        "Advertise all VNIs";
+    }
+
+    leaf-list advertise-list {
+      type identityref {
+        base oc-bgp-types:AFI_SAFI_TYPE;
+      }
+      description 
+        "AFI,SAFI";
+    }
+
+    leaf autort {
+      type enumeration {
+        enum RFC8365_COMPATIBLE {
+          description 
+            "Automatic route-target deduction following RFC 8365";
+        }
+      }
+      description 
+        "Enable automatic derivation of route-target";
+    }
+
+    uses bgp-evpn-ext-l2vpn-evpn-vni-common-config;
+  }
+
+  grouping bgp-evpn-ext-top {
+
+    description
+      "Top level grouping for BGP L2vpn Evpn address-family";
+
+    container config {
+
+      description
+        "Configuration data for BGP L2vpn Evpn address-family";
+    
+      uses bgp-evpn-ext-config;
+    }
+
+    uses bgp-evpn-ext-vnis-top;
+    uses bgp-evpn-ext-default-originate-top;
+    uses bgp-evpn-ext-dup-addr-detection-top;
+
+    container state {
+      
+      config false;
+      description
+        "Operational state data BGP L2vpn Evpn address-family";
+      
+      uses bgp-evpn-ext-config;
+    }
+  }
+
+  // augment statements
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol"
+  +"/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:l2vpn-evpn" {
+
+    description 
+      "Augments BGP l2vpn evpn address-family container";
+
+    uses bgp-evpn-ext-top;
+
+  }//end augment
+
+  grouping bgp-evpn-ext-loc-rib-key-refs {
+    description
+      "Key references to support operational state structure for
+      the BGP Adj-RIB tables";
+
+    leaf route-distinguisher {
+      type leafref {
+        path "../state/route-distinguisher";
+      }
+      description
+        "Reference to the route-distinguisher list key";
+    }
+
+    leaf prefix {
+      type leafref {
+        path "../state/prefix";
+      }
+      description
+        "Reference to the prefix list key";
+    }
+
+    leaf origin {
+      type leafref {
+        path "../state/origin";
+      }
+      description
+        "Reference to the origin list key";
+    }
+
+    leaf path-id {
+      type leafref {
+        path "../state/path-id";
+      }
+      description
+        "Reference to the path-id list key";
+    }
+
+  }
+
+  grouping bgp-evpn-ext-adj-rib-key-refs {
+    description
+      "Key references to support operational state structure for
+      the BGP Adj-RIB tables";
+
+    leaf route-distinguisher {
+      type leafref {
+        path "../state/route-distinguisher";
+      }
+      description
+        "Reference to the route-distinguisher list key";
+    }
+
+    leaf prefix {
+      type leafref {
+        path "../state/prefix";
+      }
+      description
+        "Reference to the prefix list key";
+    }
+
+    leaf path-id {
+      type leafref {
+        path "../state/path-id";
+      }
+      description
+        "Reference to the path-id list key";
+    }
+
+  }
+
+
+  grouping bgp-evpn-ext-adj-rib-common {
+    description
+      "Common structural grouping for each EVPN adj-RIB table";
+
+    uses oc-rib-bgp:bgp-common-table-attrs-top;
+
+    container routes {
+      config false;
+      description
+        "Enclosing container for list of routes in the routing
+        table.";
+
+      list route {
+        key "route-distinguisher prefix path-id";
+
+        description
+          "List of routes in the table, keyed by the route
+          distinguisher and route prefix.";
+
+        uses bgp-evpn-ext-adj-rib-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP Adj-RIB entries";
+
+          leaf prefix {
+            type string;
+            description
+              "The EVPN prefix string corresponding to the route";
+          }
+
+          leaf route-distinguisher {
+            type string;
+            description
+              "Route distinguisher for the prefix";
+          }
+
+          uses oc-rib-bgp:bgp-adj-rib-attr-state;
+          uses oc-rib-bgp:bgp-adj-rib-common-attr-refs;
+          uses oc-rib-bgp:bgp-common-route-annotations-state;
+        }
+
+        uses oc-rib-bgp:bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-ext-loc-rib-top {
+    description
+      "Top-level grouping for EVPN routing tables";
+
+    container loc-rib {
+      config false;
+      description
+        "Container for the EVPN BGP LOC-RIB data";
+
+      uses oc-rib-bgp:bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route {
+          key "route-distinguisher prefix origin path-id";
+
+          description
+            "List of routes in the table, keyed by the route
+            distinguisher and route prefix.";
+
+          uses bgp-evpn-ext-loc-rib-key-refs;
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf prefix {
+              type string;
+              description
+                "The EVPN prefix string corresponding to the route";
+            }
+
+            leaf route-distinguisher {
+              type string;
+              description
+                "Route distinguisher for the prefix";
+            }
+
+            uses oc-rib-bgp:bgp-loc-rib-common-keys;
+            uses oc-rib-bgp:bgp-loc-rib-common-attr-refs;
+            uses oc-rib-bgp:bgp-loc-rib-attr-state;
+            uses oc-rib-bgp:bgp-common-route-annotations-state;
+            uses oc-rib-bgp:bgp-loc-rib-route-annotations-state;
+
+           }
+
+           uses oc-rib-bgp:bgp-unknown-attr-top;
+
+        }
+      }
+    }
+  }
+
+  grouping bgp-evpn-ext-adj-rib-top {
+    description
+      "Top-level grouping for Adj-RIB table";
+
+    container neighbors {
+      config false;
+      description
+        "Enclosing container for neighbor list";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "List of neighbors (peers) of the local BGP speaker";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for each neighbor BGP Adj-RIB";
+
+          leaf neighbor-address {
+            type oc-inet:ip-address;
+            description
+              "IP address of the BGP neighbor or peer";
+          }
+        }
+
+        container adj-rib-in-pre {
+          description
+            "Per-neighbor table containing the NLRI updates
+            received from the neighbor before any local input
+            policy rules or filters have been applied.  This can
+            be considered the 'raw' updates from the neighbor.";
+
+          uses bgp-evpn-ext-adj-rib-common;
+
+        }
+
+        container adj-rib-out-post {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor after output
+            policy rules have been applied";
+
+          uses bgp-evpn-ext-adj-rib-common;
+
+        }
+      }
+    }
+  }
+
+  grouping bgp-evpn-ext-loc-rib-attr-state {
+
+    description
+      "EVPN Specific local RIB attributes";
+
+    leaf tag {
+      type string;
+      description
+        "EVPN Route tag";
+    }
+
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol"
+  +"/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi" {
+
+    description
+      "Augments BGP rib table for L2vpn Evpn address family";
+
+    container l2vpn-evpn {
+      when "../oc-netinst:afi-safi-name = 'oc-bgp-types:L2VPN_EVPN'" {
+        description
+          "Include this container only for the L2VPN AFI, EVPN
+          SAFI.";
+      }
+      description
+        "Routing tables for the L2VPN, EVPN SAFI.";
+
+      uses bgp-evpn-ext-loc-rib-top;
+      uses bgp-evpn-ext-adj-rib-top;
+
+    }
+  }//augment
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-bgp-evpn-ext:l2vpn-evpn/oc-bgp-evpn-ext:loc-rib/oc-bgp-evpn-ext:routes/oc-bgp-evpn-ext:route {
+      description
+        "BGP local rib extensions for l2vpn evpn address family";
+      uses oc-bgp-ext:bgp-ext-attr-sets-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-bgp-evpn-ext:l2vpn-evpn/oc-bgp-evpn-ext:neighbors/oc-bgp-evpn-ext:neighbor/oc-bgp-evpn-ext:adj-rib-in-pre/oc-bgp-evpn-ext:routes/oc-bgp-evpn-ext:route {
+      description
+        "BGP rib extensions for l2vpn evpn address family specific to received routes pre-processing from neighbors";
+      uses oc-bgp-ext:bgp-ext-attr-sets-state;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-bgp-evpn-ext:l2vpn-evpn/oc-bgp-evpn-ext:neighbors/oc-bgp-evpn-ext:neighbor/oc-bgp-evpn-ext:adj-rib-out-post/oc-bgp-evpn-ext:routes/oc-bgp-evpn-ext:route {
+      description
+        "BGP rib extensions for l2vpn evpn address family specific to received routes post-processing from neighbors";
+      uses oc-bgp-ext:bgp-ext-attr-sets-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-bgp-evpn-ext:l2vpn-evpn/oc-bgp-evpn-ext:loc-rib/oc-bgp-evpn-ext:routes/oc-bgp-evpn-ext:route/oc-bgp-evpn-ext:attr-sets {
+      description
+        "BGP local rib attr-sets extensions for l2vpn evpn address family";
+      uses bgp-evpn-ext-loc-rib-attr-state;
+  }
+
+  // Temp deviation for community Open PR: Start
+  //https://github.com/openconfig/public/pull/270
+  typedef route-distinguisher {
+    type union {
+      // type 0: <2-byte administrator>:<4-byte assigned number>
+      //         <0-65535>:<0-4294967295>
+      type string {
+        pattern 
+          '^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|[0-5][0-9]{4}|[1-9][0-9]{0,3}|0):'
+          + '(429496729[0-5]|42949672[0-8][0-9]|'
+          + '4294967[0-1][0-9]{2}|429496[0-6][0-9]{3}|'
+          + '42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'
+          + '429[0-3][0-9]{6}|42[0-8][0-9]{7}|'
+          + '4[0-1][0-9]{8}|[1-9][0-9]{0,8}|0)$';
+      }
+      // type 1: <ip-address>:<2-byte assigned number>
+      //         <ipv4>:<0-65535>
+      type string {
+        pattern
+          '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+          +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):'
+          +  '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          +  '6[0-4][0-9]{3}|[0-5][0-9]{4}|[1-9][0-9]{0,3}|0)$';
+      }
+      // type 2: <4-byte as-number>:<2-byte assigned number>
+      //         <0-4294967295>:<0-65535>
+      type string {
+        pattern
+          '^(429496729[0-5]|42949672[0-8][0-9]|'
+          + '4294967[0-1][0-9]{2}|429496[0-6][0-9]{3}|'
+          + '42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'
+          + '429[0-3][0-9]{6}|42[0-8][0-9]{7}|'
+          + '4[0-1][0-9]{8}|[1-9][0-9]{0,8}|0):'
+          +  '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          +  '6[0-4][0-9]{3}|[0-5][0-9]{4}|[1-9][0-9]{0,3}|0)$';
+      }
+    }
+    description "A route distinguisher value";
+    reference "RFC4364";
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:l2vpn-evpn/oc-bgp-evpn-ext:config/oc-bgp-evpn-ext:route-distinguisher {
+    deviate replace {
+      type route-distinguisher;
+    }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:l2vpn-evpn/oc-bgp-evpn-ext:vnis/oc-bgp-evpn-ext:vni/oc-bgp-evpn-ext:config/oc-bgp-evpn-ext:route-distinguisher {
+    deviate replace {
+      type route-distinguisher;
+    }
+  }
+  // Temp deviation for community Open PR: End
+
+  /*deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:l2vpn-evpn/oc-bgp-evpn-ext:vpn-target/oc-bgp-evpn-ext:route-target {
+    deviate replace {
+      type string{
+        pattern 
+          '((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + ':(429496729[0-5]|42949672[0-8][0-9]|4294967[01][0-9]{2}|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}'
+        + '|4294[0-8][0-9]{5}|429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|[1-3][0-9]{9}|[1-9][0-9]{0,8}|0)'
+        + '|'
+        + '((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))'
+        + ':(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + '|(429496729[0-5]|42949672[0-8][0-9]|4294967[01][0-9]{2}|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}'
+        + '|4294[0-8][0-9]{5}|429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|[1-3][0-9]{9}|[1-9][0-9]{0,8}|0)'
+        + ':(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))';
+      }
+    }
+  } 
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:l2vpn-evpn/oc-bgp-evpn-ext:vnis/oc-bgp-evpn-ext:vni/oc-bgp-evpn-ext:vpn-target/oc-bgp-evpn-ext:route-target {
+    deviate replace {
+      type string{
+        pattern 
+          '((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + ':(429496729[0-5]|42949672[0-8][0-9]|4294967[01][0-9]{2}|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}'
+        + '|4294[0-8][0-9]{5}|429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|[1-3][0-9]{9}|[1-9][0-9]{0,8}|0)'
+        + '|'
+        + '((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))'
+        + ':(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + '|(429496729[0-5]|42949672[0-8][0-9]|4294967[01][0-9]{2}|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}'
+        + '|4294[0-8][0-9]{5}|429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|[1-3][0-9]{9}|[1-9][0-9]{0,8}|0)'
+        + ':(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))';
+      }
+    }
+  }*/   
+
+}//end module

--- a/release/models/bgp/openconfig-bgp-ext.yang
+++ b/release/models/bgp/openconfig-bgp-ext.yang
@@ -1,0 +1,1863 @@
+module openconfig-bgp-ext {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/bgp/extension";
+
+  prefix "oc-bgp-ext";
+
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-types { prefix oc-types; }
+  // import some basic types
+  import openconfig-network-instance { prefix oc-netinst; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-routing-policy {prefix oc-rpol; }
+  import openconfig-bgp-policy { prefix oc-bgp-pol; }
+  import openconfig-bgp { prefix oc-bgp; }
+  import openconfig-rib-bgp { prefix oc-rib-bgp; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-bfd { prefix oc-bfd; }
+  import openconfig-extensions { prefix oc-ext; }
+  import sonic-codegen { prefix sonic-codegen; } 
+
+  organization
+      "OpenConfig working group";
+
+  contact
+      "OpenConfig working group
+      www.openconfig.net";
+
+  description
+    "This module describes a YANG model for BGP protocol
+    configuration extensions.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2019-10-31" {
+    description
+      "BGP extensions.";
+    reference "0.1.0";
+  }
+
+  typedef bgp-direction {
+    type enumeration {
+      enum INBOUND {
+        description
+          "Refers to information received from the BGP peer";
+      }
+      enum OUTBOUND {
+        description
+          "Refers to information advertised to the BGP peer";
+      }
+    }
+    description
+        "Type to describe the direction";
+  }
+
+  typedef tx-add-paths-type {
+      type enumeration {
+          enum TX_ALL_PATHS {
+              description
+                  "Send multiple path advertisements for an NLRI from 
+                  the neighbor or group";
+          }
+          enum TX_BEST_PATH_PER_AS {
+              description
+                  "Send only best path per AS advertisements for an NLRI from 
+                  the neighbor or group";
+          }
+      }
+      description
+          "Type to describe the add paths advertisement method.";
+  }
+
+  typedef bgp-orf-type {
+    type enumeration {
+      enum SEND {
+          description
+              "Capability to receive the outbound route filtering from this neighbor";
+      }
+      enum RECEIVE {
+          description
+              "Capability to send the outbound route filtering to this neighbor";
+      }
+      enum BOTH {
+          description
+              "Capability to send and receive the outbound route filtering to/from this neighbor";
+      }
+    }
+    description
+        "Type to describe the BGP ORF(Outbound route filtering) capability";
+  }
+
+  typedef bgp-ext-community-type {
+      type enumeration {
+          enum STANDARD {
+              description "Send only standard communities";
+          }
+          enum EXTENDED {
+              description "Send only extended communities";
+          }
+          enum BOTH {
+              description "Send both standard and extended communities";
+          }
+          enum LARGE {
+              description "Send only large communities";
+          }
+
+          enum ALL {
+              description "Send standrd, extended and large communities";
+          }
+          enum NONE {
+              description "Do not send any community attribute";
+          }
+      }
+      description
+          "type describing variations of community attributes:
+          STANDARD: standard BGP community [rfc1997]
+          EXTENDED: extended BGP community [rfc4360]
+          BOTH: both standard and extended community
+          LARGE: large BGP community
+          ALL: standard, extended and large community";
+  }
+
+  identity MPBGP_RECEIVED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "Multi-protocol extensions to BGP";
+    reference "RFC2858";
+  }
+
+  identity ROUTE_REFRESH_RECEIVED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "The BGP route-refresh functionality";
+    reference "RFC2918";
+  }
+
+  identity ASN32_RECEIVED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "4-byte (32-bit) AS number functionality";
+    reference "RFC6793";
+  }
+
+  identity GRACEFUL_RESTART_RECEIVED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "Graceful restart functionality";
+    reference "RFC4724";
+  }
+
+  identity ADD_PATHS_RECEIVED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "BGP add-paths";
+    reference "draft-ietf-idr-add-paths";
+  }
+
+  identity MPBGP_ADVERTISED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "Multi-protocol extensions to BGP";
+    reference "RFC2858";
+  }
+
+  identity ROUTE_REFRESH_ADVERTISED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "The BGP route-refresh functionality";
+    reference "RFC2918";
+  }
+
+  identity ASN32_ADVERTISED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "4-byte (32-bit) AS number functionality";
+    reference "RFC6793";
+  }
+
+  identity GRACEFUL_RESTART_ADVERTISED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "Graceful restart functionality";
+    reference "RFC4724";
+  }
+
+  identity ADD_PATHS_ADVERTISED_ONLY {
+    base oc-bgp-types:BGP_CAPABILITY;
+    description
+      "BGP add-paths";
+    reference "draft-ietf-idr-add-paths";
+  }
+
+  grouping bgp-ext-peer-group-config {
+    description
+      "Configuration data for peer group";
+      leaf enabled {
+          type boolean;
+          default true;
+          description
+              "Whether the BGP peer group is enabled. In cases where the
+              enabled leaf is set to false, the local system should not
+              initiate connections to the peer group associated neighbors, and should not
+              respond to TCP connections attempts from the peer group associated neighbors. If
+              the state of the BGP session is ESTABLISHED at the time
+              that this leaf is set to false, the BGP session should be
+              ceased.";
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-route-reflector-config {
+    description
+      "Configuration data for router reflector global address family";
+      leaf route-reflector-cluster-id {
+          type oc-bgp-types:rr-cluster-id-type;
+          description
+              "route-reflector cluster id to use when local router is
+              configured as a route reflector.";
+      }
+
+      leaf allow-outbound-policy {
+          type boolean;
+          description
+              "This leaf indicates whether to allow the outbound policy.";
+      }
+  }
+
+  grouping bgp-ext-global-route-reflector-top{
+      description
+          "Configuration parameters determining whether the behaviour of
+          the local system when acting as a route-reflector";
+
+      container bgp-ext-route-reflector {
+          description
+              "Parameters relating to BGP route reflector";
+          container config {
+              description
+                  "Configuration options for BGP route reflector";
+              uses bgp-ext-global-afi-safi-route-reflector-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP route reflector";
+              uses bgp-ext-global-afi-safi-route-reflector-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-config{
+    description
+      "Configuration data for global address family level";
+      leaf table-map-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "A reference to a routing policy which can be used to
+              apply policy on route updates from BGP to RTM.";
+      }
+
+  }
+
+  grouping bgp-ext-global-graceful-restart-config {
+    description
+      "Configuration data for graceful restart under global level";
+      leaf preserve-fw-state {
+          type boolean;
+          description
+              "Set F-bit indication that FIB is preserved while doing Graceful Restart.";
+      }
+  }
+
+  grouping bgp-ext-global-use-multiple-paths-config {
+    description
+      "Configuration data for multiple paths under global level";
+      leaf as-set {
+          type boolean;
+          description
+              "Generate an AS_SET.";
+      }
+  }
+
+  grouping bgp-ext-global-route-selection-options-config {
+    description
+      "Configuration data for route selection options under global level";
+      leaf med-confed {
+          type boolean;
+          description
+              "Compare MED among confederation paths when set to true.";
+      }
+
+      leaf med-missing-as-worst {
+          type boolean;
+          description
+              "Treat missing MED as the least preferred one when set to true.";
+      }
+
+      leaf compare-confed-as-path {
+          type boolean;
+          description
+              "Compare path lengths including confederation sets & sequences in selecting a route";
+      }
+  }
+
+  grouping bgp-ext-global-config{
+    description
+      "Configuration data for global level";
+      leaf disable-ebgp-connected-route-check {
+          type boolean;
+          description
+              "Disable EBGP conntected route check, this helps to connect EBGP neighbors multi-hops away.";
+      }
+
+      leaf fast-external-failover {
+          type boolean;
+          default true;
+          description
+              "This causes bgp to take down ebgp peers immediately when a link flaps.";
+      }
+
+      leaf network-import-check {
+          type boolean;
+          default true;
+          description
+              "This helps to advertise a BGP route not present in the routing table.";
+      }
+
+      leaf graceful-shutdown { 
+          type boolean;
+          description
+              "This helps to reduce the amount of lost traffic when taking BGP sessions down for maintenance.";
+      }
+
+      leaf clnt-to-clnt-reflection {
+          type boolean;
+          description
+              "Enable client to client route reflection.";
+      }
+
+      leaf max-dynamic-neighbors {
+          type uint16 {
+              range 1..5000;
+          }
+          description
+              "Maximum number of BGP dynamic neighbors that can be created.";
+      }
+
+      leaf read-quanta {
+          type uint8 {
+              range 1..10;
+          }
+          description
+              "This indicates how many packets to read from peer socket per I/O cycle";
+      }
+
+      leaf write-quanta {
+          type uint8 {
+              range 1..10;
+          }
+          description
+              "This indicates how many packets to write to peer socket per run";
+      }
+
+      leaf coalesce-time {
+          type uint32;
+          description
+              "Subgroup coalesce timer value in milli-sec";
+      }
+
+      leaf route-map-process-delay {
+          type uint16 {
+              range 0..600;
+          }
+          description
+              "0 disables the timer, no route updates happen when route-maps change";
+      }
+
+      leaf deterministic-med {
+          type boolean;
+          description
+              "Pick the best-MED path among paths advertised from the neighboring AS.";
+      }
+
+      leaf hold-time {
+          type decimal64 {
+              fraction-digits 2;
+          }
+          default 180;
+          description
+              "Time interval in seconds that a BGP session will be
+              considered active in the absence of keepalive or other
+              messages from the peer.  The hold-time is typically
+              set to 3x the keepalive-interval.";
+      }
+
+      leaf keepalive-interval {
+          type decimal64 {
+              fraction-digits 2;
+          }
+          default 60;
+          description
+              "Time interval in seconds between transmission of keepalive
+              messages to the neighbor.  Typically set to 1/3 the
+              hold-time.";
+      }
+  }
+
+  grouping bgp-ext-global-route-flap-damping-top {
+    description
+      "Configuration data for route flap damping under global level";
+    container route-flap-damping {
+          description
+              "Parameters relating to BGP route flap damping";
+          container config {
+              description
+                  "Configuration options for BGP route flap damping";
+              uses bgp-ext-global-route-flap-damping-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP route flap damping";
+              uses bgp-ext-global-route-flap-damping-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-global-defaults-config {
+    description
+      "Configuration data for global defaults";
+      leaf ipv4-unicast {
+          type boolean;
+          description
+              "Activate ipv4-unicast for a peer by default";
+      }
+
+      leaf local-preference {
+          type uint32;
+          description
+              "Configure default local preference value.";
+      }
+
+      leaf show-hostname {
+          type boolean;
+          description
+              "Show hostname in BGP dumps.";
+      }
+
+      leaf shutdown {
+          type boolean;
+          description
+              "Apply administrative shutdown to newly configured peers.";
+      }
+
+      leaf subgroup-pkt-queue-max {
+          type uint8 {
+              range 20..100;
+          }
+          description
+              "Configure subgroup packet queue max.";
+      }
+  }
+  
+  grouping bgp-ext-global-defaults-top {
+    description
+      "Configuration data for global defaults";
+    container global-defaults {
+          description
+              "Parameters relating to BGP defaults";
+          container config {
+              description
+                  "Configuration options for BGP global defaults";
+              uses bgp-ext-global-defaults-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP global defaults";
+              uses bgp-ext-global-defaults-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-global-update-delay-config {
+    description
+      "Configuration data for update delay under global level";
+      leaf max-delay {
+          type uint16 {
+              range 0..3600;
+          }
+          description
+              "Maximum delay for best path calculation.";
+      }
+      leaf establish-wait {
+          type uint16 {
+              range 0..3600;
+          }
+          description
+              "Maximum delay for updates.";
+      }
+  }
+
+  grouping bgp-ext-global-update-delay-top {
+    description
+      "Configuration data for update delay under global level";
+      container update-delay {
+          description
+              "Parameters relating to force initial delay for best-path and updates.";
+          container config {
+              description
+                  "Configuration options for BGP update delay";
+              uses bgp-ext-global-update-delay-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP update delay";
+              uses bgp-ext-global-update-delay-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-global-max-med-config {
+    description
+      "Configuration data for max med under global level";
+      leaf time {
+          type uint32{
+              range 5..86400;
+          }
+          description
+              "Time (seconds) period for max-med";
+      }
+      leaf max-med-val {
+          type uint32;
+          description
+              "Max MED value to be used";
+      }
+      leaf administrative {
+          type boolean;
+          description
+              "Administratively applied, for an indefinite period.";
+      }
+      leaf admin-max-med-val {
+          type uint32;
+          description
+              "Administrative Max MED value to be used";
+      }
+  }
+
+  grouping bgp-ext-global-max-med-top {
+    description
+      "Configuration data for max med under global level";
+      container max-med {
+          description
+              "Parameters relating to advertise routes with max-med.";
+          container config {
+              description
+                  "Configuration options for BGP max med.";
+              uses bgp-ext-global-max-med-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP max med.";
+              uses bgp-ext-global-max-med-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-default-route-distance-config {
+    description
+      "Configuration data for default route distance";
+      leaf local-route-distance {
+          type uint8 {
+              range "1..255";
+          }
+          description
+              "Administrative distance for local routes.";
+      }
+  }
+
+  grouping bgp-ext-import-network-instance-config {
+    description
+      "Configuration data for import network instance";
+      leaf name {
+          type leafref {
+              path "/oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:config/oc-netinst:name";
+          }
+          description
+              "An operator-assigned unique name for the forwarding
+              instance";
+      }
+
+      leaf policy-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "A reference to a routing policy which can be used to
+              restrict the prefixes import from particular network-instance.";
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-top {
+    description
+      "Configuration data for global address family";
+      container aggregate-address-config {
+          description
+              "Parameters relating to BGP route aggregation.";
+
+          list aggregate-address {
+              key "prefix";
+              description
+                  "BGP aggregate address configurtion.";
+              
+              leaf prefix {
+                  type leafref {
+                      path "../config/prefix";
+                  }
+                  description
+                      "Reference to the aggregate prefix.";
+              }
+
+              container config {
+                  description
+                      "Configuration options for BGP route aggregation";
+                  uses bgp-ext-global-afi-safi-aggregate-address-config;
+              }
+              container state {
+                  config false;
+                  description
+                      "State information for BGP route aggregation";
+                  uses bgp-ext-global-afi-safi-aggregate-address-config;
+              }
+          }
+      }
+
+      container network-config {
+          description
+              "Parameters relating to BGP network announcement.";
+          
+          list network {
+              key "prefix";
+              description
+                  "BGP network configurtion.";
+
+              leaf prefix {
+                  type leafref {
+                      path "../config/prefix";
+                  }
+                  description
+                      "Reference to the IP network.";
+              }
+
+              container config {
+                  description
+                      "Configuration options for BGP network.";
+                  uses bgp-ext-global-afi-safi-network-config;
+              }
+              container state {
+                  config false;
+                  description
+                      "State information for BGP network.";
+                  uses bgp-ext-global-afi-safi-network-config;
+              }
+          }
+      }
+
+      container default-route-distance {
+          description
+              "Administrative distance (or preference) assigned to
+              routes received from different sources
+              (external, internal, and local).";
+
+          container config {
+              description
+                  "Configuration parameters relating to the default route
+                  distance";
+              uses oc-bgp:bgp-global-default-route-distance-config;
+              uses bgp-ext-default-route-distance-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information relating to the default route distance";
+              uses oc-bgp:bgp-global-default-route-distance-config;
+              uses bgp-ext-default-route-distance-config;
+          }
+      }
+
+      container import-network-instance {
+          description
+              "Import routes to this address-family from network-instance.";
+
+          container config {
+              description
+                  "Configuration parameters relating to route importing from network instance.";
+              uses bgp-ext-import-network-instance-config;
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to route importing from network instance";
+              uses bgp-ext-import-network-instance-config;
+          }
+      }
+  }
+
+  grouping bgp-ext-auth-password-config {
+    description
+      "Configuration data for authentication password";
+      leaf password {
+          type oc-types:routing-password;
+          description
+              "Authentication password for the neighbor group, 
+              this will be changed to encrypted text internally 
+              when the encrypted flag is configured with false.";
+      }
+
+      leaf encrypted {
+          type boolean;
+          default "false";
+          description
+              "This leaf indicates whether the password is encrypted text, 
+              the value of this will be changed to true internally when the password
+              is configured with encrypted false.";
+      }
+  }
+
+  grouping bgp-ext-neighbor-group-auth-password-top {
+      description
+          "Configuration parameters related to authentication password for neighbor group.";
+
+      container auth-password {
+          description
+              "Parameters relating to BGP authentication password";
+          container config {
+              description
+                  "Configuration information for BGP neighbor group authentication.";
+              uses bgp-ext-auth-password-config;
+          }
+          container state {
+              config false;
+              description
+                  "State information for BGP neighbor group authentication.";
+              uses bgp-ext-auth-password-config;
+          }
+      }
+  }
+
+
+  grouping bgp-ext-neighbor-group-config{
+    description
+      "Configuration data for neighbor group authentication password";
+      leaf disable-ebgp-connected-route-check {
+          type boolean;
+          description
+              "Disable EBGP conntected route check, this helps to connect EBGP neighbors multi-hops away.";
+      }
+
+      leaf enforce-first-as {
+          type boolean;
+          description
+              "Enforces the EBGP peer AS as the first AS PATH segment in the AS_PATH attribute.";
+      }
+
+      leaf solo-peer {
+          type boolean;
+          description
+              "This indicates that routes advertised by the peer should not be reflected back to the peer.";
+      }
+  
+      leaf ttl-security-hops {
+          type uint8 {
+              range 1..254;
+          }
+          description
+              "This enforces only the neighbors that are specified number of hops away will be allowed to become neighbors.";
+      }
+
+      leaf capability-extended-nexthop {
+          type boolean;
+          description
+              "Advertise extended next-hop capability to the peer.";
+      }
+
+      leaf capability-dynamic {
+          type boolean;
+          description
+              "Advertise dynamic capability to this neighbor.";
+      }
+
+      leaf dont-negotiate-capability {
+          type boolean;
+          description
+              "Do not perform capability negotiation";
+      }
+
+      leaf enforce-multihop {
+          type boolean;
+          description
+              "Enforce EBGP neighbors perform multihop";
+      }
+
+      leaf override-capability {
+          type boolean;
+          description
+              "Override capability negotiation result.";
+      }
+
+      leaf peer-port {
+          type uint16 {
+              range 0..65535;
+          }
+          description
+              "Neighbor's BGP port.";
+      }
+
+      leaf shutdown-message {
+          type string {
+             length "1..127";
+          }
+          description
+              "Add a shutdown message.";
+      }
+
+      leaf strict-capability-match {
+          type boolean;
+          description
+              "Strict capability negotiation match";
+      }
+
+      leaf local-as-no-prepend {
+          type boolean;
+          description
+              "Do not prepend the local-as number in AS-Path advertisements.";
+      }
+
+      leaf local-as-replace-as {
+          type boolean;
+          description
+              "Replace the configured AS Number with the local-as number in AS-Path advertisements";
+      }
+  }
+  grouping bgp-ext-neighbor-group-state { 
+    description
+      "State data for neighbor group";
+  
+      leaf connections-dropped {
+          type oc-yang:counter64;
+          description
+              "This indicates the Number of times a TCP and BGP connection has been successfully established.";
+      }
+
+      leaf last-reset-time {
+          type uint64;
+          description
+             "This value indicates the time peering session was last reset in seconds.";
+      }
+
+      leaf last-reset-reason {
+          type string;
+          description
+              "Indicates the reason the BGP neighbor down";
+      }
+      
+      leaf last-read {
+          type uint64;
+          description
+             "This value indicates the time that the
+             BGP last received a message from neighbor in seconds"; 
+      }
+
+      leaf last-write {
+          type uint64;
+          description
+             "This value indicates the time that the
+             BGP last sent message from neighbor in seconds"; 
+      }
+     
+      leaf remote-router-id {
+          type oc-yang:dotted-quad;
+          description
+             "A identifier for the remote network instance - typically
+              used within associated routing protocols or signalling
+              routing information in another network instance";
+      }
+  }
+  grouping bgp-ext-neighbor-group-afi-safi-allow-own-as-config {
+    description
+      "Configuration data for allow own AS under neighbor group address family";
+      leaf enabled {
+          type boolean;
+          default false;
+          description
+              "This leaf indicates whether to accept as-path update with local AS present in it.";
+      }
+
+      leaf as-count {
+          type uint8 {
+              range 1..10;
+          }
+          description
+              "Number of occurences of AS number.";
+      }
+
+      leaf origin {
+          type boolean;
+          description
+              "Only accept local AS in the as-path if the route was originated in local AS";
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-network-config {
+    description
+      "Configuration data for network address under global address family";
+      leaf prefix {
+          type oc-inet:ip-prefix;
+          description
+              "This specifies a network address.";
+      }
+
+      leaf policy-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "A reference to a routing policy which can be used to
+              restrict the prefixes for which advertisement is enabled";
+      }
+
+      leaf backdoor {
+          type boolean;
+          description
+              "This leaf indicates whether to make the prefix less perferred over IGP route 
+              and the prefix will not be advertised to the BGP peers.";
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-aggregate-address-config {
+    description
+      "Configuration data for aggregate address under global address family";
+      leaf prefix {
+          type oc-inet:ip-prefix;
+          description
+              "This specifies an aggregate address.";
+      }
+
+      leaf policy-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "A reference to a routing policy which can be used to
+              restrict the prefixes for which advertisement is enabled";
+      }
+
+      leaf as-set {
+          type boolean;
+          description
+              "This leaf indicates whether the resulting routes include AS set.";
+      }
+
+      leaf summary-only {
+          type boolean;
+          description
+              "This leaf indicates resulting routes will not be announced.";
+      }
+  }
+
+  grouping bgp-ext-global-route-flap-damping-config {
+    description
+      "Configuration data for route flap damping under global level";
+      leaf enabled {
+          type boolean;
+          default false;
+          description
+              "This leaf indicates whether route flap damping is enabled for
+              this AFI-SAFI";
+      }
+
+      leaf half-life {
+          type uint8 {
+              range 1..45;
+          }
+          description
+              "Half-life time for the penalty.";
+      }
+
+      leaf reuse-threshold {
+          type uint16 {
+              range 1..20000;
+          }
+          description
+              "Value to start reusing a route";
+      }
+
+      leaf suppress-threshold {
+          type uint16 {
+              range 1..20000;
+          }
+          description
+              "Value to start suppressing a route";
+      }
+
+      leaf max-suppress {
+          type uint8 {
+              range 1..255;
+          }
+          description
+              "Maximum duration to suppress a stable route.";
+      }
+  }
+
+  grouping bgp-ext-neighbor-group-afi-safi-originate-default-config {
+    description
+      "Configuration data for default route origination under neighbor group address family level";
+      leaf default-policy-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "Routing policy definition to specify criteria to originate default.";
+      }
+  }
+
+  grouping bgp-ext-attribute-unchanged-config {
+    description
+        "Configuration data for attribute unchanged to the neighbor";
+      leaf as-path {
+          type boolean;
+          description "Propagate AS-path attribute unchanged to the neighbor.";
+      }
+
+      leaf med {
+          type boolean;
+          description "Propagate MED attribute unchanged to the neighbor.";
+      }
+
+      leaf next-hop {
+          type boolean;
+          description "Propagate next-hop attribute unchanged to the neighbor.";
+      }
+  }
+
+  grouping bgp-ext-filter-list-config {
+    description
+        "Configuration data for filter list";
+      leaf import-policy {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+                  "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:as-path-sets/" +
+                  "oc-bgp-pol:as-path-set/oc-bgp-pol:as-path-set-name";
+          }
+          description "References a defined AS path set";
+      }
+
+      leaf export-policy {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+                  "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:as-path-sets/" +
+                  "oc-bgp-pol:as-path-set/oc-bgp-pol:as-path-set-name";
+          }
+          description "References a defined AS path set";
+      }
+  }
+  
+  grouping bgp-ext-prefix-list-config {
+    description
+        "Configuration data for prefix list";
+      leaf import-policy {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+                  "oc-rpol:prefix-sets/oc-rpol:prefix-set/oc-rpol:name";
+          }
+          description "References a defined prefix set";
+      }
+
+      leaf export-policy {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+                  "oc-rpol:prefix-sets/oc-rpol:prefix-set/oc-rpol:name";
+          }
+          description "References a defined prefix set";
+      }
+  }
+
+  grouping bgp-ext-next-hop-self-config {
+    description
+        "Configuration data for nexthop self for routes";
+      leaf enabled {
+          type boolean;
+          description 
+              "Disable the next hop calculation for the neighbor group";
+      }
+
+      leaf force {
+          type boolean;
+          description "Set the next hop to self for reflected routes";
+      }
+  }
+
+  grouping bgp-ext-remove-private-as-config {
+    description
+        "Configuration data for private AS in outbound updates";
+      leaf enabled {
+          type boolean;
+          description
+              "Remove private ASNs in outbound updates";
+      }
+
+      leaf all {
+          type boolean;
+          description 
+              "Apply to all AS numbers";
+      }
+
+      leaf replace-as {
+          type boolean;
+          description
+              "Replace private ASNs with local ASN in outbound updates";
+      }
+  }
+
+  grouping bgp-ext-neighbor-group-afi-safi-config{
+    description
+        "Configuration data for neighbor group address family";
+
+      leaf soft-reconfiguration-in {
+          type boolean;
+          description
+              "This enables to store the inbound BGP updates for soft reconfiguration.";
+      }
+
+      leaf unsuppress-map-name {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+                  "oc-rpol:policy-definition/oc-rpol:name";
+          }
+          description
+              "This helps to selectively advertise more-specific routes to neighbor group 
+              based on routing policy definition when aggregate-address is active.";
+      }
+
+      leaf weight {
+          type uint32 {
+              range 0..65535;
+          }
+          description
+              "This indicates the default weight value for the neighbor's routes";
+      }
+
+      leaf as-override {
+          type boolean;
+          description
+              "Override ASNs in outbound updates if as-path equals remote-as.";
+      }
+
+      leaf send-community {
+          type bgp-ext-community-type;
+          default "BOTH";
+          description
+              "Specify which types of community should be sent to the
+              neighbor or group. The default is to send both standard and extended
+              community attributes";
+      }
+
+      leaf route-reflector-client {
+          type boolean;
+          default "false";
+          description
+              "Configure the neighbor as a route reflector client.";
+      }
+
+      leaf route-server-client {
+          type boolean;
+          description
+              "Configure a neighbor as Route Server client.";
+      }
+  }
+
+  grouping bgp-ext-neighbor-group-add-paths-config {
+    description
+        "Configuration data for neighbor group add paths";
+      leaf tx-add-paths {
+          type tx-add-paths-type;
+          description
+              "Send multiple path or only best path per AS advertisements for an NLRI from 
+              the neighbor or group";
+          reference
+              "RFC 7911 - Advertisement of Multiple Paths in BGP";
+      }
+  }
+
+  grouping bgp-ext-capability-orf-config {
+    description
+        "Configuration data for outbound route filtering";
+      leaf orf-type {
+          type bgp-orf-type;
+          description
+              "Describes the outbound route filtering (ORF) capability type";
+      }
+  }
+
+  grouping bgp-ext-global-afi-safi-ibgp-config {
+    description
+        "Configuration data for iBGP under global address family";
+      leaf equal-cluster-length {
+          type boolean;
+          description
+              "Match the cluster length.";
+      }
+  }
+
+  grouping bgp-ext-attr-sets-state {
+    description
+        "Operational data for PATH attributes";
+      container attr-sets {
+          config false;
+          description
+              "Various PATH attributes for a given prefix.";
+          leaf weight {
+              type uint32;
+              description
+                  "This indicates the weight value for the neighbor's routes";
+          }
+          uses oc-rib-bgp:bgp-shared-common-attr-state;
+          uses oc-rib-bgp:bgp-aggregator-attr-top;
+          uses oc-rib-bgp:bgp-as-path-attr-top;
+          uses oc-rib-bgp:bgp-as4-path-attr-top;
+          uses oc-rib-bgp:bgp-community-attr-state;
+          uses oc-rib-bgp:bgp-extended-community-attr-state;
+      }
+  }
+
+  grouping bgp-ext-neighbor-group-afi-safi-top {
+    description
+        "Configuration data for address family under neighbor group";
+      container allow-own-as {
+          description
+              "This enables BGP to accept as-path update with local AS.";
+          container config {
+              description
+                  "Configuration parameters relating to accept as-path update with local AS";
+              uses bgp-ext-neighbor-group-afi-safi-allow-own-as-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to accept as-path update with local AS";
+              uses bgp-ext-neighbor-group-afi-safi-allow-own-as-config; 
+          }
+      }
+
+      container attribute-unchanged {
+          description
+              "BGP attribute is propagated unchanged to the neighbor.";
+          container config {
+              description
+                  "Configuration parameters relating to propagate BGP attribute unchanged to the neighbor";
+              uses bgp-ext-attribute-unchanged-config;
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to propagate BGP attribute unchanged to the neighbor";
+              uses bgp-ext-attribute-unchanged-config;
+          }
+      }
+
+      container filter-list {
+          description
+              "Apply AS-path filter list.";
+          container config {
+              description
+                  "Configuration parameters relating to AS-Path filter list";
+              uses bgp-ext-filter-list-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to AS-Path filter list";
+              uses bgp-ext-filter-list-config; 
+          }
+      }
+
+      container next-hop-self {
+          description
+              "Disable the next hop calculation for the neighbor group";
+          container config {
+              description
+                  "Configuration parameters relating to disable the next hop calculation for the neighbor group";
+              uses bgp-ext-next-hop-self-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to disable the next hop calculation for the neighbor group";
+              uses bgp-ext-next-hop-self-config; 
+          }
+      }
+
+      container prefix-list {
+          description
+              "Apply prefix filter list.";
+          container config {
+              description
+                  "Configuration parameters relating to prefix filter list";
+              uses bgp-ext-prefix-list-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to prefix filter list";
+              uses bgp-ext-prefix-list-config; 
+          }
+      }
+
+      container remove-private-as {
+          description
+              "Remove private ASNs in outbound updates";
+          container config {
+              description
+                  "Configuration parameters relating to remove private ASNs in outbound updates";
+              uses bgp-ext-remove-private-as-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to remove private ASNs in outbound updates";
+              uses bgp-ext-remove-private-as-config; 
+          }
+      }
+
+      container capability-orf {
+          description
+              "Advertise prefix-list outbound route filtering capability to this neighbor.";
+          container config {
+              description
+                  "Configuration parameters relating to advertise prefix-list outbound route filtering capability to this neighbor";
+              uses bgp-ext-capability-orf-config; 
+          }
+          container state {
+              config false;
+              description
+                  "Operational state parameters relating to advertise prefix-list outbound route filtering capability to this neighbor";
+              uses bgp-ext-capability-orf-config; 
+          }
+      }
+  }
+
+  grouping bgp-ext-neighbor-msgs-state {
+    description
+        "Operational data for neighbor messages";
+      leaf open {
+          type uint64;
+          description
+              "Number of BGP OPEN messages.";
+      }
+      leaf keepalive {
+          type uint64;
+          description
+              "Number of BGP KEEPALIVE messages.";
+      }
+      leaf route-refresh {
+          type uint64;
+          description
+              "Number of BGP ROUTE_REFRESH messages.";
+      }
+      leaf capability {
+          type uint64;
+          description
+              "Number of BGP CAPABILITY essages.";
+      }
+  }
+
+  grouping bgp-ext-peer-group-members-state {
+    description
+        "Operational data for neighbors of the peer group";
+    container members-state {
+        config false;
+        description
+            "Describes the members of the peer groups";
+        list member {
+            key "neighbor";
+            description
+                "Neighbors in a peer group";
+            leaf neighbor {
+                type leafref {
+                    path "../state/neighbor";
+                }
+                description
+                    "Reference to the neighbor key";
+            }
+            container state {
+                description
+                    "Operation state parameters relating to members of the peer group";
+                leaf neighbor {
+                    type leafref {
+                        path "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+                            "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/" +
+                            "oc-netinst:neighbor/oc-netinst:config/oc-netinst:neighbor-address";
+                    }
+                    description
+                        "Indicates neighbor address or interface.";
+                }
+                leaf dynamic {
+                    type boolean;
+                    description
+                        "Indicates neighbor is dynamic or not.";
+                }
+                leaf state {
+                    type string;
+                    description
+                        "Indicates neighbor current state.";
+                }
+            }
+        }
+     }
+  }
+  
+  grouping bgp-ext-neighbor-group-bfd-config {
+    description
+        "Configuration data for BFD under neighbors group";
+      leaf bfd-check-control-plane-failure {
+          type boolean;
+          description
+              "Link dataplane status with BGP control plane.";
+      }
+  }
+
+  typedef bgp-neighbor {
+      type union {
+          type oc-inet:ip-address;
+
+          // TODO: in YANG 1.1, unions support leafref types which
+          // should be used here to reference a configured interface by
+          // name
+          // type leafref {
+          //    path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+          // }
+          type string;
+      }
+      description
+          "BGP neighbor can be either IP or interface name";
+  }
+  
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:config/oc-netinst:neighbor-address {
+      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      deviate replace {
+          type bgp-neighbor;
+      }
+  }
+ 
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
+      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      deviate replace {
+          type bgp-neighbor;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
+      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      deviate replace {
+          type bgp-neighbor;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
+      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      deviate replace {
+          type bgp-neighbor;
+      }
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global {
+      description
+          "BGP global extensions";
+      uses oc-bgp:bgp-common-structure-neighbor-group-logging-options;
+      uses bgp-ext-global-route-reflector-top;
+      uses bgp-ext-global-defaults-top;
+      uses bgp-ext-global-update-delay-top;
+      uses bgp-ext-global-max-med-top;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:config {
+      description
+          "BGP global extensions";
+      uses bgp-ext-global-config;
+  }
+  
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:state {
+      description
+          "BGP global extensions";
+      uses bgp-ext-global-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:graceful-restart/oc-netinst:config {
+      description
+          "BGP global extensions for graceful restart";
+      uses bgp-ext-global-graceful-restart-config;
+}
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:graceful-restart/oc-netinst:state {
+      description
+          "BGP global extensions for graceful restart";
+      uses bgp-ext-global-graceful-restart-config;
+}
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:route-selection-options/oc-netinst:config {
+      description
+          "BGP global extensions for route selection options";
+      uses bgp-ext-global-route-selection-options-config;
+}
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:route-selection-options/oc-netinst:state {
+      description
+          "BGP global extensions for route selection options";
+      uses bgp-ext-global-route-selection-options-config;
+}
+ 
+ augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:use-multiple-paths/oc-netinst:ebgp/oc-netinst:config {
+      description
+          "BGP global extensions for multiple paths configuration";
+      uses bgp-ext-global-use-multiple-paths-config;
+}
+  
+ augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:use-multiple-paths/oc-netinst:ebgp/oc-netinst:state {
+      description
+          "BGP global extensions for multiple paths configuration";
+      uses bgp-ext-global-use-multiple-paths-config;
+}
+ 
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi {
+      description
+          "BGP global extensions for address family";
+      uses bgp-ext-global-afi-safi-top;
+      uses bgp-ext-global-route-flap-damping-top;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:config  {
+      description
+          "BGP global extensions for address family configs";
+      uses bgp-ext-global-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:state  {
+      description
+          "BGP global extensions for address family configs";
+      uses bgp-ext-global-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:use-multiple-paths/oc-netinst:ibgp/oc-netinst:config  {
+      description
+          "BGP global extensions for address family multiple path configs";
+      uses bgp-ext-global-afi-safi-ibgp-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:use-multiple-paths/oc-netinst:ibgp/oc-netinst:state  {
+      description
+          "BGP global extensions for address family multiple path configs";
+      uses bgp-ext-global-afi-safi-ibgp-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor {
+      description
+          "BGP neighbor extensions";
+      uses bgp-ext-neighbor-group-auth-password-top;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:config {
+      description
+          "BGP neighbor extensions";
+      uses bgp-ext-neighbor-group-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state {
+      description
+          "BGP neighbor extensions";
+      uses bgp-ext-neighbor-group-config;
+      uses bgp-ext-neighbor-group-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:messages/oc-netinst:sent {
+      description
+          "BGP neighbor extensions for messages";
+      uses bgp-ext-neighbor-msgs-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:messages/oc-netinst:received {
+      description
+          "BGP neighbor extensions for messages received from peer";
+      uses bgp-ext-neighbor-msgs-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group {
+      description
+          "BGP peer group extensions";
+      uses bgp-ext-neighbor-group-auth-password-top; 
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:config {
+      description
+          "BGP peer group extensions for configs";
+      uses bgp-ext-peer-group-config;
+      uses bgp-ext-neighbor-group-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:state {
+      description
+          "BGP peer group extensions for configs";
+      uses bgp-ext-peer-group-config;
+      uses bgp-ext-neighbor-group-config;
+      uses bgp-ext-neighbor-group-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:config {
+      description
+          "BGP neighbor address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:state {
+      description
+          "BGP neighbor address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:add-paths/oc-netinst:config {
+      description
+          "BGP neighbor address family extensions for add paths";
+      uses bgp-ext-neighbor-group-add-paths-config;
+  }
+  
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:add-paths/oc-netinst:state {
+      description
+          "BGP neighbor address family extensions for add paths";
+      uses bgp-ext-neighbor-group-add-paths-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:add-paths/oc-netinst:config {
+      description
+          "BGP peer group address family extensions for add paths";
+      uses bgp-ext-neighbor-group-add-paths-config;
+  }
+  
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:add-paths/oc-netinst:state {
+      description
+          "BGP peer group address family extensions for add paths";
+      uses bgp-ext-neighbor-group-add-paths-config;
+  }
+
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:config {
+      description
+          "BGP peer group address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:state {
+      description
+          "BGP peer group address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi {
+      description
+          "BGP neighbor address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-top;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi {
+      description
+          "BGP neighbor address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-top;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:config {
+      description
+          "BGP neighbor ipv4 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:state {
+      description
+          "BGP neighbor ipv4 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:config {
+      description
+          "BGP neighbor ipv6 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+  
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:state {
+      description
+          "BGP neighbor ipv6 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:config {
+      description
+          "BGP peer group ipv4 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+  
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:state {
+      description
+          "BGP peer group ipv4 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:config {
+      description
+          "BGP peer group ipv6 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+ 
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:state {
+      description
+          "BGP peer group ipv6 unicast address family extensions";
+      uses bgp-ext-neighbor-group-afi-safi-originate-default-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group {
+      description
+          "BGP peer group extensions";
+      uses bgp-ext-peer-group-members-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:loc-rib/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP local rib extensions for ipv4 address family";
+      uses bgp-ext-attr-sets-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-in-pre/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv4 address family specific to received routes pre-processing from neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-in-post/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv4 address family specific to received routes post-processing from neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-out-post/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv4 address family specific to advertised routes to neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:loc-rib/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP local rib extensions";
+      uses bgp-ext-attr-sets-state;
+  }
+
+augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-in-pre/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv6 address family specific to received routes pre-processing from neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+
+augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-in-post/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv6 address family specific to received routes post-processing from neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:adj-rib-out-post/oc-netinst:routes/oc-netinst:route {
+      description
+          "BGP rib extensions for ipv6 address family specific to advertised routes to neighbors";
+      uses bgp-ext-attr-sets-state;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-bfd:enable-bfd/oc-bfd:config {
+      description
+          "BGP neighbor extensions for BFD configs";
+      uses bgp-ext-neighbor-group-bfd-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-bfd:enable-bfd/oc-bfd:state {
+      description
+          "BGP neighbor extensions for BFD configs";
+      uses bgp-ext-neighbor-group-bfd-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-bfd:enable-bfd/oc-bfd:config {
+      description
+          "BGP peer group extensions for BFD configs";
+      uses bgp-ext-neighbor-group-bfd-config;
+  }
+
+  augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-bfd:enable-bfd/oc-bfd:state {
+      description
+          "BGP peer group extensions for BFD configs";
+      uses bgp-ext-neighbor-group-bfd-config;
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:hold-time {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      deviate replace {
+          default 180;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:hold-time {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      deviate replace {
+          default 180;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:keepalive-interval {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      deviate replace {
+          default 60;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:keepalive-interval {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      deviate replace {
+          default 60;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:minimum-advertisement-interval {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      deviate replace {
+          default 0;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:minimum-advertisement-interval {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      deviate replace {
+          default 0;
+      }
+  }
+
+  deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:route-selection-options/oc-netinst:config/oc-netinst:external-compare-router-id {
+      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      deviate replace {
+          default "false";
+      }
+  }
+
+}

--- a/release/models/bgp/openconfig-bgp-ext.yang
+++ b/release/models/bgp/openconfig-bgp-ext.yang
@@ -19,7 +19,6 @@ module openconfig-bgp-ext {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-bfd { prefix oc-bfd; }
   import openconfig-extensions { prefix oc-ext; }
-  import sonic-codegen { prefix sonic-codegen; } 
 
   organization
       "OpenConfig working group";
@@ -1453,28 +1452,32 @@ module openconfig-bgp-ext {
   }
   
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:config/oc-netinst:neighbor-address {
-      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      description
+          "Deviated to support BGP unnumbered use-case";
       deviate replace {
           type bgp-neighbor;
       }
   }
  
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
-      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      description
+          "Deviated to support BGP unnumbered use-case";
       deviate replace {
           type bgp-neighbor;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv4-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
-      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      description
+          "Deviated to support BGP unnumbered use-case";
       deviate replace {
           type bgp-neighbor;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:rib/oc-netinst:afi-safis/oc-netinst:afi-safi/oc-netinst:ipv6-unicast/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:state/oc-netinst:neighbor-address {
-      sonic-codegen:lint-ignore "Deviated to support BGP unnumbered use-case"; 
+      description
+          "Deviated to support BGP unnumbered use-case";
       deviate replace {
           type bgp-neighbor;
       }
@@ -1812,49 +1815,56 @@ augment /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:pro
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:hold-time {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 180;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:hold-time {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 180;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:keepalive-interval {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 60;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:keepalive-interval {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors."; 
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 60;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:neighbors/oc-netinst:neighbor/oc-netinst:timers/oc-netinst:config/oc-netinst:minimum-advertisement-interval {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 0;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:peer-groups/oc-netinst:peer-group/oc-netinst:timers/oc-netinst:config/oc-netinst:minimum-advertisement-interval {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default 0;
       }
   }
 
   deviation /oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/oc-netinst:global/oc-netinst:route-selection-options/oc-netinst:config/oc-netinst:external-compare-router-id {
-      sonic-codegen:lint-ignore "Deviated to be aligned with other vendors.";
+      description
+          "Deviated to be aligned with other vendors.";
       deviate replace {
           default "false";
       }

--- a/release/models/bgp/openconfig-bgp-policy-ext.yang
+++ b/release/models/bgp/openconfig-bgp-policy-ext.yang
@@ -1,0 +1,164 @@
+module openconfig-bgp-policy-ext {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/bgp-policy/extension";
+
+  prefix "oc-bgp-pol-ext";
+
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-routing-policy {prefix oc-rpol; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-bgp-policy { prefix oc-bgp-pol; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-routing-policy-ext {prefix oc-rpol-ext;}
+
+  organization
+      "OpenConfig Working Group";
+
+  contact
+      "OpenConfig Working Group
+      www.openconfig.net";
+
+  description
+    "This module describes a deviation for BGP routing policy 
+     configuration extensions.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2020-08-01" {
+    description
+      "Added the action for as-path, community and ext-community.";
+    reference "0.1.2";
+  }
+
+  revision "2020-04-08" {
+    description
+      "Added the attributes for IPv6 next hop.";
+    reference "0.1.1";
+  }
+
+  revision "2019-11-13" {
+    description
+      "BGP Routing Policy extensions.";
+    reference "0.1.0";
+  }
+
+  grouping bgp-policy-ext-action-next-hop-set-config {
+    description
+        "Configuration data for IP nexthop under BGP policy conditions";
+      leaf next-hop-set {
+          type leafref {
+              path "/oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:prefix-sets/oc-rpol:prefix-set/oc-rpol:config/oc-rpol:name";
+          }
+          description "References a defined prefix set";
+      }
+  }
+
+  typedef bgp-community-defined-regexp-type {
+      type string;
+      description
+          "Type definition for communities specified as regular
+          expression patterns";
+    }
+ 
+  grouping bgp-policy-ext-ipv6-next-hop-config {
+    description
+        "Configuration data for IPv6 nexthop under BGP policy actions";
+      leaf set-ipv6-next-hop-global {
+          type oc-inet:ipv6-address;
+          description "set the IPv6 global next-hop attribute in the route update";
+      }
+
+      leaf set-ipv6-next-hop-prefer-global {
+          type boolean;
+          description
+              "If we receive a ipv6 global and link-local address for the route, 
+              then prefer to use the global address as the nexthop.";
+      }
+  }
+
+  deviation /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:community-sets/oc-bgp-pol:community-set/oc-bgp-pol:config/oc-bgp-pol:community-member {
+      deviate replace {
+          type union {
+              type oc-bgp-types:bgp-std-community-type;
+              type bgp-community-defined-regexp-type;
+              type oc-bgp-types:bgp-well-known-community-type;
+          }
+      }
+  }
+
+  deviation /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:ext-community-sets/oc-bgp-pol:ext-community-set/oc-bgp-pol:config/oc-bgp-pol:ext-community-member {
+      deviate replace {
+          type union {
+              type oc-bgp-types:bgp-ext-community-type;
+              type bgp-community-defined-regexp-type;
+          }
+      }
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-bgp-pol:bgp-conditions/oc-bgp-pol:config {
+    description
+        "Policy definition extensions for BGP conditions";
+      uses bgp-policy-ext-action-next-hop-set-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-bgp-pol:bgp-conditions/oc-bgp-pol:state {
+    description
+        "Policy definition extensions for BGP conditions";
+      uses bgp-policy-ext-action-next-hop-set-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:actions/oc-bgp-pol:bgp-actions/oc-bgp-pol:config {
+    description
+        "Policy definition extensions for BGP actions";
+        uses bgp-policy-ext-ipv6-next-hop-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:actions/oc-bgp-pol:bgp-actions/oc-bgp-pol:state {
+    description
+        "Policy definition extensions for BGP actions";
+        uses bgp-policy-ext-ipv6-next-hop-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:as-path-sets/oc-bgp-pol:as-path-set/oc-bgp-pol:config {
+    description
+        "BGP as-path set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:as-path-sets/oc-bgp-pol:as-path-set/oc-bgp-pol:state {
+    description
+        "BGP as-path set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:community-sets/oc-bgp-pol:community-set/oc-bgp-pol:config {
+    description
+        "BGP community set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:community-sets/oc-bgp-pol:community-set/oc-bgp-pol:state {
+    description
+        "BGP community set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:ext-community-sets/oc-bgp-pol:ext-community-set/oc-bgp-pol:config {
+    description
+        "BGP ext-community set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:ext-community-sets/oc-bgp-pol:ext-community-set/oc-bgp-pol:state {
+    description
+        "BGP ext-community set extensions";
+      uses oc-rpol-ext:routing-policy-ext-action-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+}

--- a/release/models/policy/.spec.yml
+++ b/release/models/policy/.spec.yml
@@ -5,12 +5,14 @@
     - yang/isis/openconfig-isis-types.yang
     - yang/ospf/openconfig-ospf-types.yang
     - yang/policy/openconfig-routing-policy.yang
+    - yang/policy/openconfig-routing-policy-ext.yang
     - yang/network-instance/openconfig-network-instance-policy.yang
     - yang/bgp/openconfig-bgp-policy.yang
     - yang/isis/openconfig-isis-policy.yang
     - yang/ospf/openconfig-ospf-policy.yang
   build:
     - yang/policy/openconfig-routing-policy.yang
+    - yang/policy/openconfig-routing-policy-ext.yang
     - yang/network-instance/openconfig-network-instance-policy.yang
     - yang/bgp/openconfig-bgp-policy.yang
     - yang/isis/openconfig-isis-policy.yang

--- a/release/models/policy/openconfig-routing-policy-ext.yang
+++ b/release/models/policy/openconfig-routing-policy-ext.yang
@@ -1,0 +1,426 @@
+module openconfig-routing-policy-ext {
+
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/routing-policy/extension";
+
+    prefix "oc-rpol-ext";
+
+    // import some basic types
+    import openconfig-routing-policy { prefix oc-rpol; }
+    import openconfig-bgp-policy { prefix oc-bgp-pol; }
+    import openconfig-inet-types { prefix oc-inet; }
+    import openconfig-network-instance { prefix oc-netinst; }
+    import openconfig-extensions { prefix oc-ext; }
+    import openconfig-bgp-types { prefix oc-bgp-type; }
+
+    organization
+      "OpenConfig Working Group";
+
+    contact
+      "OpenConfig Working Group
+      www.openconfig.net";
+
+    description
+        "This module describes a YANG model for routing policy
+        configuration extensions.";
+
+    oc-ext:openconfig-version "0.1.4";
+
+    revision "2020-09-11" {
+        description
+            "Added Sequence number support for IP Prefix list.";
+        reference "0.1.4";
+    }
+
+    revision "2020-09-01" {
+        description
+            "Added the ipv6 prefix set in routing policy conditions.";
+        reference "0.1.3";
+    }
+
+    revision "2020-06-23" {
+        description
+            "Added the set community option additive.";
+        reference "0.1.2";
+    }
+
+    revision "2020-05-13" {
+        description
+            "Replaced the type of match tag and set med to uint32.";
+        reference "0.1.1";
+    }
+
+    revision "2019-11-11" {
+        description
+            "Add OpenConfig unsupported attributes.";
+        reference "0.1.0";
+    }
+
+    identity ADDITIVE {
+        base "oc-bgp-type:BGP_WELL_KNOWN_STD_COMMUNITY";
+        description
+            "Internal type to append the communities for route advertisement.";
+    }
+
+    typedef routing-policy-ext-action-type {
+        type enumeration {
+            enum PERMIT {
+                description "Permit action.";
+            }
+            enum DENY {
+                description "Deny action.";
+            }
+        }
+        description
+            "Routing policy action type permit or deny";
+    }
+
+    identity ROUTEMAP_SET_METRIC_TYPE {
+        description
+            "Type used to specify route metric value to be set in
+             a policy chain.";
+    }
+
+    identity METRIC_SET_VALUE {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+        description
+          "Set a specified metric value.";
+    }
+
+    identity METRIC_ADD_VALUE {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+         description
+            "Add a specified metric value from current
+             set value of metric.";
+    }
+
+    identity METRIC_SUBTRACT_VALUE {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+        description
+            "Subtract a specified metric value from current
+             set value of metric.";
+    }
+
+    identity METRIC_SET_RTT {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+        description
+            "Add round trip time value as metric.";
+    }
+
+    identity METRIC_ADD_RTT {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+        description
+            "Add round trip time value from current
+             set value of metric.";
+    }
+
+    identity METRIC_SUBTRACT_RTT {
+        base "ROUTEMAP_SET_METRIC_TYPE";
+        description
+            "Subtract round trip time value from current
+             set value of metric.";
+    }
+
+    grouping routing-policy-ext-asn-list-val-config {
+        description
+            "Configuration data for ASN numbers";
+         leaf asn-list{
+           type string;
+           description
+                "Comma separated list of asn numbers";
+            
+      }
+    }
+
+    grouping routing-policy-ext-action-config {
+        description
+            "Configuration data for action type";
+        leaf action {
+            type oc-rpol-ext:routing-policy-ext-action-type;
+            description
+                "Select the action, accept or reject.";
+        }
+    }
+
+    grouping routing-policy-ext-metric-action-config {
+        description
+            "Metric action to be set for the policy.";
+
+        leaf action {
+            type identityref {
+                base "ROUTEMAP_SET_METRIC_TYPE";
+            }
+            description
+                "Metric set action type for the the policy.";
+        }
+
+        leaf metric {
+             when "../action = 'METRIC_SET_VALUE' " +
+                  "or ../action = 'METRIC_ADD_VALUE' " +
+                  "or ../action = 'METRIC_SUBTRACT_VALUE'";
+
+             type uint32 {
+                 range "0..4294967295";
+             }
+             description
+                 "Metric value to be set for the policy.
+                  Specified only when action is for set metric or
+                  add metric or subtract metric.";
+        }
+    }
+
+    grouping routing-policy-ext-metric-action {
+        description
+            "Definitions for metric set";
+
+        container metric-action {
+            description
+                "Set metric actions for the routing policy";
+
+            container config {
+                description
+                    "Configuration data for metric set policy actions";
+
+                uses routing-policy-ext-metric-action-config;
+            }
+
+            container state {
+                config false;
+                description
+                    "Operational state data for metric set policy actions";
+
+                uses routing-policy-ext-metric-action-config;
+            }
+        }
+    }
+
+
+    grouping routing-policy-ext-neighbor-set-config {
+        description
+            "Configuration data for neighbor set definitions";
+
+        leaf-list address {
+            type union {
+                type oc-inet:ip-address;
+
+                // TODO: in YANG 1.1, unions support leafref types which
+                // should be used here to reference a configured interface by
+                // name
+                // type leafref {
+                //    path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+                // }
+                type string;
+            }
+            description
+                "List of IP addresses or interfaces in the neighbor set";
+        }
+    }
+
+    grouping routing-policy-ext-tag-set-config {
+        description
+            "Configuration data for tag set definitions.";
+
+        leaf-list tag-value {
+            type uint32;
+            description
+                "Value of the tag set member";
+        }
+    }
+
+    grouping routing-policy-ext-prefix-set-config {
+        description
+            "Configuration data for ipv6 prefix set definitions.";
+
+        leaf ipv6-prefix-set {
+            type leafref {
+                path "/oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:prefix-sets/oc-rpol:prefix-set/oc-rpol:config/oc-rpol:name";
+            }
+            description
+                "Leaf reference of the ipv6 prefix set name";
+        }
+    }
+
+
+    grouping routing-policy-ext-match-network-instance-config {
+        description
+            "Configuration data for match network instance.";
+
+        leaf name {
+            type leafref {
+                path "/oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:config/oc-netinst:name";
+            }
+            description
+                "An operator-assigned unique name for the forwarding
+                instance";
+        }
+    }
+
+    grouping routing-policy-ext-match-src-network-instance-top {
+        description
+            "Configuration data for source VRF match definitions.";
+
+        container match-src-network-instance {
+            description
+                "Source network instance match configuration";
+            container config {
+                description
+                    "Configuration parameters relating to source network instance";
+                uses routing-policy-ext-match-network-instance-config;
+            }
+            container state {
+                config false;
+                description
+                    "Operational state parameters relating to source network instance";
+                uses routing-policy-ext-match-network-instance-config;
+            }
+        }
+    }
+
+    grouping routing-policy-ext-prefix-config {
+        description
+            "Configuration data for prefix definitions";
+
+        leaf sequence-number {
+            type uint32 {
+                range "1..4294967295";
+            }
+            description
+                "The sequence number determines the order in which prefix-list entries are applied. It must be unique
+                 for each prefix in a prefix-list. Target devices should apply the prefixes in ascending order determined
+                 by sequence no (low to high), rather than relying only on order in the list.";
+        }
+
+        uses oc-rpol:prefix-config;
+        uses routing-policy-ext-action-config;
+    }
+
+    grouping routing-policy-ext-prefix-state {
+        description
+            "Operational state data for prefix definitions";
+    }
+
+    grouping routing-policy-ext-prefix-top {
+        description
+            "Top-level grouping for prefixes in a prefix list";
+
+        container prefixes-ext {
+            description
+                "Enclosing container for the list of prefixes in a policy prefix list";
+
+            list prefix {
+                key "sequence-number ip-prefix masklength-range";
+                description
+                    "List of prefixes in the prefix set";
+
+                leaf sequence-number {
+                    type leafref {
+                        path "../config/sequence-number";
+                    }
+                    description
+                        "Reference to the sequence-number.";
+                }
+
+                leaf ip-prefix {
+                    type leafref {
+                        path "../config/ip-prefix";
+                    }
+                    description
+                        "Reference to the ip-prefix.";
+                }
+
+                leaf masklength-range {
+                    type leafref {
+                        path "../config/masklength-range";
+                    }
+                    description
+                        "Reference to the masklength-range.";
+                }
+
+                container config {
+                    description
+                        "Configuration data for prefix definition";
+
+                    uses routing-policy-ext-prefix-config;
+                }
+
+                container state {
+                    config false;
+
+                    description
+                        "Operational state data for prefix definition";
+
+                    uses routing-policy-ext-prefix-config;
+                    uses routing-policy-ext-prefix-state;
+                }
+            }
+        }
+    }
+
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:actions{
+      description
+          "Policy definition extensions for setting metric actions";
+        uses routing-policy-ext-metric-action;
+    }
+
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:actions/oc-bgp-pol:bgp-actions/oc-bgp-pol:set-as-path-prepend/oc-bgp-pol:config {
+      description
+          "Policy definition extensions for BGP AS-PATH prepend configs";
+        uses routing-policy-ext-asn-list-val-config;
+   }
+ 
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:actions/oc-bgp-pol:bgp-actions/oc-bgp-pol:set-as-path-prepend/oc-bgp-pol:state {
+      description
+          "Policy definition extensions for BGP AS-PATH prepend configs";
+        uses routing-policy-ext-asn-list-val-config;
+   }
+
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions {
+      description
+          "Policy definition extensions for conditions";
+        uses routing-policy-ext-match-src-network-instance-top;
+    }
+
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-neighbor-set/oc-rpol:config {
+      description
+          "Policy definition extensions for neighbor match configs";
+        uses routing-policy-ext-neighbor-set-config;
+    }
+    
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-neighbor-set/oc-rpol:state {
+      description
+          "Policy definition extensions for neighbor match configs";
+        uses routing-policy-ext-neighbor-set-config;
+    }
+   
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-tag-set/oc-rpol:config {
+      description
+          "Policy definition extensions for tag match configs";
+        uses routing-policy-ext-tag-set-config;
+    }
+    
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-tag-set/oc-rpol:state{
+      description
+          "Policy definition extensions for tag match configs";
+        uses routing-policy-ext-tag-set-config;
+    }
+  
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-prefix-set/oc-rpol:config {
+      description
+          "Policy definition extensions for prefix match configs";
+        uses routing-policy-ext-prefix-set-config;
+    }
+    
+    augment /oc-rpol:routing-policy/oc-rpol:policy-definitions/oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/oc-rpol:conditions/oc-rpol:match-prefix-set/oc-rpol:state{
+      description
+          "Policy definition extensions for prefix match configs";
+        uses routing-policy-ext-prefix-set-config;
+    }
+
+    augment /oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:prefix-sets/oc-rpol:prefix-set {
+      description
+          "IP prefix set extensions";
+        uses routing-policy-ext-prefix-top;
+    }
+}

--- a/release/models/rib/openconfig-rib-bgp-ext.yang
+++ b/release/models/rib/openconfig-rib-bgp-ext.yang
@@ -160,7 +160,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv4";
 
-      uses rib-bgp-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +

--- a/release/models/rib/openconfig-rib-bgp-ext.yang
+++ b/release/models/rib/openconfig-rib-bgp-ext.yang
@@ -3,13 +3,19 @@ module openconfig-rib-bgp-ext {
   yang-version "1";
 
   // namespace
-  namespace "http://openconfig.net/yang/rib/bgp-ext";
+  namespace "http://openconfig.net/yang/rib-bgp/extension";
 
   prefix "oc-bgprib-ext";
 
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-rib-bgp-types { prefix oc-bgpribt; }
   import openconfig-network-instance { prefix oc-ni; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-rib-bgp { prefix oc-rib-bgp; }
+  import openconfig-policy-types { prefix oc-pol-types; }
+  import openconfig-bgp-ext { prefix oc-bgp-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-bgp-evpn-ext { prefix oc-bgp-evpn-ext; }
 
   organization "OpenConfig working group";
 
@@ -23,7 +29,14 @@ module openconfig-rib-bgp-ext {
     are not currently supported in a majority of BGP
     implementations.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2020-12-16" {
+    description
+      "Added extended annotations for Loc-RIB for IPv4, IPv6 and
+      EVPN address families.";
+    reference "0.7.0";
+  }
 
   revision "2019-04-25" {
     description
@@ -69,7 +82,7 @@ module openconfig-rib-bgp-ext {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  grouping rib-ext-route-annotations {
+  grouping rib-bgp-ext-route-annotations-state {
     description
       "Extended annotations for routes in the routing tables";
 
@@ -96,7 +109,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to the Loc-RIB for IPv4";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -107,7 +120,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to the Loc-RIB for IPv6";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -120,7 +133,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv4";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment
@@ -134,7 +147,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv4";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -147,7 +160,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv4";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -160,7 +173,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv4";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -173,7 +186,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv6";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -186,7 +199,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv6";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -199,7 +212,7 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv6";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/" +
@@ -212,7 +225,254 @@ module openconfig-rib-bgp-ext {
       description
         "Add extended annotations to Adj-RIB for IPv6";
 
-      uses rib-ext-route-annotations;
+      uses rib-bgp-ext-route-annotations-state;
+  }
+
+  grouping rib-bgp-ext-prefix-paths-top {
+    description
+      "Top-level grouping for IPv4 routing tables for prefix";
+
+    container loc-rib-prefix-paths {
+      config false;
+      description
+        "Container for the IPv4 BGP LOC-RIB data for prefix";
+
+      container paths {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list path {
+          key "origin path-id";
+
+          description
+            "List of routes in the table, keyed by the route
+            prefix, the route origin, and path-id.  The route
+            origin can be either the neighbor address from which
+            the route was learned, or the source protocol that
+            injected the route.  The path-id distinguishes routes
+            for the same prefix received from a neighbor (e.g.,
+            if add-paths is eanbled).";
+
+          leaf origin {
+              type leafref {
+                  path "../state/origin";
+              }
+              description
+                  "Reference to the origin list key";
+          }
+
+          leaf path-id {
+              type leafref {
+                  path "../state/path-id";
+              }
+              description
+                  "Reference to the path-id list key";
+          }
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf origin {
+                type union {
+                    type oc-inet:ip-address;
+                    type identityref {
+                        base oc-pol-types:INSTALL_PROTOCOL_TYPE;
+                    }
+                }
+                description
+                    "Indicates the origin of the route.  If the route is learned
+                    from a neighbor, this value is the neighbor address.  If
+                    the route was injected or redistributed from another
+                    protocol, the origin indicates the source protocol for the
+                    route.";
+            }
+
+            leaf path-id {
+                type uint32;
+                default 0;
+                description
+                    "If the route is learned from a neighbor, the path-id
+                    corresponds to the path-id for the route in the
+                    corresponding adj-rib-in-post table.  If the route is
+                    injected from another protocol, or the neighbor does not
+                    support BGP add-paths, the path-id should be set
+                    to zero, also the default value.";
+            }
+
+            leaf remote-router-id {
+                type oc-yang:dotted-quad;
+                description
+                    "A identifier for the remote network instance - typically
+                    used within associated routing protocols or signalling
+                    routing information in another network instance";
+            }
+
+            leaf best-path {
+                type boolean;
+                description
+                    "Current path was selected as the best path.";
+            }
+
+            uses rib-bgp-ext-route-annotations-state;
+            uses oc-rib-bgp:bgp-loc-rib-attr-state;
+            uses oc-rib-bgp:bgp-common-route-annotations-state;
+            uses oc-rib-bgp:bgp-loc-rib-route-annotations-state;
+          }
+          uses oc-rib-bgp:bgp-unknown-attr-top;
+          uses oc-bgp-ext:bgp-ext-attr-sets-state;
+        }
+      }
+    }
+  }
+
+  grouping rib-bgp-ext-ipv4-loc-rib-prefix-top {
+    description
+      "Top-level grouping for IPv4 routing tables for prefix";
+
+    container loc-rib-prefix {
+      config false;
+      description
+        "Container for the IPv4 BGP LOC-RIB data for prefix";
+
+      uses oc-rib-bgp:bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route {
+          key "prefix";
+
+          description
+            "List of routes in the table, keyed by the route
+            prefix, the route origin, and path-id.  The route
+            origin can be either the neighbor address from which
+            the route was learned, or the source protocol that
+            injected the route.  The path-id distinguishes routes
+            for the same prefix received from a neighbor (e.g.,
+            if add-paths is eanbled).";
+
+          leaf prefix {
+              type leafref {
+                  path "../state/prefix";
+              }
+              description
+                  "Reference to the prefix list key";
+          }
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf prefix {
+              type oc-inet:ipv4-prefix;
+              description
+                "The IPv4 prefix corresponding to the route";
+            }
+          }
+          uses rib-bgp-ext-prefix-paths-top;
+        }
+      }
+    }
+  }
+
+  grouping rib-bgp-ext-ipv6-loc-rib-prefix-top {
+    description
+      "Top-level grouping for IPv6 routing tables for prefix";
+
+    container loc-rib-prefix {
+      config false;
+      description
+        "Container for the IPv6 BGP LOC-RIB data for prefix";
+
+      uses oc-rib-bgp:bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route {
+          key "prefix";
+
+          description
+            "List of routes in the table, keyed by the route
+            prefix, the route origin, and path-id.  The route
+            origin can be either the neighbor address from which
+            the route was learned, or the source protocol that
+            injected the route.  The path-id distinguishes routes
+            for the same prefix received from a neighbor (e.g.,
+            if add-paths is eanbled).";
+
+          leaf prefix {
+              type leafref {
+                  path "../state/prefix";
+              }
+              description
+                  "Reference to the prefix list key";
+          }
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf prefix {
+              type oc-inet:ipv6-prefix;
+              description
+                "The IPv6 prefix corresponding to the route";
+            }
+          }
+          uses rib-bgp-ext-prefix-paths-top;
+        }
+      }
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol/" +
+    "oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast" {
+      description
+        "Add extended annotations for prefix based Loc-RIB for IPv4";
+
+      uses rib-bgp-ext-ipv4-loc-rib-prefix-top;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol/" +
+    "oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast" {
+      description
+        "Add extended annotations for prefix based Loc-RIB for IPv6";
+
+      uses rib-bgp-ext-ipv6-loc-rib-prefix-top;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol/" +
+    "oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-bgp-evpn-ext:l2vpn-evpn/oc-bgp-evpn-ext:loc-rib/" +
+    "oc-bgp-evpn-ext:routes/oc-bgp-evpn-ext:route/oc-bgp-evpn-ext:state" {
+      description
+        "Add best-path field to the Loc-RIB for EVPN";
+
+      leaf best-path {
+        type boolean;
+        description
+          "Current path was selected as the best path.";
+      }
+
+      leaf weight {
+        type uint16;
+        description
+          "Weight of the path.";
+      }
   }
 
 }


### PR DESCRIPTION
This pull request adds extensions to BGP model.
The changes include:
    - l2vpn evpn address family extensions to enable EVPN functionality (openconfig-bgp-evpn-ext.yang)
    - rib extensions for IPv4, IPv6 and l2vpn evpn address families. (openconfig-bgp-ext.yang, openconfig-rib-bgp-ext.yang)
    - Extensions to bgp policy. (openconifg-bgp-policy-ext.yang)

These models have been adopted by Dell, Broadcom & VmWare to enable BGP EVPN functionality and various other BGP configuration constructs.

Please review these models and provide your comments.

Thanks