### PR TITLE
Add initial support for L2VPN EVPN extensions for BGP RIB

### DIFF
--- a/release/models/network-instance/openconfig-evpn-types.yang
+++ b/release/models/network-instance/openconfig-evpn-types.yang
@@ -25,7 +25,13 @@ module openconfig-evpn-types {
     policy. It can be imported by modules that make use of EVPN
     attributes";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2021-06-21" {
+    description
+      "Add types needed for BGP l2vpn evpn support";
+    reference "0.2.0";
+  }
 
   revision "2021-06-16" {
     description
@@ -287,4 +293,13 @@ module openconfig-evpn-types {
       "Type of MAC address learning procedure";
   }
 
+  typedef ethernet-tag {
+    type uint32;
+    description
+      "An Ethernet Tag ID is a 32-bit field containing either a 12-bit
+       or 24-bit identifier that identifies a particular broadcast
+       domain (e.g., a VLAN) in an EVPN instance.";
+    reference
+      "RFC 7432: BGP MPLS-Based Ethernet VPN page-10";
+  }
 }

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -847,14 +847,6 @@ submodule openconfig-rib-bgp-tables {
       "Key references to support operational state structure for
       BGP EVPN type 5 routes";
 
-      leaf esi {
-        type leafref {
-          path "../state/esi";
-        }
-        description
-          "Reference to the esi list key";
-      }
-
       leaf ethernet-tag {
         type leafref {
           path "../state/ethernet-tag";
@@ -878,15 +870,6 @@ submodule openconfig-rib-bgp-tables {
         description
           "Reference to the ip-prefix list key";
       }
-
-      leaf gateway-ip-address {
-        type leafref {
-          path "../state/gateway-ip-address";
-        }
-        description
-          "Reference to the gateway-ip-address list key";
-      }
-
   }
 
   grouping bgp-evpn-type-five-state {
@@ -894,7 +877,7 @@ submodule openconfig-rib-bgp-tables {
     container type-five-ip-prefix {
       description "Top level container for type five l2vpn evpn routes";
       list type-five-route {
-        key "esi ethernet-tag ip-prefix-length ip-prefix gateway-ip-address";
+        key "ethernet-tag ip-prefix-length ip-prefix";
         description
           "List of evpn ip prefix routes";
 

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -684,7 +684,7 @@ submodule openconfig-rib-bgp-tables {
 
           uses bgp-loc-rib-attr-state;
           uses bgp-loc-rib-route-annotations-state;
-         }
+        }
 
          uses bgp-evpn-route-path-common-state;
       }
@@ -804,7 +804,7 @@ submodule openconfig-rib-bgp-tables {
 
           uses bgp-loc-rib-attr-state;
           uses bgp-loc-rib-route-annotations-state;
-         }
+        }
 
          uses bgp-evpn-route-path-type2-state;
       }
@@ -895,7 +895,7 @@ submodule openconfig-rib-bgp-tables {
 
           uses bgp-loc-rib-attr-state;
           uses bgp-loc-rib-route-annotations-state;
-         }
+        }
 
          uses bgp-evpn-route-path-common-state;
       }
@@ -983,7 +983,7 @@ submodule openconfig-rib-bgp-tables {
           uses bgp-loc-rib-attr-state;
           uses bgp-loc-rib-route-annotations-state;
 
-         }
+        }
 
          uses bgp-evpn-route-path-common-state;
       }
@@ -1070,7 +1070,7 @@ submodule openconfig-rib-bgp-tables {
 
           uses bgp-loc-rib-attr-state;
           uses bgp-loc-rib-route-annotations-state;
-         }
+        }
 
          uses bgp-evpn-route-path-type5-state;
       }

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -324,12 +324,12 @@ submodule openconfig-rib-bgp-tables {
 
   grouping l2vpn-evpn-loc-rib-top {
     description
-      "Top-level grouping for l2vpn evpn routing tables";
+      "Top-level grouping for L2VPN EVPN routing tables";
 
     container loc-rib {
       config false;
       description
-        "Container for the l2vpn evpn BGP LOC-RIB data";
+        "Container for the L2VPN EVPN BGP LOC-RIB data";
 
       uses bgp-common-table-attrs-top;
 
@@ -347,15 +347,17 @@ submodule openconfig-rib-bgp-tables {
               path "../state/route-distinguisher";
             }
             description
-              "Reference to the rd list key";
+              "An EVPN instance requires a Route Distinguisher (RD) that is
+              unique per MAC-VRF";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
 
           container state {
-            description "Top level containern for l2vpn evpn RDs";
+            description "Top level container for L2VPN EVPN RDs";
             leaf route-distinguisher {
               type oc-ni-types:route-distinguisher;
               description
-                "Route distinguisher for local and remote l2vpn evpn routes";
+                "Route Distinguisher for all supported EVPN route types";
             }
           }
           uses bgp-evpn-type-one-state;
@@ -403,125 +405,235 @@ submodule openconfig-rib-bgp-tables {
     }
   }
 
-  grouping bgp-evpn-route-path-state {
+  grouping bgp-evpn-route-path-common-state {
     description
-      "BGP l2vpn evpn route-type path state info grouping";
+      "Grouping for BGP L2VPN EVPN route-type common path state information";
 
     container paths {
-      description "List of BGP paths attributes for this route";
+      description "List of BGP path attributes for this route";
+
       list path {
         description "List of paths";
         key "peer-ip peer-path-id source-route-distinguisher source-address-family";
 
-        leaf peer-ip {
-          type leafref {
-            path "../state/peer-ip";
-          }
-          description
-            "Reference to the peer-ip key";
-        }
-
-        leaf peer-path-id {
-          type leafref {
-            path "../state/peer-path-id";
-          }
-          description
-            "Reference to the peer-path-id key";
-        }
-
-        leaf source-route-distinguisher {
-          type leafref {
-            path "../state/source-route-distinguisher";
-          }
-          description
-            "Reference to the source-route-distinguisher key";
-        }
-
-        leaf source-address-family {
-          type leafref {
-            path "../state/source-address-family";
-          }
-          description
-            "Reference to the source-address-family key";
-        }
+        uses bgp-evpn-route-path-lefref-common;
 
         container state {
           description "BGP path attributes for this route";
 
-          leaf peer-ip {
-            type oc-inet:ip-address;
-            description "Peer IP information";
-          }
-
-          leaf peer-path-id {
-            type uint32;
-            description "Peer path identifier";
-          }
-
-          leaf source-route-distinguisher {
-            type oc-ni-types:route-distinguisher;
-            description
-              "The source route distinguisher is the remote RD source of the
-              imported route";
-          }
-
-          leaf source-address-family {
-            type identityref {
-              base oc-bgpt:AFI_SAFI_TYPE;
-            }
-            description "The source address-family of the imported route";
-          }
-
-          leaf-list advertised-to-peer {
-            type oc-inet:ip-address;
-            description "List of peers to which this path is advertised";
-          }
-
-          leaf label {
-            type string;
-            description 
-              "MPLS Label field used for route attributes";
-            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
-          }
-
-          leaf label2 {
-            type string;
-            description "MPLS Label2 field used for route attributes";
-            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
-          }
-
-          leaf bestpath {
-            type boolean;
-            description "Marked as bestpath";
-          }
-
-          leaf multipath {
-            type boolean;
-            description "Marked as multipath";
-          }
-
-          leaf backup {
-            type boolean;
-            description "Marked as backup";
-          }
-
-          uses bgp-loc-rib-l2vpn-evpn-attr-refs;
+          uses bgp-evpn-route-path-keys-common;
+          uses bgp-evpn-route-path-attributes-common;
         }
+
+        uses bgp-unknown-attr-top;
+
       }
     }
+  }
+
+  grouping bgp-evpn-route-path-type2-state {
+    description
+      "Grouping for BGP L2VPN EVPN route-type path state information for
+      route type 2";
+
+    container paths {
+      description "List of BGP path attributes for this route";
+
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
+
+        uses bgp-evpn-route-path-lefref-common;
+
+        container state {
+          description "BGP path attributes for this route";
+
+          uses bgp-evpn-route-path-keys-common;
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          uses bgp-evpn-route-path-attributes-common;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-route-path-type5-state {
+    description
+      "Grouping for BGP L2VPN EVPN route-type path state information for
+      route type 5";
+
+    container paths {
+      description "List of BGP path attributes for this route";
+
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
+
+        uses bgp-evpn-route-path-lefref-common;
+
+        container state {
+          description "BGP path attributes for this route";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          leaf gateway-ip-address {
+            type oc-inet:ip-prefix;
+            description
+              "The gateway-ip-address for the route";
+          }
+
+          uses bgp-evpn-route-path-keys-common;
+          uses bgp-evpn-route-path-attributes-common;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-route-path-lefref-common {
+    description "Common BGP L2VPN EVPN Path Leaf References";
+
+    leaf peer-ip {
+      type leafref {
+        path "../state/peer-ip";
+      }
+      description "The source peer ip address of the imported route";
+    }
+
+    leaf peer-path-id {
+      type leafref {
+        path "../state/peer-path-id";
+      }
+      description "The source peer path id of the imported route";
+    }
+
+    leaf source-route-distinguisher {
+      type leafref {
+        path "../state/source-route-distinguisher";
+      }
+      description
+        "The source route distinguisher is the remote RD source of the
+        imported route";
+    }
+
+    leaf source-address-family {
+      type leafref {
+        path "../state/source-address-family";
+      }
+      description "The source address-family of the imported route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-keys-common {
+    description "Common BGP L2VPN EVPN Path Keys";
+
+    leaf peer-ip {
+      type oc-inet:ip-address;
+      description
+        "The source peer ip address of the imported route";
+    }
+
+    leaf peer-path-id {
+      type uint32;
+      description "The source peer path id of the imported route";
+    }
+
+    leaf source-route-distinguisher {
+      type oc-ni-types:route-distinguisher;
+      description
+        "The source route distinguisher is the remote RD source of the
+        imported route";
+    }
+
+    leaf source-address-family {
+      type identityref {
+        base oc-bgpt:AFI_SAFI_TYPE;
+      }
+      description "The source address-family of the imported route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-attributes-common {
+    description "Common BGP L2VPN EVPN Path Attributes";
+
+    leaf-list advertised-to-peer {
+      type oc-inet:ip-address;
+      description "List of peers to which this path is advertised";
+    }
+
+    leaf label {
+      type string;
+      description
+        "MPLS Label field used for route attributes";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf label2 {
+      type string;
+      description "MPLS Label2 field used for route attributes";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf bestpath {
+      type boolean;
+      description
+        "BGP can receive multiple paths to the same destination. This
+        parameter indicates that this path is the bestpath to install
+        in the IP routing table and use for traffic forwarding";
+    }
+
+    leaf multipath {
+      type boolean;
+      description
+        "BGP can use multiple paths to reach a destination allowing
+        BGP to load-balance traffic. This parameter indicates that this
+        path is marked as multipath";
+    }
+
+    leaf backup {
+      type boolean;
+      description "BGP path marked as a backup path";
+    }
+
+    uses bgp-common-route-annotations-state;
+    uses bgp-loc-rib-l2vpn-evpn-attr-refs;
   }
 
   grouping bgp-evpn-type-one-key-refs {
     description
       "Key references to support operational state structure for
-      BGP EVPN type 1 routes";
+      BGP EVPN Ethernet Auto-discovery routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Segment
+      Identifier and Ethernet Tag ID are considered to be part of the prefix in
+      the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
 
       leaf esi {
         type leafref {
           path "../state/esi";
         }
         description
-          "Reference to the esi list key";
+          "The Ethernet Segment Identifier (ESI) is a unique non-zero
+          identifier that identifies an Ethernet segment";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf ethernet-tag {
@@ -529,45 +641,52 @@ submodule openconfig-rib-bgp-tables {
           path "../state/ethernet-tag";
         }
         description
-          "Reference to the esi list key";
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
   }
 
   grouping bgp-evpn-type-one-state {
-    description "Grouping for type one l2vpn evpn routes";
+    description "Grouping for BGP EVPN Ethernet Auto-discovery routes";
     container type-one-ethernet-auto-discovery {
-      description "Top level container for type one l2vpn evpn routes";
+      description "Top level container BGP EVPN Ethernet Auto-discovery routes";
       list type-one-route {
         key "esi ethernet-tag";
         description
-          "List of evpn ethernet auto discovery routes";
+          "List of BGP EVPN Ethernet Auto-discovery routes
+
+          For the purpose of BGP route key processing, only the Ethernet Segment
+          Identifier and Ethernet Tag ID are considered to be part of the prefix in
+          the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
         uses bgp-evpn-type-one-key-refs;
 
         container state {
           description
-            "Operational state data for type1 evpn route entries
-            in the BGP LOC-RIB";
+            "Operational state data for BGP EVPN Ethernet Auto-discovery route
+            entries in the BGP LOC-RIB";
 
           leaf esi {
             type oc-evpn-types:esi;
             description
-              "The ethernet segment identifier for local and remote routes";
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
           }
 
           leaf ethernet-tag {
             type oc-evpn-types:ethernet-tag;
             description
-              "The ethernet tag for the route";
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
           }
 
           uses bgp-loc-rib-attr-state;
-          uses bgp-common-route-annotations-state;
           uses bgp-loc-rib-route-annotations-state;
          }
 
-         uses bgp-evpn-route-path-state;
-         uses bgp-unknown-attr-top;
+         uses bgp-evpn-route-path-common-state;
       }
     }
   }
@@ -575,22 +694,21 @@ submodule openconfig-rib-bgp-tables {
   grouping bgp-evpn-type-two-key-refs {
     description
       "Key references to support operational state structure for
-      BGP EVPN type 2 routes";
+      MAC_IP Advertisement routes.
 
-      leaf esi {
-        type leafref {
-          path "../state/esi";
-        }
-        description
-          "Reference to the esi list key";
-      }
+      For the purpose of BGP route key processing, only the Ethernet Tag ID,
+      MAC Address Length, MAC Address, IP Address Length, and IP Address fields
+      are considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
       leaf ethernet-tag {
         type leafref {
           path "../state/ethernet-tag";
         }
         description
-          "Reference to the esi list key";
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf mac-address {
@@ -598,7 +716,9 @@ submodule openconfig-rib-bgp-tables {
           path "../state/mac-address";
         }
         description
-          "Reference to the mac-address list key";
+          "The PEs forward packets that they receive based on the destination
+          MAC address";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf mac-length {
@@ -606,7 +726,8 @@ submodule openconfig-rib-bgp-tables {
           path "../state/mac-length";
         }
         description
-          "Reference to the mac-length list key";
+          "The MAC Address Length for the MAC address defined in mac-address";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf ip-prefix {
@@ -614,7 +735,7 @@ submodule openconfig-rib-bgp-tables {
           path "../state/ip-prefix";
         }
         description
-          "Reference to the ip-prefix list key";
+          "The IPv4 or IPv6 address carried in a MAC_IP Advertisement route";
       }
 
       leaf ip-length {
@@ -622,84 +743,92 @@ submodule openconfig-rib-bgp-tables {
           path "../state/ip-length";
         }
         description
-          "Reference to the ip-length list key";
+          "The IPv4 or IPv6 address prefix length for the address defined in
+          ip-prefix";
       }
   }
 
   grouping bgp-evpn-type-two-state {
-    description "Grouping for type two l2vpn evpn routes";
+    description "Grouping for MAC_IP Advertisement L2VPN EVPN routes";
     container type-two-mac-ip-advertisement {
-      description "Top level container for type two l2vpn evpn routes";
+      description
+        "Top level container for MAC_IP Advertisement L2VPN EVPN routes";
       list type-two-route {
-        key "esi ethernet-tag mac-address mac-length ip-prefix ip-length";
+        key "ethernet-tag mac-address mac-length ip-prefix ip-length";
         description
-          "List of evpn mac/ip advertisement routes";
+          "List of MAC_IP Advertisement L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Tag ID,
+          MAC Address Length, MAC Address, IP Address Length, and IP Address fields
+          are considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
         uses bgp-evpn-type-two-key-refs;
 
         container state {
           description
-            "Operational state data for type2 evpn route entries
-            in the BGP LOC-RIB";
-
-          leaf esi {
-            type oc-evpn-types:esi;
-            description
-              "The ethernet segment identifier for the route";
-          }
+            "Operational state data MAC_IP Advertisement L2VPN EVPN route
+            entries in the BGP LOC-RIB";
 
           leaf ethernet-tag {
             type oc-evpn-types:ethernet-tag;
             description
-              "The ethernet tag for the route";
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
           }
 
           leaf mac-address {
             type yang:mac-address;
             description
-              "The mac-address for the route";
+              "The MAC address that is learned on a PE from a CE that is
+              connected to it or learned from other PEs";
           }
 
           leaf mac-length {
             type uint32;
             description
-              "The mac-address length for the route";
+              "The MAC address length for the mac-address";
           }
 
           leaf ip-prefix {
             type oc-inet:ip-prefix;
             description
-              "The ip-prefix for the route";
+              "The IP address for end-host reachability information";
           }
 
           leaf ip-length {
             type uint32;
             description
-              "The ip-prefix length for the route";
+              "The ip-prefix length for the IP address specified by ip-prefix";
           }
 
           uses bgp-loc-rib-attr-state;
-          uses bgp-common-route-annotations-state;
           uses bgp-loc-rib-route-annotations-state;
          }
 
-         uses bgp-evpn-route-path-state;
-         uses bgp-unknown-attr-top;
+         uses bgp-evpn-route-path-type2-state;
       }
     }
   }
 
   grouping bgp-evpn-type-three-key-refs {
     description
-      "Key references to support operational state structure for
-      BGP EVPN type 3 routes";
+      "Key references to support operational state structure for Inclusive
+      Multicast Ethernet Tag routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Tag ID,
+      IP Address Length, and Originating Router's IP Address fields are
+      considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
       leaf ethernet-tag {
         type leafref {
           path "../state/ethernet-tag";
         }
         description
-          "Reference to the esi list key";
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf originating-router-ip {
@@ -720,32 +849,42 @@ submodule openconfig-rib-bgp-tables {
   }
 
   grouping bgp-evpn-type-three-state {
-    description "Grouping for type three l2vpn evpn routes";
+    description
+      "Grouping for Inclusive Multicast Ethernet Tag L2VPN EVPN routes";
     container type-three-inclusive-multicast-ethernet-tag {
-      description "Top level container for type three l2vpn evpn routes";
+      description
+        "Top level container for Inclusive Multicast Ethernet Tag L2VPN EVPN
+        routes";
 
       list type-three-route {
         key "ethernet-tag originating-router-ip originator-ip-length";
         description
-          "List of evpn inclusive multicast ethernet tag routes";
+          "List of Inclusive Multicast Ethernet Tag L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Tag ID,
+          IP Address Length, and Originating Router's IP Address fields are
+          considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
         uses bgp-evpn-type-three-key-refs;
 
         container state {
           description
-            "Operational state data for type3 evpn route entries
-            in the BGP LOC-RIB";
+            "Operational state data for Inclusive Multicast Ethernet Tag L2VPN
+            EVPN entries in the BGP LOC-RIB";
 
           leaf ethernet-tag {
             type oc-evpn-types:ethernet-tag;
             description
-              "The ethernet tag for the route";
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
           }
 
           leaf originating-router-ip {
             type oc-inet:ip-prefix;
             description
-              "The originating router ip";
+              "The Originating Router's IP Address";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
 
           leaf originator-ip-length {
@@ -755,27 +894,32 @@ submodule openconfig-rib-bgp-tables {
           }
 
           uses bgp-loc-rib-attr-state;
-          uses bgp-common-route-annotations-state;
           uses bgp-loc-rib-route-annotations-state;
          }
 
-         uses bgp-evpn-route-path-state;
-         uses bgp-unknown-attr-top;
+         uses bgp-evpn-route-path-common-state;
       }
     }
   }
 
   grouping bgp-evpn-type-four-key-refs {
     description
-      "Key references to support operational state structure for
-      BGP EVPN type 4 routes";
+      "Key references to support operational state structure for Ethernet
+      Segment routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Segment ID,
+      IP Address Length, and Originating Router's IP Address fields are
+      considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
       leaf esi {
         type leafref {
           path "../state/esi";
         }
         description
-          "Reference to the esi list key";
+          "The Ethernet Segment Identifier (ESI) is a unique non-zero
+          identifier that identifies an Ethernet segment";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf originating-router-ip {
@@ -796,26 +940,32 @@ submodule openconfig-rib-bgp-tables {
   }
 
   grouping bgp-evpn-type-four-state {
-    description "Grouping for type four l2vpn evpn routes";
+    description "Grouping for Ethernet Segment L2VPN EVPN routes";
     container type-four-ethernet-segment {
-      description "Top level container for type four l2vpn evpn routes";
+      description "Top level container for Ethernet Segment L2VPN EVPN routes";
 
       list type-four-route {
         key "esi originating-router-ip originator-ip-length";
         description
-          "List of evpn ethernet segment routes";
+          "List of Ethernet Segment L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Segment ID,
+          IP Address Length, and Originating Router's IP Address fields are
+          considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
 
         uses bgp-evpn-type-four-key-refs;
 
         container state {
           description
-            "Operational state data for type4 evpn route entries
-            in the BGP LOC-RIB";
+            "Operational state data for Ethernet Segment L2VPN EVPN route
+            entries in the BGP LOC-RIB";
 
           leaf esi {
             type oc-evpn-types:esi;
             description
-              "The ethernet segment identifier for the route";
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
           }
 
           leaf originating-router-ip {
@@ -831,28 +981,33 @@ submodule openconfig-rib-bgp-tables {
           }
 
           uses bgp-loc-rib-attr-state;
-          uses bgp-common-route-annotations-state;
           uses bgp-loc-rib-route-annotations-state;
 
          }
 
-         uses bgp-evpn-route-path-state;
-         uses bgp-unknown-attr-top;
+         uses bgp-evpn-route-path-common-state;
       }
     }
   }
 
   grouping bgp-evpn-type-five-key-refs {
     description
-      "Key references to support operational state structure for
-      BGP EVPN type 5 routes";
+      "Key references to support operational state structure for IP Prefix
+      Advertisement routes.
+
+      For the purpose of BGP route key processing, only The RD, Ethernet Tag ID,
+      IP prefix length, and IP prefix are part of the route key used by BGP to
+      compare routes";
+    reference "RFC9136: IP Prefix Advertisement in Ethernet VPN (EVPN)";
 
       leaf ethernet-tag {
         type leafref {
           path "../state/ethernet-tag";
         }
         description
-          "Reference to the ethernet-tag list key";
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
       }
 
       leaf ip-prefix-length {
@@ -873,31 +1028,32 @@ submodule openconfig-rib-bgp-tables {
   }
 
   grouping bgp-evpn-type-five-state {
-    description "Grouping for type five l2vpn evpn routes";
+    description "Grouping for IP Prefix Advertisement L2VPN EVPN routes";
     container type-five-ip-prefix {
-      description "Top level container for type five l2vpn evpn routes";
+      description
+        "Top level container for IP Prefix Advertisement L2VPN EVPN routes";
       list type-five-route {
         key "ethernet-tag ip-prefix-length ip-prefix";
         description
-          "List of evpn ip prefix routes";
+          "List of IP Prefix Advertisement L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only The RD, Ethernet Tag ID,
+          IP prefix length, and IP prefix are part of the route key used by BGP to
+          compare routes";
+        reference "RFC9136: IP Prefix Advertisement in Ethernet VPN (EVPN)";
 
         uses bgp-evpn-type-five-key-refs;
 
         container state {
           description
-            "Operational state data for type5 evpn route entries
-            in the BGP LOC-RIB";
-
-          leaf esi {
-            type oc-evpn-types:esi;
-            description
-              "The ethernet segment identifier for the route";
-          }
+            "Operational state data for IP Prefix Advertisement L2VPN EVPN
+            route entries in the BGP LOC-RIB";
 
           leaf ethernet-tag {
             type oc-evpn-types:ethernet-tag;
             description
-              "The ethernet tag for the route";
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
           }
 
           leaf ip-prefix-length {
@@ -912,19 +1068,11 @@ submodule openconfig-rib-bgp-tables {
               "The ip-prefix for the route";
           }
 
-          leaf gateway-ip-address {
-            type oc-inet:ip-prefix;
-            description
-              "The gateway-ip-address for the route";
-          }
-
           uses bgp-loc-rib-attr-state;
-          uses bgp-common-route-annotations-state;
           uses bgp-loc-rib-route-annotations-state;
          }
 
-         uses bgp-evpn-route-path-state;
-         uses bgp-unknown-attr-top;
+         uses bgp-evpn-route-path-type5-state;
       }
     }
   }
@@ -968,9 +1116,6 @@ submodule openconfig-rib-bgp-tables {
             received from the neighbor before any local input
             policy rules or filters have been applied.  This can
             be considered the 'raw' updates from the neighbor.";
-
-          /* uses ipv4-adj-rib-common; */
-
         }
 
         container adj-rib-in-post {
@@ -978,8 +1123,6 @@ submodule openconfig-rib-bgp-tables {
             "Per-neighbor table containing the paths received from
             the neighbor that are eligible for best-path selection
             after local input policy rules have been applied.";
-
-          /* uses ipv4-adj-rib-in-post; */
         }
 
         container adj-rib-out-pre {
@@ -987,8 +1130,6 @@ submodule openconfig-rib-bgp-tables {
             "Per-neighbor table containing paths eligble for
             sending (advertising) to the neighbor before output
             policy rules have been applied";
-
-          /* uses ipv4-adj-rib-common; */
         }
 
         container adj-rib-out-post {
@@ -996,8 +1137,6 @@ submodule openconfig-rib-bgp-tables {
             "Per-neighbor table containing paths eligble for
             sending (advertising) to the neighbor after output
             policy rules have been applied";
-
-          /* uses ipv4-adj-rib-common; */
         }
       }
     }

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -13,6 +13,7 @@ submodule openconfig-rib-bgp-tables {
 
   import openconfig-network-instance-types { prefix oc-ni-types; }
   import openconfig-evpn-types { prefix oc-evpn-types; }
+  import openconfig-bgp-types { prefix oc-bgpt; }
 
   include openconfig-rib-bgp-attributes;
   include openconfig-rib-bgp-shared-attributes;
@@ -410,7 +411,7 @@ submodule openconfig-rib-bgp-tables {
       description "List of BGP paths attributes for this route";
       list path {
         description "List of paths";
-        key "peer-ip peer-path-id";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
 
         leaf peer-ip {
           type leafref {
@@ -428,6 +429,22 @@ submodule openconfig-rib-bgp-tables {
             "Reference to the peer-path-id key";
         }
 
+        leaf source-route-distinguisher {
+          type leafref {
+            path "../state/source-route-distinguisher";
+          }
+          description
+            "Reference to the source-route-distinguisher key";
+        }
+
+        leaf source-address-family {
+          type leafref {
+            path "../state/source-address-family";
+          }
+          description
+            "Reference to the source-address-family key";
+        }
+
         container state {
           description "BGP path attributes for this route";
 
@@ -435,42 +452,59 @@ submodule openconfig-rib-bgp-tables {
             type oc-inet:ip-address;
             description "Peer IP information";
           }
+
           leaf peer-path-id {
             type uint32;
             description "Peer path identifier";
           }
+
+          leaf source-route-distinguisher {
+            type oc-ni-types:route-distinguisher;
+            description
+              "The source route distinguisher is the remote RD source of the
+              imported route";
+          }
+
+          leaf source-address-family {
+            type identityref {
+              base oc-bgpt:AFI_SAFI_TYPE;
+            }
+            description "The source address-family of the imported route";
+          }
+
           leaf-list advertised-to-peer {
             type oc-inet:ip-address;
             description "List of peers to which this path is advertised";
           }
+
           leaf label {
             type string;
             description 
               "MPLS Label field used for route attributes";
             reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
+
           leaf label2 {
             type string;
             description "MPLS Label2 field used for route attributes";
             reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
+
           leaf bestpath {
             type boolean;
             description "Marked as bestpath";
           }
+
           leaf multipath {
             type boolean;
             description "Marked as multipath";
           }
+
           leaf backup {
             type boolean;
             description "Marked as backup";
           }
-          leaf source-route-distinguisher {
-            type oc-ni-types:route-distinguisher;
-            description
-              "The source route distinguisher";
-          }
+
           uses bgp-loc-rib-l2vpn-evpn-attr-refs;
         }
       }
@@ -813,20 +847,12 @@ submodule openconfig-rib-bgp-tables {
       "Key references to support operational state structure for
       BGP EVPN type 5 routes";
 
-      leaf ip-prefix {
+      leaf esi {
         type leafref {
-          path "../state/ip-prefix";
+          path "../state/esi";
         }
         description
-          "Reference to the ip-prefix list key";
-      }
-
-      leaf ip-length {
-        type leafref {
-          path "../state/ip-length";
-        }
-        description
-          "Reference to the ip-length list key";
+          "Reference to the esi list key";
       }
 
       leaf ethernet-tag {
@@ -836,6 +862,31 @@ submodule openconfig-rib-bgp-tables {
         description
           "Reference to the ethernet-tag list key";
       }
+
+      leaf ip-prefix-length {
+        type leafref {
+          path "../state/ip-prefix-length";
+        }
+        description
+          "Reference to the ip-prefix-length list key";
+      }
+
+      leaf ip-prefix {
+        type leafref {
+          path "../state/ip-prefix";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+
+      leaf gateway-ip-address {
+        type leafref {
+          path "../state/gateway-ip-address";
+        }
+        description
+          "Reference to the gateway-ip-address list key";
+      }
+
   }
 
   grouping bgp-evpn-type-five-state {
@@ -843,7 +894,7 @@ submodule openconfig-rib-bgp-tables {
     container type-five-ip-prefix {
       description "Top level container for type five l2vpn evpn routes";
       list type-five-route {
-        key "ip-prefix ip-length ethernet-tag";
+        key "esi ethernet-tag ip-prefix-length ip-prefix gateway-ip-address";
         description
           "List of evpn ip prefix routes";
 
@@ -854,22 +905,34 @@ submodule openconfig-rib-bgp-tables {
             "Operational state data for type5 evpn route entries
             in the BGP LOC-RIB";
 
-          leaf ip-prefix {
-            type oc-inet:ip-prefix;
+          leaf esi {
+            type oc-evpn-types:esi;
             description
-              "The ip-prefix for the route";
-          }
-
-          leaf ip-length {
-            type string;
-            description
-              "The ip-prefix length for the route";
+              "The ethernet segment identifier for the route";
           }
 
           leaf ethernet-tag {
             type oc-evpn-types:ethernet-tag;
             description
               "The ethernet tag for the route";
+          }
+
+          leaf ip-prefix-length {
+            type string;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          leaf ip-prefix {
+            type oc-inet:ip-prefix;
+            description
+              "The ip-prefix for the route";
+          }
+
+          leaf gateway-ip-address {
+            type oc-inet:ip-prefix;
+            description
+              "The gateway-ip-address for the route";
           }
 
           uses bgp-loc-rib-attr-state;

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -354,7 +354,7 @@ submodule openconfig-rib-bgp-tables {
             leaf route-distinguisher {
               type oc-ni-types:route-distinguisher;
               description
-                "The route distinguisher";
+                "Route distinguisher for local and remote l2vpn evpn routes";
             }
           }
           uses bgp-evpn-type-one-state;
@@ -445,11 +445,14 @@ submodule openconfig-rib-bgp-tables {
           }
           leaf label {
             type string;
-            description "Label info";
+            description 
+              "MPLS Label field used for route attributes";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
           leaf label2 {
             type string;
-            description "Label2 info";
+            description "MPLS Label2 field used for route attributes";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
           }
           leaf bestpath {
             type boolean;
@@ -515,7 +518,7 @@ submodule openconfig-rib-bgp-tables {
           leaf esi {
             type oc-evpn-types:esi;
             description
-              "The ethernet segment identifier for the route";
+              "The ethernet segment identifier for local and remote routes";
           }
 
           leaf ethernet-tag {

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -9,6 +9,10 @@ submodule openconfig-rib-bgp-tables {
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-policy-types { prefix oc-pol-types; }
+  import ietf-yang-types { prefix yang; }
+
+  import openconfig-network-instance-types { prefix oc-ni-types; }
+  import openconfig-evpn-types { prefix oc-evpn-types; }
 
   include openconfig-rib-bgp-attributes;
   include openconfig-rib-bgp-shared-attributes;
@@ -25,7 +29,13 @@ submodule openconfig-rib-bgp-tables {
     "This submodule contains structural data definitions for
     BGP routing tables.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
 
   revision "2019-10-15" {
     description
@@ -306,6 +316,639 @@ submodule openconfig-rib-bgp-tables {
           }
 
           uses bgp-unknown-attr-top;
+        }
+      }
+    }
+  }
+
+  grouping l2vpn-evpn-loc-rib-top {
+    description
+      "Top-level grouping for l2vpn evpn routing tables";
+
+    container loc-rib {
+      config false;
+      description
+        "Container for the l2vpn evpn BGP LOC-RIB data";
+
+      uses bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route-distinguisher {
+          description "List of route distinguishers";
+          key "route-distinguisher";
+
+          leaf route-distinguisher {
+            type leafref {
+              path "../state/route-distinguisher";
+            }
+            description
+              "Reference to the rd list key";
+          }
+
+          container state {
+            description "Top level containern for l2vpn evpn RDs";
+            leaf route-distinguisher {
+              type oc-ni-types:route-distinguisher;
+              description
+                "The route distinguisher";
+            }
+          }
+          uses bgp-evpn-type-one-state;
+          uses bgp-evpn-type-two-state;
+          uses bgp-evpn-type-three-state;
+          uses bgp-evpn-type-four-state;
+          uses bgp-evpn-type-five-state;
+        }
+      }
+    }
+  }
+
+  grouping bgp-loc-rib-l2vpn-evpn-attr-refs {
+    description
+      "Definitions of common references to attribute sets for
+      multiple AFI-SAFIs for LOC-RIB tables";
+
+    leaf attr-index {
+      type leafref {
+        path "../../../../../../../../../../../../attr-sets/attr-set/" +
+          "state/index";
+      }
+      description
+        "Reference to the common attribute group for the
+        route";
+    }
+
+    leaf community-index {
+      type leafref {
+        path "../../../../../../../../../../../../communities/community/" +
+          "state/index";
+      }
+      description
+        "Reference to the community attribute for the route";
+    }
+
+    leaf ext-community-index {
+      type leafref {
+        path "../../../../../../../../../../../../ext-communities/" +
+          "ext-community/state/index";
+      }
+      description
+        "Reference to the extended community attribute for the
+        route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-state {
+    description
+      "BGP l2vpn evpn route-type path state info grouping";
+
+    container paths {
+      description "List of BGP paths attributes for this route";
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id";
+
+        leaf peer-ip {
+          type leafref {
+            path "../state/peer-ip";
+          }
+          description
+            "Reference to the peer-ip key";
+        }
+
+        leaf peer-path-id {
+          type leafref {
+            path "../state/peer-path-id";
+          }
+          description
+            "Reference to the peer-path-id key";
+        }
+
+        container state {
+          description "BGP path attributes for this route";
+
+          leaf peer-ip {
+            type oc-inet:ip-address;
+            description "Peer IP information";
+          }
+          leaf peer-path-id {
+            type uint32;
+            description "Peer path identifier";
+          }
+          leaf-list advertised-to-peer {
+            type oc-inet:ip-address;
+            description "List of peers to which this path is advertised";
+          }
+          leaf label {
+            type string;
+            description "Label info";
+          }
+          leaf label2 {
+            type string;
+            description "Label2 info";
+          }
+          leaf bestpath {
+            type boolean;
+            description "Marked as bestpath";
+          }
+          leaf multipath {
+            type boolean;
+            description "Marked as multipath";
+          }
+          leaf backup {
+            type boolean;
+            description "Marked as backup";
+          }
+          leaf source-route-distinguisher {
+            type oc-ni-types:route-distinguisher;
+            description
+              "The source route distinguisher";
+          }
+          uses bgp-loc-rib-l2vpn-evpn-attr-refs;
+        }
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-one-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN type 1 routes";
+
+      leaf esi {
+        type leafref {
+          path "../state/esi";
+        }
+        description
+          "Reference to the esi list key";
+      }
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "Reference to the esi list key";
+      }
+  }
+
+  grouping bgp-evpn-type-one-state {
+    description "Grouping for type one l2vpn evpn routes";
+    container type-one-ethernet-auto-discovery {
+      description "Top level container for type one l2vpn evpn routes";
+      list type-one-route {
+        key "esi ethernet-tag";
+        description
+          "List of evpn ethernet auto discovery routes";
+
+        uses bgp-evpn-type-one-key-refs;
+
+        container state {
+          description
+            "Operational state data for type1 evpn route entries
+            in the BGP LOC-RIB";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The ethernet segment identifier for the route";
+          }
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The ethernet tag for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-common-route-annotations-state;
+          uses bgp-loc-rib-route-annotations-state;
+         }
+
+         uses bgp-evpn-route-path-state;
+         uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-two-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN type 2 routes";
+
+      leaf esi {
+        type leafref {
+          path "../state/esi";
+        }
+        description
+          "Reference to the esi list key";
+      }
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "Reference to the esi list key";
+      }
+
+      leaf mac-address {
+        type leafref {
+          path "../state/mac-address";
+        }
+        description
+          "Reference to the mac-address list key";
+      }
+
+      leaf mac-length {
+        type leafref {
+          path "../state/mac-length";
+        }
+        description
+          "Reference to the mac-length list key";
+      }
+
+      leaf ip-prefix {
+        type leafref {
+          path "../state/ip-prefix";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+
+      leaf ip-length {
+        type leafref {
+          path "../state/ip-length";
+        }
+        description
+          "Reference to the ip-length list key";
+      }
+  }
+
+  grouping bgp-evpn-type-two-state {
+    description "Grouping for type two l2vpn evpn routes";
+    container type-two-mac-ip-advertisement {
+      description "Top level container for type two l2vpn evpn routes";
+      list type-two-route {
+        key "esi ethernet-tag mac-address mac-length ip-prefix ip-length";
+        description
+          "List of evpn mac/ip advertisement routes";
+
+        uses bgp-evpn-type-two-key-refs;
+
+        container state {
+          description
+            "Operational state data for type2 evpn route entries
+            in the BGP LOC-RIB";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The ethernet segment identifier for the route";
+          }
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The ethernet tag for the route";
+          }
+
+          leaf mac-address {
+            type yang:mac-address;
+            description
+              "The mac-address for the route";
+          }
+
+          leaf mac-length {
+            type uint32;
+            description
+              "The mac-address length for the route";
+          }
+
+          leaf ip-prefix {
+            type oc-inet:ip-prefix;
+            description
+              "The ip-prefix for the route";
+          }
+
+          leaf ip-length {
+            type uint32;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-common-route-annotations-state;
+          uses bgp-loc-rib-route-annotations-state;
+         }
+
+         uses bgp-evpn-route-path-state;
+         uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-three-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN type 3 routes";
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "Reference to the esi list key";
+      }
+
+      leaf originating-router-ip {
+        type leafref {
+          path "../state/originating-router-ip";
+        }
+        description
+          "Reference to the originating-router-ip list key";
+      }
+
+      leaf originator-ip-length {
+        type leafref {
+          path "../state/originator-ip-length";
+        }
+        description
+          "Reference to the originating router ip length list key";
+      }
+  }
+
+  grouping bgp-evpn-type-three-state {
+    description "Grouping for type three l2vpn evpn routes";
+    container type-three-inclusive-multicast-ethernet-tag {
+      description "Top level container for type three l2vpn evpn routes";
+
+      list type-three-route {
+        key "ethernet-tag originating-router-ip originator-ip-length";
+        description
+          "List of evpn inclusive multicast ethernet tag routes";
+
+        uses bgp-evpn-type-three-key-refs;
+
+        container state {
+          description
+            "Operational state data for type3 evpn route entries
+            in the BGP LOC-RIB";
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The ethernet tag for the route";
+          }
+
+          leaf originating-router-ip {
+            type oc-inet:ip-prefix;
+            description
+              "The originating router ip";
+          }
+
+          leaf originator-ip-length {
+            type uint32;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-common-route-annotations-state;
+          uses bgp-loc-rib-route-annotations-state;
+         }
+
+         uses bgp-evpn-route-path-state;
+         uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-four-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN type 4 routes";
+
+      leaf esi {
+        type leafref {
+          path "../state/esi";
+        }
+        description
+          "Reference to the esi list key";
+      }
+
+      leaf originating-router-ip {
+        type leafref {
+          path "../state/originating-router-ip";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+
+      leaf originator-ip-length {
+        type leafref {
+          path "../state/originator-ip-length";
+        }
+        description
+          "Reference to the ip-length list key";
+      }
+  }
+
+  grouping bgp-evpn-type-four-state {
+    description "Grouping for type four l2vpn evpn routes";
+    container type-four-ethernet-segment {
+      description "Top level container for type four l2vpn evpn routes";
+
+      list type-four-route {
+        key "esi originating-router-ip originator-ip-length";
+        description
+          "List of evpn ethernet segment routes";
+
+        uses bgp-evpn-type-four-key-refs;
+
+        container state {
+          description
+            "Operational state data for type4 evpn route entries
+            in the BGP LOC-RIB";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The ethernet segment identifier for the route";
+          }
+
+          leaf originating-router-ip {
+            type oc-inet:ip-prefix;
+            description
+              "The originating router ip";
+          }
+
+          leaf originator-ip-length {
+            type uint32;
+            description
+              "The originating router ip length";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-common-route-annotations-state;
+          uses bgp-loc-rib-route-annotations-state;
+
+         }
+
+         uses bgp-evpn-route-path-state;
+         uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-five-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN type 5 routes";
+
+      leaf ip-prefix {
+        type leafref {
+          path "../state/ip-prefix";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+
+      leaf ip-length {
+        type leafref {
+          path "../state/ip-length";
+        }
+        description
+          "Reference to the ip-length list key";
+      }
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "Reference to the ethernet-tag list key";
+      }
+  }
+
+  grouping bgp-evpn-type-five-state {
+    description "Grouping for type five l2vpn evpn routes";
+    container type-five-ip-prefix {
+      description "Top level container for type five l2vpn evpn routes";
+      list type-five-route {
+        key "ip-prefix ip-length ethernet-tag";
+        description
+          "List of evpn ip prefix routes";
+
+        uses bgp-evpn-type-five-key-refs;
+
+        container state {
+          description
+            "Operational state data for type5 evpn route entries
+            in the BGP LOC-RIB";
+
+          leaf ip-prefix {
+            type oc-inet:ip-prefix;
+            description
+              "The ip-prefix for the route";
+          }
+
+          leaf ip-length {
+            type string;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The ethernet tag for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-common-route-annotations-state;
+          uses bgp-loc-rib-route-annotations-state;
+         }
+
+         uses bgp-evpn-route-path-state;
+         uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping l2vpn-evpn-adj-rib-top {
+    description
+      "Top-level grouping for L2VPN-EVPN Adj-RIB table";
+
+    container neighbors {
+      config false;
+      description
+        "Enclosing container for neighbor list";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "List of neighbors (peers) of the local BGP speaker";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for each neighbor BGP Adj-RIB";
+
+          leaf neighbor-address {
+            type oc-inet:ip-address;
+            description
+              "IP address of the BGP neighbor or peer";
+          }
+        }
+
+        container adj-rib-in-pre {
+          description
+            "Per-neighbor table containing the NLRI updates
+            received from the neighbor before any local input
+            policy rules or filters have been applied.  This can
+            be considered the 'raw' updates from the neighbor.";
+
+          /* uses ipv4-adj-rib-common; */
+
+        }
+
+        container adj-rib-in-post {
+          description
+            "Per-neighbor table containing the paths received from
+            the neighbor that are eligible for best-path selection
+            after local input policy rules have been applied.";
+
+          /* uses ipv4-adj-rib-in-post; */
+        }
+
+        container adj-rib-out-pre {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor before output
+            policy rules have been applied";
+
+          /* uses ipv4-adj-rib-common; */
+        }
+
+        container adj-rib-out-post {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor after output
+            policy rules have been applied";
+
+          /* uses ipv4-adj-rib-common; */
         }
       }
     }

--- a/release/models/rib/openconfig-rib-bgp.yang
+++ b/release/models/rib/openconfig-rib-bgp.yang
@@ -67,7 +67,13 @@ module openconfig-rib-bgp {
     eligible for sending (advertising) to the neighbor after output
     policy rules have been applied.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
 
   revision "2019-10-15" {
     description
@@ -221,6 +227,19 @@ module openconfig-rib-bgp {
 
             uses ipvX-srte-policy-locrib-top;
             uses ipvX-srte-policy-adjrib-top;
+          }
+
+          container l2vpn-evpn {
+            when "../afi-safi-name = 'oc-bgpt:L2VPN_EVPN'" {
+              description
+                "Include this container for l2vpn evpn route-types";
+            }
+            description
+              "Routing tables for l2vpn evpn -- active when the
+              afi-safi name is l2vpn-evpn";
+
+            uses l2vpn-evpn-loc-rib-top;
+            uses l2vpn-evpn-adj-rib-top;
           }
         }
       }


### PR DESCRIPTION
**Summary:**

* Add extensions for l2vpn evpn support in the BGP RIB.  Route types 1-5
* Fix white space issues in `openconfig-evpn-types.yang`

NOTE: This update adds the containers for neighbors but only the local rib `loc-rib` container is modeled.  Once we settle on the structure for the local rib container then we can make the updates to the neighbors container.