### PR TITLE
Support referencing a non-local network-instance in PF action.

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -260,7 +260,7 @@ submodule openconfig-pf-forwarding-policies {
 
     leaf network-instance {
       type leafref {
-        // this must be an absolute reference to allow another NHG to be
+        // this must be an absolute reference to allow another NI to be
         // referenced.
         path "/network-instances/network-instance/config/name";
       }

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,14 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
 
   revision "2021-05-19" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -253,12 +253,9 @@ submodule openconfig-pf-forwarding-policies {
 
     leaf network-instance {
       type leafref {
-
-        // We are at:
-        // $NIROOT/policy-forwarding/policies/
-        // policy/rules/rule/action/config/
-        // network-instance
-        path "../../../../../../../../config/name";
+        // this must be an absolute reference to allow another NHG to be
+        // referenced.
+        path "/network-instances/network-instance/config/name";
       }
       description
         "When this leaf is set, packets matching the match criteria

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,14 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
 
   revision "2021-05-19" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,14 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
 
   revision "2021-05-19" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -81,7 +81,14 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
 
   revision "2021-05-19" {
     description


### PR DESCRIPTION
```
  * (M)yang/policy-forwarding/openconfig-pf-forwarding-policies.yang
  * (M)yang/policy-forwarding/openconfig-pf-interfaces.yang
  * (M)yang/policy-forwarding/openconfig-pf-path-groups.yang
  * (M)yang/policy-forwarding/openconfig-policy-forwarding.yang
   - Fix a reference in the policy-forwarding module where the
     network-instance reference was relative such that it allowed only
     the local network-instance's name to be referenced. Make this an
     absolute reference.
```
