### PR TITLE
Add identities for P4RT and gRIBI.

### DIFF
--- a/release/models/gribi/.spec.yml
+++ b/release/models/gribi/.spec.yml
@@ -1,0 +1,6 @@
+- name: openconfig-gribi
+  docs:
+    - yang/gribi/openconfig-gribi.yang
+  build:
+    - yang/gribi/openconfig-gribi.yang
+  run-ci: true

--- a/release/models/gribi/openconfig-gribi.yang
+++ b/release/models/gribi/openconfig-gribi.yang
@@ -1,0 +1,39 @@
+module openconfig-gribi {
+  yang-version "1";
+
+  prefix "oc-gribi";
+
+  namespace "http://openconfig.net/yang/gribi";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system-grpc { prefix oc-grpc; }
+
+  organization
+    "OpenConfig Working Group";
+
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module defines a set of exdtensions that provide gRIBI (the gRPC
+    RIB Interface) specific extensions to the OpenConfig data models.
+    Specifically, the parameters for the configuration of the service, and
+    configuration and state are added.
+
+    The gRIBI protobufs and documentation are published at
+    https://github.com/openconfig/gribi.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2021-04-06 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GRIBI {
+    base "oc-grpc:GRPC_SERVICE";
+    description
+      "gRIBI: gRPC Routing Information Base Interface";
+  }
+}

--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -25,12 +25,24 @@ module openconfig-p4rt {
     The P4RT protocol specification is linkde from https://p4.org/specs/
     under the P4Runtime heading.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision 2021-07-20 {
+    description
+      "Add identity for P4RT as a gRPC service.";
+    reference "0.2.0";
+  }
 
   revision 2021-04-06 {
     description
       "Initial revision.";
     reference "0.1.0";
+  }
+
+  identity P4RT {
+    base "oc-grpc:GRPC_SERVICE";
+    description
+      "P4RT: P4 Runtime (P4RT) Service.";
   }
 
   grouping p4rt-interface-config {

--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -8,6 +8,7 @@ module openconfig-p4rt {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-platform { prefix oc-platform; }
+  import openconfig-system-grpc { prefix oc-grpc; }
 
   organization
     "OpenConfig Working Group";


### PR DESCRIPTION
```
 * (A) gribi/{.spec.yml,openconfig-gribi.yang}
  - Add gRIBI identity to allow gRIBI daemon configuration.
 * (M) p4rt/openconfig-p4rt.yang
  - Add P4RT identity to allow P4RT daemon configuration.
```

PR to be upstreamed following public comments.