### PR TITLE
Fix for date/time pattern statement

### DIFF
--- a/release/models/types/openconfig-yang-types.yang
+++ b/release/models/types/openconfig-yang-types.yang
@@ -32,7 +32,13 @@ module openconfig-yang-types {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
+  
+  revision "2021-06-30" {
+    description
+      "Fix date-and-time's pattern statement,to conform with RFC3339.";
+    reference "0.3.1";
+  }
 
   revision "2021-03-02" {
     description
@@ -146,21 +152,25 @@ module openconfig-yang-types {
       "A date and time, expressed in the format described in RFC3339.
       That is to say:
 
-      YYYY-MM-DDTHH:MM:SSZ+-hh:mm
+      YYYY-MM-DDTHH:MM:SSZ
+      or
+      YYYY-MM-DDTHH:MM:SS+-hh:mm
 
       where YYYY is the year, MM is the month expressed as a two-digit
       month (zero padding if required), DD is the day of the month,
       expressed as a two digit value. T is the literal character 'T',
       HH is the hour of the day expressed as a two digit number, using
       the 24-hour clock, MM is the minute of the hour expressed as a
-      two digit number. Z is the literal character 'Z', followed by a
-      timezone offset expressed in hours (hh) and minutes (mm), both
-      expressed as two digit numbers. The time offset is specified as
-      a positive or negative offset to UTC using the '+' or '-'
-      character preceding the offset.
+      two digit number, SS is the second of the minute expressed as a
+      two digit number (based on leap second rules). The time offset
+      can either be the literal character 'Z', representing UTC
+      (Coordinated Universal Time), or a timezone offset expressed in
+      hours (hh) and minutes (mm), both expressed as two digit numbers. 
+      The time offset is specified as a positive or negative offset to
+      UTC using the '+' or '-' character preceding the offset.
 
-      Optionally, fractional seconds can be expressed after the minute
-      of the hour as a decimal number of unspecified precision
+      Optionally, fractional seconds can be expressed after the second
+      of the minute as a decimal number of unspecified precision
       reflecting fractions of a second.";
     reference
       "RFC3339 - Date and Time on the Internet: Timestamps";


### PR DESCRIPTION
  * (M) release/models/types/openconfig-yang-types.yang
    - Fix date-and-time description to match RFC3339