### PR TITLE
Drop Lookup-aggregte Type

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -714,7 +714,7 @@ module openconfig-platform-pipeline-counters {
         due to DF bit.";
     }
 
-    leaf lookup-aggregte {
+    leaf lookup-aggregate {
       type oc-yang:counter64;
       description
         "Packets dropped due to aggregate lookup drop counters - this counter

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2021-10-05" {
+    description
+      "Fixed typo for aggregte field";
+    reference "0.1.1";
+  }
 
   revision "2020-07-31" {
     description


### PR DESCRIPTION
Is the leaf name a typo? Should it be "lookup-aggregate"?