### PR TITLE
Add protobuf-metadata annotation.

### DIFF
--- a/release/models/extensions/.spec.yml
+++ b/release/models/extensions/.spec.yml
@@ -8,5 +8,5 @@
   docs:
     - yang/extensions/openconfig-metadata.yang
   build:
-    - yang/extensions/openconfig-metdata.yang
+    - yang/extensions/openconfig-metadata.yang
   run-ci: true

--- a/release/models/extensions/.spec.yml
+++ b/release/models/extensions/.spec.yml
@@ -4,3 +4,9 @@
   build:
     - yang/extensions/openconfig-codegen-extensions.yang
   run-ci: true
+- name: openconfig-metadata
+  docs:
+    - yang/extensions/openconfig-metadata.yang
+  build:
+    - yang/extensions/openconfig-metdata.yang
+  run-ci: true

--- a/release/models/extensions/openconfig-metadata.yang
+++ b/release/models/extensions/openconfig-metadata.yang
@@ -1,0 +1,48 @@
+module openconfig-metadata {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/openconfig-metadata";
+  prefix "oc-metadata";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import ietf-yang-metadata { prefix ietf-md; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines metadata types that are defined by
+    the OpenConfig group.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2020-08-06 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  ietf-md:annotation protobuf-metadata {
+    type binary {
+      length "0..1048000";
+    }
+    description
+      "A binary marshalled protobuf message, with a size that does not exceed
+      1MiB containing metadata related to the element of the data tree at which
+      the metadata annotation is used.
+
+      It is expected that this metadata can be both written and read by a
+      client - and that the value is persistent across system restarts.
+
+      A client using this metadata extension should ensure that it is able
+      to unmarshal its contents successfully. It is suggested that the
+      payload should be a protobuf.Any message, which has corresponding
+      type information such that information as to the intended structure
+      can be retrieved by any reader.";
+  }
+}

--- a/third_party/ietf/ietf-yang-metadata.yang
+++ b/third_party/ietf/ietf-yang-metadata.yang
@@ -1,0 +1,84 @@
+module ietf-yang-metadata {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-metadata";
+
+  prefix "md";
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Lou Berger
+               <mailto:lberger@labn.net>
+
+     WG Chair: Kent Watsen
+               <mailto:kwatsen@juniper.net>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+
+  description
+    "This YANG module defines an 'extension' statement that allows
+     for defining metadata annotations.
+
+     Copyright (c) 2016 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7952
+     (http://www.rfc-editor.org/info/rfc7952); see the RFC itself
+     for full legal notices.";
+
+  revision 2016-08-05 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7952: Defining and Using Metadata with YANG";
+  }
+
+  extension annotation {
+    argument name;
+    description
+      "This extension allows for defining metadata annotations in
+       YANG modules.  The 'md:annotation' statement can appear only
+       at the top level of a YANG module or submodule, i.e., it
+       becomes a new alternative in the ABNF production rule for
+       'body-stmts' (Section 14 in RFC 7950).
+
+       The argument of the 'md:annotation' statement defines the name
+       of the annotation.  Syntactically, it is a YANG identifier as
+       defined in Section 6.2 of RFC 7950.
+
+       An annotation defined with this 'extension' statement inherits
+       the namespace and other context from the YANG module in which
+       it is defined.
+
+       The data type of the annotation value is specified in the same
+       way as for a leaf data node using the 'type' statement.
+
+       The semantics of the annotation and other documentation can be
+       specified using the following standard YANG substatements (all
+       are optional): 'description', 'if-feature', 'reference',
+       'status', and 'units'.
+
+       A server announces support for a particular annotation by
+       including the module in which the annotation is defined among
+       the advertised YANG modules, e.g., in a NETCONF <hello>
+       message or in the YANG library (RFC 7950).  The annotation can
+       then be attached to any instance of a data node defined in any
+       YANG module that is advertised by the server.
+
+       XML encoding and JSON encoding of annotations are defined in
+       RFC 7952.";
+  }
+}


### PR DESCRIPTION
```
 * (A) release/models/extensions/openconfig-metadata.yang
  - Add an annotation that can be used to store binary-marshalled
    protobuf contents within a YANG data tree.
 * (A) third_party/ietf/ietf-yang-metadata.yang
  - Import the YANG metadata annotation module from IETF. This
    module is vendored and subject to the IETF licensing.
```
