### PR TITLE
Fix a typo in p2p-primary-paths

### DIFF
--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -1196,7 +1196,7 @@ submodule openconfig-mpls-te {
     description
       "Top level grouping for p2p primary paths";
 
-    container p2p-primary-path {
+    container p2p-primary-paths {
       description
         "Primary paths associated with the LSP";
 


### PR DESCRIPTION
Typically the name of a container is a plural if it holds a list inside.