### PR TITLE
Add initial support for EVPN VXLAN Overlay Endpoint Oper Data

### DIFF
--- a/release/models/network-instance/openconfig-evpn-types.yang
+++ b/release/models/network-instance/openconfig-evpn-types.yang
@@ -7,7 +7,6 @@ module openconfig-evpn-types {
 
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-yang-types { prefix oc-yang; }
-  import openconfig-inet-types { prefix oc-inet; }
 
   // TODO:
   // Include definitions of EVPN error notifications

--- a/release/models/network-instance/openconfig-evpn-types.yang
+++ b/release/models/network-instance/openconfig-evpn-types.yang
@@ -7,6 +7,7 @@ module openconfig-evpn-types {
 
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-inet-types { prefix oc-inet; }
 
   // TODO:
   // Include definitions of EVPN error notifications

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1096,7 +1096,7 @@ module openconfig-evpn {
         type leafref{
           path '../state/peer-address';
         }
-        description "IP Address for the VTEP peer";
+        description "IP address for the VTEP peer";
         }
 
         container state {
@@ -1110,10 +1110,10 @@ module openconfig-evpn {
 
     container endpoint-vnis {
       description
-        "Top level container for state information related to layer2 and layer3
-        virtual network identifiers (L2/L3 VNIs) that are learned on the local
-        VXLAN Tunnel End Point from remote VTEPS in the default network
-        instance";
+        "Top level container for state information related to layer-2 and
+        layer-3 virtual network identifiers (L2/L3 VNIs) that are learned on
+        the local VXLAN Tunnel End Point from remote VTEPs in the default
+        network instance";
       config false;
 
       list endpoint-vni {
@@ -1173,21 +1173,21 @@ module openconfig-evpn {
     leaf control-plane-vnis {
       type string;
       description
-        "The control plan VNIs are all of the VNIs that are discovered by the
-        control plane behind this peer VTEP";
+        "The control-plane VNIs are all of the VNIs that are discovered by the
+        control-plane behind this peer VTEP";
     }
 
     leaf router-mac {
       type oc-yang:mac-address;
-      description "Mac address of the remote VTEP";
+      description "MAC address of the remote VTEP";
     }
   }
 
   grouping evpn-endpoint-vni-state {
     description
-      "Grouping for state information related layer2 and layer3 virtual network
-      identifiers (L2/L3 VNIs) that are learned on the local VXLAN Tunnel End
-      Point from remote VTEPS";
+      "Grouping for state information related layer-2 and layer-33 virtual
+      network identifiers (L2/L3 VNIs) that are learned on the local VXLAN
+      Tunnel End Point from remote VTEPs";
 
     leaf vni {
       type oc-evpn-types:evi-id;
@@ -1223,8 +1223,8 @@ module openconfig-evpn {
     leaf learning-mode {
       type oc-evpn-types:learning-mode;
       description
-        "Indicates that the learning mode for this VNI is either control plane
-        or data plane";
+        "Indicates whether the learning mode for this VNI is either
+        control-plane or data-plane";
     }
 
     leaf vni-type {
@@ -1240,7 +1240,7 @@ module openconfig-evpn {
             communication between subnets";
         }
       }
-      description "They type of virtual network identfier (L2 or L3)";
+      description "The type of virtual network identfier (L2 or L3)";
     }
 
     leaf vni-state {

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1170,13 +1170,15 @@ module openconfig-evpn {
     }
     leaf multidestination-traffic {
       type union {
-        type oc-inet:ip-address;
+        type oc-inet:ip-address {
+          description "Multicast address used for BUM traffic";
+        }
         type enumeration {
           enum STATIC_INGRESS_REPLICATION {
             description
               "Static ingress replication mode.";
           }
-          enum BGP {
+          enum BGP_INGRESS_REPLICATION {
             description
               "BGP EVPN ingress replication mode. It includes the ability to
               signal a P2MP LSP for the EVPN Inclusive Provider Tunnel

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1089,37 +1089,37 @@ module openconfig-evpn {
 
         container state {
           config false;
-           description
-             "Container for state parameters related to this VTEP peer";
-             uses evpn-endpoint-peer-state;
+            description
+              "Container for state parameters related to this VTEP peer";
+            uses evpn-endpoint-peer-state;
         }
       }
     }
 
     container endpoint-vnis {
       description
-        "Top level container for state information related to layer-2 and
-        layer-3 virtual network identifiers (L2/L3 VNIs) that are learned on
-        the local VXLAN Tunnel End Point from remote VTEPs in the default
-        network instance";
+        "Top level container for state information related to Layer 2 virtual
+        network identifiers (L2VNIs) and Layer 3 virtual network identifiers
+        (L3VNIs) that are learned on the local VXLAN Tunnel End Point from
+        remote VTEPs in the default network instance";
       config false;
 
       list endpoint-vni {
         key "vni";
-        description "List of L2 and L3 VNIs learned on the local VTEP";
+        description "List of L2VNIs and L3VNIs learned on the local VTEP";
 
         leaf vni {
           type leafref {
             path '../state/vni';
           }
-          description "VNI Identifier";
+          description "L2VNI or L3VNI Identifier";
         }
 
         container state {
           config false;
           description
-            "Container for state parameters related to this L2 or L3 VNI";
-             uses evpn-endpoint-vni-state;
+            "Container for state parameters related to this L2VNI or L3VNI";
+          uses evpn-endpoint-vni-state;
         }
       }
     }
@@ -1173,13 +1173,12 @@ module openconfig-evpn {
 
   grouping evpn-endpoint-vni-state {
     description
-      "Grouping for state information related layer-2 and layer-33 virtual
-      network identifiers (L2/L3 VNIs) that are learned on the local VXLAN
-      Tunnel End Point from remote VTEPs";
+      "Grouping for L2VNI and L3VNI state information learned on the
+      local VXLAN Tunnel End Point from remote VTEPs";
 
     leaf vni {
       type oc-evpn-types:evi-id;
-      description "VNI Identifier";
+      description "L2VNI or L3VNI Identifier";
     }
 
     leaf multidestination-traffic {
@@ -1219,16 +1218,17 @@ module openconfig-evpn {
       type enumeration {
         enum L2 {
           description
-            "This is a layer2 service VNI that is used for communication within
-            the same subnet or broadcast domain";
+            "This is a Layer 2 service virtual network identifier (L2VNI)
+            that is used for communication within the same subnet or
+            broadcast domain";
         }
         enum L3 {
           description
-            "This is a layer3 service VNI or VRF VNI that is used for
-            communication between subnets";
+            "This is a Layer 3 service virtual network identifier (L3VNI)
+            or VRF VNI that is used for communication between subnets";
         }
       }
-      description "The type of virtual network identfier (L2 or L3)";
+      description "The type of virtual network identfier";
     }
 
     leaf vni-state {
@@ -1244,7 +1244,7 @@ module openconfig-evpn {
             indicate that it is DOWN";
         }
       }
-      description "Operational state of the L2 or L3 Virtual Network Identifier";
+      description "Operational state of the L2VNI or L3VNI";
     }
 
     leaf svi-state {
@@ -1269,14 +1269,14 @@ module openconfig-evpn {
       type uint32;
       description
         "This reflects the configured VLAN or Bridge Domain that maps to this
-        Layer2 VNI in the VXLAN fabric";
+        L2VNI in the VXLAN fabric";
     }
 
     leaf l3-vrf-name {
       type string;
       description
-        "This refects the configured VRF instance that maps to this layer3
-        VNI that is used for routing between subnets in the VXLAN fabric";
+        "This refects the configured VRF instance that maps to this L3VNI
+        that is used for routing between subnets in the VXLAN fabric";
     }
 
   }

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1118,7 +1118,7 @@ module openconfig-evpn {
 
       list endpoint-vni {
         key "vni";
-        description "List of L2 and L3 VNIs learned on the local VTEP"
+        description "List of L2 and L3 VNIs learned on the local VTEP";
 
         leaf vni {
           type leafref{

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1093,10 +1093,10 @@ module openconfig-evpn {
           description "List of VTEP peers and associated state information";
 
         leaf peer-address {
-        type leafref{
-          path '../state/peer-address';
-        }
-        description "IP address for the VTEP peer";
+          type leafref {
+            path '../state/peer-address';
+          }
+          description "IP address for the VTEP peer";
         }
 
         container state {
@@ -1121,10 +1121,10 @@ module openconfig-evpn {
         description "List of L2 and L3 VNIs learned on the local VTEP";
 
         leaf vni {
-          type leafref{
+          type leafref {
             path '../state/vni';
-            }
-            description "VNI Identifier";
+          }
+          description "VNI Identifier";
         }
 
         container state {

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -55,18 +55,6 @@ module openconfig-evpn {
    reference "0.2.0";
   }
 
-  revision "2021-06-28" {
-   description
-     "Add vxlan endpoint oper data";
-   reference   "0.2.0";
-  }
-
-  revision "2020-11-24" {
-   description
-     "Initial revision";
-   reference   "0.1.0";
-  }
-
   revision "2020-11-24" {
    description
      "Initial revision.";

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1100,10 +1100,10 @@ module openconfig-evpn {
         }
 
         container state {
-         config false;
-         description
-           "Container for state parameters related to this VTEP peer";
-           uses evpn-endpoint-peer-state;
+          config false;
+           description
+             "Container for state parameters related to this VTEP peer";
+             uses evpn-endpoint-peer-state;
         }
       }
     }

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -12,6 +12,7 @@ module openconfig-evpn {
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-bgp-types { prefix oc-bgp-types; }
+  import ietf-yang-types { prefix yang; }
 
   // meta
   organization
@@ -39,13 +40,31 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2021-06-28" {
+   description
+     "Add vxlan endpoint oper data";
+   reference   "0.3.0";
+  }
 
   revision "2021-06-11" {
    description
      "Structural update for arp-proxy and
      nd-proxy.";
    reference "0.2.0";
+  }
+
+  revision "2021-06-28" {
+   description
+     "Add vxlan endpoint oper data";
+   reference   "0.2.0";
+  }
+
+  revision "2020-11-24" {
+   description
+     "Initial revision";
+   reference   "0.1.0";
   }
 
   revision "2020-11-24" {
@@ -1061,5 +1080,165 @@ module openconfig-evpn {
 
       uses evpn-vxlan-parameters-config;
     }
+
+    container endpoint-peers {
+      description "Overlay endpoint peers oper data";
+      config false;
+
+      list endpoint-peer {
+        key "peer-address";
+          description "Overlay endpoint peers oper data";
+
+        leaf peer-address {
+        type leafref{
+          path '../state/peer-address';
+        }
+        description "overlay endpoint peer ip address";
+        }
+        container state {
+         config false;
+         description
+           "State parameters relating to the overlay tunnel endpoints
+           of the network instance";
+           uses evpn-endpoint-peer-state;
+        }
+      }
+    }
+
+    container endpoint-vnis {
+      description "Overlay endpoint peers oper data";
+      config false;
+
+      list endpoint-vni {
+        key "vni";
+        description "Overlay endpoint evis oper data";
+
+        leaf vni {
+          type leafref{
+            path '../state/vni';
+            }
+            description "VNI Identifier";
+        }
+        container state {
+          config false;
+           description
+             "State parameters relating to the overlay tunnel endpoints
+             of the network instance";
+             uses evpn-endpoint-vni-state;
+        }
+      }
+    }
   }
+
+  grouping evpn-endpoint-peer-state {
+    description
+    "Grouping for VXLAN EVPN Overlay endpoint oper data";
+    leaf peer-address {
+      type oc-inet:ip-address;
+      description "VXLAN EVPN Overlay endpoint peer ip address";
+    }
+    leaf peer-state {
+      type enumeration {
+        enum UP {
+          description "VXLAN EVPN Overlay peer state is UP";
+        }
+        enum DOWN {
+          description "VXLAN EVPN Overlay peer state is DOWN";
+        }
+      }
+      description "VXLAN EVPN Overlay peer state";
+    }
+    leaf uptime {
+      type yang:timestamp;
+      description "VXLAN EVPN Overlay Peer Uptime";
+    }
+    leaf control-plane-vnis {
+      type string;
+      description "VNIs learned over the control-plane";
+    }
+    leaf router-mac {
+      type oc-yang:mac-address;
+      description "Peer Router mac-address";
+    }
+  }
+
+  grouping evpn-endpoint-vni-state {
+    description "Grouping for VXLAN EVPN Overlay endpoint to vni mapping data";
+    leaf vni {
+      type oc-evpn-types:evi-id;
+      description "VNI Identifier";
+    }
+    leaf multidestination-traffic {
+      type union {
+        type oc-inet:ip-address;
+        type enumeration {
+          enum STATIC_INGRESS_REPLICATION {
+            description
+              "Static ingress replication mode.";
+          }
+          enum BGP {
+            description
+              "BGP EVPN ingress replication mode. It includes the ability to
+              signal a P2MP LSP for the EVPN Inclusive Provider Tunnel
+              for BUM traffic";
+          }
+        }
+      }
+      description
+        "The data plane for overlays needs to handle the transport of
+         multidestination traffic. Multidestination traffic is typically
+         referred to as “BUM,” which stands for broadcast, unknown unicast,
+         or multicast. The two most common methods that can accommodate this
+         replication and transport in the underlay are IP multicast and
+         ingress replication
+         (also called head-end replication or unicast mode).";
+    }
+    leaf learning-mode {
+      type oc-evpn-types:learning-mode;
+      description "Learning mode";
+    }
+    leaf vni-type {
+      type enumeration {
+        enum L2 {
+          description "L2 VNI Type";
+        }
+        enum L3 {
+          description "L3 VNI Type";
+        }
+      }
+      description "VNI Type";
+    }
+    leaf vni-state {
+        type enumeration {
+          enum UP {
+            description "VNI state is UP";
+          }
+          enum DOWN {
+            description "VNI state is DOWN";
+          }
+        }
+        description "L2/3 VNI State";
+      }
+    leaf svi-state {
+        type enumeration {
+          enum UP {
+            description "SVI state is UP";
+          }
+          enum DOWN {
+            description "SVI state is DOWN";
+          }
+        }
+        description "SVI State used for VLAN to L3 VNI mapping";
+      }
+    leaf bridge-domain {
+        type uint32;
+        description "VLAN or BD that maps to this L2 VNI";
+      }
+
+    leaf l3-vrf-name {
+        type string;
+        description "VRF routing instance that maps to this L3 VNI";
+      }
+    }
+
 }

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -1170,9 +1170,7 @@ module openconfig-evpn {
     }
     leaf multidestination-traffic {
       type union {
-        type oc-inet:ip-address {
-          description "Multicast address used for BUM traffic";
-        }
+        type oc-evpn-types:multicast-address;
         type enumeration {
           enum STATIC_INGRESS_REPLICATION {
             description

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -12,7 +12,7 @@ module openconfig-evpn {
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-bgp-types { prefix oc-bgp-types; }
-  import ietf-yang-types { prefix yang; }
+  import openconfig-types { prefix oc-types; }
 
   // meta
   organization
@@ -1082,36 +1082,43 @@ module openconfig-evpn {
     }
 
     container endpoint-peers {
-      description "Overlay endpoint peers oper data";
+      description
+        "Top level container for state information related to peer VXLAN Tunnel
+        Endpoints(VTEPs) learned by the local VTEP in the default network
+        instance";
       config false;
 
       list endpoint-peer {
         key "peer-address";
-          description "Overlay endpoint peers oper data";
+          description "List of VTEP peers and associated state information";
 
         leaf peer-address {
         type leafref{
           path '../state/peer-address';
         }
-        description "overlay endpoint peer ip address";
+        description "IP Address for the VTEP peer";
         }
+
         container state {
          config false;
          description
-           "State parameters relating to the overlay tunnel endpoints
-           of the network instance";
+           "Container for state parameters related to this VTEP peer";
            uses evpn-endpoint-peer-state;
         }
       }
     }
 
     container endpoint-vnis {
-      description "Overlay endpoint peers oper data";
+      description
+        "Top level container for state information related to layer2 and layer3
+        virtual network identifiers (L2/L3 VNIs) that are learned on the local
+        VXLAN Tunnel End Point from remote VTEPS in the default network
+        instance";
       config false;
 
       list endpoint-vni {
         key "vni";
-        description "Overlay endpoint evis oper data";
+        description "List of L2 and L3 VNIs learned on the local VTEP"
 
         leaf vni {
           type leafref{
@@ -1119,11 +1126,11 @@ module openconfig-evpn {
             }
             description "VNI Identifier";
         }
+
         container state {
           config false;
-           description
-             "State parameters relating to the overlay tunnel endpoints
-             of the network instance";
+          description
+            "Container for state parameters related to this L2 or L3 VNI";
              uses evpn-endpoint-vni-state;
         }
       }
@@ -1132,45 +1139,64 @@ module openconfig-evpn {
 
   grouping evpn-endpoint-peer-state {
     description
-    "Grouping for VXLAN EVPN Overlay endpoint oper data";
+      "Grouping for state information related to peer VXLAN Tunnel
+      Endpoints(VTEPs) learned by the local VTEP";
+
     leaf peer-address {
       type oc-inet:ip-address;
-      description "VXLAN EVPN Overlay endpoint peer ip address";
+      description "IP address of the remote VXLAN Tunnel Endpoint peer";
     }
+
     leaf peer-state {
       type enumeration {
         enum UP {
-          description "VXLAN EVPN Overlay peer state is UP";
+          description
+            "Operational status of the remote VTEP to indicate that the peer
+            status is UP";
         }
         enum DOWN {
-          description "VXLAN EVPN Overlay peer state is DOWN";
+          description
+            "Operational status of the remote VTEP to indicate that the peer
+            status is DOWN";
         }
       }
-      description "VXLAN EVPN Overlay peer state";
+      description "State parameters related to the remote VTEP peer state";
     }
+
     leaf uptime {
-      type yang:timestamp;
-      description "VXLAN EVPN Overlay Peer Uptime";
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time elapsed relative to the moment that
+        the remote VTEP peer was discovered.";
     }
+
     leaf control-plane-vnis {
       type string;
-      description "VNIs learned over the control-plane";
+      description
+        "The control plan VNIs are all of the VNIs that are discovered by the
+        control plane behind this peer VTEP";
     }
+
     leaf router-mac {
       type oc-yang:mac-address;
-      description "Peer Router mac-address";
+      description "Mac address of the remote VTEP";
     }
   }
 
   grouping evpn-endpoint-vni-state {
-    description "Grouping for VXLAN EVPN Overlay endpoint to vni mapping data";
+    description
+      "Grouping for state information related layer2 and layer3 virtual network
+      identifiers (L2/L3 VNIs) that are learned on the local VXLAN Tunnel End
+      Point from remote VTEPS";
+
     leaf vni {
       type oc-evpn-types:evi-id;
       description "VNI Identifier";
     }
+
     leaf multidestination-traffic {
       type union {
-        type oc-evpn-types:multicast-address;
+        type oc-inet:ip-address;
         type enumeration {
           enum STATIC_INGRESS_REPLICATION {
             description
@@ -1187,58 +1213,83 @@ module openconfig-evpn {
       description
         "The data plane for overlays needs to handle the transport of
          multidestination traffic. Multidestination traffic is typically
-         referred to as “BUM,” which stands for broadcast, unknown unicast,
+         referred to as (BUM) which stands for broadcast, unknown unicast,
          or multicast. The two most common methods that can accommodate this
          replication and transport in the underlay are IP multicast and
          ingress replication
          (also called head-end replication or unicast mode).";
     }
+
     leaf learning-mode {
       type oc-evpn-types:learning-mode;
-      description "Learning mode";
+      description
+        "Indicates that the learning mode for this VNI is either control plane
+        or data plane";
     }
+
     leaf vni-type {
       type enumeration {
         enum L2 {
-          description "L2 VNI Type";
+          description
+            "This is a layer2 service VNI that is used for communication within
+            the same subnet or broadcast domain";
         }
         enum L3 {
-          description "L3 VNI Type";
+          description
+            "This is a layer3 service VNI or VRF VNI that is used for
+            communication between subnets";
         }
       }
-      description "VNI Type";
+      description "They type of virtual network identfier (L2 or L3)";
     }
+
     leaf vni-state {
-        type enumeration {
-          enum UP {
-            description "VNI state is UP";
-          }
-          enum DOWN {
-            description "VNI state is DOWN";
-          }
+      type enumeration {
+        enum UP {
+          description
+            "Operational status of the virtual network identifier (VNI) to
+            indicate that it is UP";
         }
-        description "L2/3 VNI State";
+        enum DOWN {
+          description
+            "Operational status of the virtual network identifier (VNI) to
+            indicate that it is DOWN";
+        }
       }
+      description "Operational state of the L2 or L3 Virtual Network Identifier";
+    }
+
     leaf svi-state {
-        type enumeration {
-          enum UP {
-            description "SVI state is UP";
-          }
-          enum DOWN {
-            description "SVI state is DOWN";
-          }
+      type enumeration {
+        enum UP {
+          description
+            "Operational status of the SVI mapped to the L3VNI used for routing
+            between subnets to indicate the SVI is UP";
         }
-        description "SVI State used for VLAN to L3 VNI mapping";
+        enum DOWN {
+          description
+            "Operational status of the SVI mapped to the L3VNI used for routing
+            between subnets to indicate the SVI is DOWN";
+        }
       }
+      description
+        "Operational status of the SVI mapped to the L3VNI that is used for
+        routing between subnets in the VXLAN fabric";
+    }
+
     leaf bridge-domain {
-        type uint32;
-        description "VLAN or BD that maps to this L2 VNI";
-      }
+      type uint32;
+      description
+        "This reflects the configured VLAN or Bridge Domain that maps to this
+        Layer2 VNI in the VXLAN fabric";
+    }
 
     leaf l3-vrf-name {
-        type string;
-        description "VRF routing instance that maps to this L3 VNI";
-      }
+      type string;
+      description
+        "This refects the configured VRF instance that maps to this layer3
+        VNI that is used for routing between subnets in the VXLAN fabric";
     }
 
+  }
 }


### PR DESCRIPTION
**Summary of changes:**

* Adds support for EVPN VXLAN Overlay Endpoint Oper Data
    * State of peers learned over the endpoint
    * State of VNI's learned over a peer
* Addresses whitespace issues in `openconfig-evpn.yang`.