### PR TITLE
Update MACsec model to include security policy

### DIFF
--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -17,10 +17,16 @@ module openconfig-macsec {
     "This module defines configuration and state data for
      MACsec IEEE Std 802.1AE-2018.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2021-01-08" {
+    description
+      "Add security-policy modes (shoud/must-secure) in MKA config.";
+    reference "0.2.1";
+  }
 
   revision "2020-05-01" {
     description
@@ -601,6 +607,24 @@ module openconfig-macsec {
       type string;
       description
         "Name of the MKA policy.";
+    }
+
+   leaf security-policy {
+      type enumeration {
+        enum SHOULD_SECURE {
+          description 
+            "Allows unencrypted traffic to flow until MKA session is
+             secured. After the MKA session is secured, Should-Secure
+             policy imposes only encrypted traffic to flow.";
+        }
+        enum MUST_SECURE {
+          description 
+            "Allows only MACsec encrypted traffic to flow. 
+             Until MKA session is not secured, traffic will be dropped.";
+        }
+      }
+      description
+        "MKA Security Policy to use";
     }
 
     leaf key-server-priority {


### PR DESCRIPTION
Added directives to specify should-secure/must-secure security policy modes in MACsec MKA. This is supported by both [Cisco](https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/security/62x/b-system-security-cg-ncs5500-62x/b-system-security-cg-ncs5500-62x_chapter_0101.html#task_40CD2BB4BAD64B0BA51E88AB1EC42143) and [Juniper](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/must-secure-edit-security-macsec.html)