### PR TITLE
NHG-ID and NH-ID space management

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,12 +22,12 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.6.1";
 
   revision "2021-07-15" {
     description
       "NHG-ID and NH-ID space management.";
-    reference "0.7.0";
+    reference "0.6.1";
   }
 
   revision "2020-11-06" {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -120,6 +120,16 @@ submodule openconfig-aft-common {
             "Operational state parameters relating to the AFT
             next-hop entry";
 
+          leaf config-nh-index {
+            type uint64;
+            description
+              "In some systems it may not be possible to retain the
+              nexthop index configured by a client. This will help
+              the client in creating an association/mapping between
+              original index pushed by the client and the index
+              extracted as a key in next-hop AFT list.";
+          }
+
           uses aft-common-entry-nexthop-state;
           uses aft-labeled-entry-state;
         }
@@ -297,6 +307,17 @@ submodule openconfig-aft-common {
           config false;
           description
             "Operational state parameters relating to next-hop-groups.";
+
+          leaf config-nhg-id {
+            type uint64;
+            description
+              "In some systems it may not be possible to retain the
+              nexthop-group id configured by a client. This will help
+              the client in creating an association/mapping between
+              original id pushed by the client and the id extracted
+              as a key in next-hop-group AFT list.";
+          }
+
           uses aft-nhg-state;
         }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,7 +22,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.6.1";
+  }
 
   revision "2020-11-06" {
     description


### PR DESCRIPTION
In some systems NHG & NH ID generation is internal so it would
result in mismatch between index pushed by the client and index
created by the system.

Adding a new leaf in the next-hop-group & next-hop AFT entry to
represent the client published value. This helps the client to
create an association between configured & extracted index.