### PR TITLE
Add instance-id leaf to IS-IS config container

### DIFF
--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -153,6 +153,15 @@ module openconfig-isis {
         "ISIS Instance.";
     }
 
+    leaf instance-id {
+      type uint16;
+      default 0;
+      description
+        "ISIS instance ID.";
+      reference
+        "RFC8202 IS-IS Multi-Instance";
+    }
+
     leaf-list net {
       type oc-isis-types:net;
       description


### PR DESCRIPTION
As per [RFC8202](https://tools.ietf.org/html/rfc8202), `instance-id:uint16` is used to uniquely identify an IS-IS instance. The existing key for ISIS instances is `instance:string`, which cannot be used for the instance ID TLV 7.