### PR TITLE
Add ip-address-zoned union type for link-local neighbor addresses

### DIFF
--- a/release/models/types/openconfig-inet-types.yang
+++ b/release/models/types/openconfig-inet-types.yang
@@ -31,7 +31,14 @@ module openconfig-inet-types {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.4.2";
+
+  revision "2021-08-17" {
+    description
+      "Add ip-address-zoned typedef as a union between ipv4-address-zoned
+      and ipv6-address-zoned types.";
+    reference "0.4.2";
+  }
 
   revision "2021-07-14" {
     description
@@ -271,6 +278,16 @@ module openconfig-inet-types {
     }
     description
       "An IPv4 or IPv6 address with no prefix specified.";
+  }
+
+  typedef ip-address-zoned {
+    type union {
+      type ipv4-address-zoned;
+      type ipv6-address-zoned;
+    }
+    description
+      "An IPv4 or IPv6 address with no prefix specified and an optional
+      zone index.";
   }
 
   typedef ip-prefix {


### PR DESCRIPTION
Similar to the existing typedef for ip-address, this new typedef
provides a union between existing ipv4-address-zoned and
ipv6-address-zoned types that are used by link-local peering.

Currently systems such as Arista's EOS support link-local peering.
In particular when dealing with BGP IPv6 link-local peering, the current
neighbor-address key is incompatible as it requires an ip-address type.
With this new union typedef, it may be possible to update the
neighbor-address key for BGP peer information to use this new
"ip-address-zoned" key instead to allow supporting link-local peers.
This change should be backwards compatible as it simply relaxes the
restrictions on the key type.