### PR TITLE
Fix lsp-pacing-interval description

### DIFF
--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -58,6 +58,12 @@ module openconfig-isis {
 
   oc-ext:openconfig-version "0.6.1";
 
+  revision "2021-06-21" {
+    description
+      "Fix lsp-pacing-interval description.";
+    reference "0.7.0";
+  }
+  
   revision "2021-03-17" {
     description
       "Add bfd support without augmentation.";
@@ -821,8 +827,8 @@ module openconfig-isis {
       type uint64;
       units milliseconds;
       description
-        "The interval interval in milliseconds between the
-        detection of topology change and when the SPF algorithm runs.";
+        "Time interval in milliseconds during flooding successive LSPs
+        on an interface.";
     }
   }
 


### PR DESCRIPTION
change lsp-pacing-interval description to "Time interval in milliseconds during flooding successive LSPs on an interface."