### PR TITLE
Add alarm leaves, and threshold configuration.

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -72,7 +72,8 @@ module openconfig-platform-pipeline-counters {
   revision "2020-10-16" {
     description
       "Update pipeline error counters to allow for multiple errors
-      per block.";
+      per block.
+      Add alarms for lookup utilisation and lookup next-hop utilisation.";
     reference "0.2.0";
   }
 
@@ -482,6 +483,15 @@ module openconfig-platform-pipeline-counters {
         "The integrated-circuit lookup subsystem block utilization percentage.";
     }
 
+    leaf lookup-utilization-alarm {
+      type boolean;
+      description
+        "The integrated-circuit lookup subsystem has exceeded the threshold that
+        is set for it by the system. In the case of configurable threshold values
+        the threshold value is set within the /system/thresholds hierarchy with
+        the IC_LOOKUP_MEMORY threshold type.";
+    }
+
     uses pipeline-packets-common;
 
     leaf lookup-memory {
@@ -510,6 +520,15 @@ module openconfig-platform-pipeline-counters {
       units bytes;
       description
         "The amount of nexthops memory used in the lookup subsystem.";
+    }
+
+    leaf nexthop-memory-alarm {
+      type boolean;
+      description
+        "The integrated-circuit lookup system's next-hop memory has exceeded the
+        threshold that is set for it by the system. In the case of configurable
+        threshold values, the threshold value is set within the /system/thresholds
+        hierarchy with the IC_LOOKUP_NEXTHOP threshold type.";
     }
 
     leaf acl-memory-total-entries {

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -46,7 +46,14 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.13.0";
+  oc-ext:openconfig-version "0.14.0";
+
+  revision "2021-10-16" {
+    description
+      "Add a threshold configuration container to allow for thresholds
+      to be generically set across elements of the system.";
+    reference "0.14.0";
+  }
 
   revision "2021-07-20" {
     description
@@ -1122,6 +1129,79 @@ module openconfig-system {
     }
   }
 
+  grouping thresholds-top {
+    description
+      "Grouping containing top-level configuration of thresholds
+      in the system.";
+
+    container thresholds {
+      description
+        "Surrounding container for the thresholds that are configured on
+        the system.";
+
+      list threshold {
+        key "type";
+
+        description
+          "A threshold that is configured against a particular type of
+          parameters on the system. The type of threshold is uniquely
+          identified by an enumerated value that stores a subset of known
+          resources that should be alerted on.";
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "A reference to the type of the threshold.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to a threshold on the system.";
+          uses threshold-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to a threshold on the system.";
+          uses threshold-config;
+        }
+      }
+    }
+  }
+
+  grouping threshold-config {
+    description
+      "Configuration parameters relating to a particular threshold on the system.";
+
+    leaf type {
+      type enumeration {
+        enum IC_LOOKUP_MEMORY {
+          description
+            "The threshold relates to the integrated circuit lookup subsystem's memory.
+            The parameters specified here apply to the lookup memory data reported by
+            each INTEGRATED_CIRCUIT component within the /components/component hierarchy.";
+        }
+        enum IC_LOOKUP_NEXTHOP {
+          description
+            "The threshold reates to the integrated circuit lookup subsystem's next-hop
+            memory. The parameters specified here apply to the next-hop memory data reported
+            by each INTEGRATED_CIRCUIT component within the /components/component hierarchy.";
+        }
+      }
+      description
+        "The type of the threshold that is being applied.";
+    }
+
+    leaf percentage {
+      type oc-types:percentage;
+      description
+        "The percentage at which the threshold is triggered.";
+    }
+  }
+
   grouping system-top {
     description
       "Top level system data containers";
@@ -1159,6 +1239,7 @@ module openconfig-system {
       uses oc-alarms:alarms-top;
       uses oc-messages:messages-top;
       uses oc-license:license-top;
+      uses thresholds-top;
     }
   }
 


### PR DESCRIPTION
# Support thresholding for resources in the system, fix pipeline errors.

## Establishing contextual alarms in the model

Currently, the `/components/component` model specifies certain parameters that there is a requirement to alert on. The `/system/alarms` hierarchy provides a generic mechanism to raise such alarms, but this does not provide the context that the alarm is raised within.

This PR suggests three changes:

* Add specific `-alarm` leaves to the relevant `/components/component` hierarchy elements to allow a system to raise an alarm within the context of the component. This ensures that a consumer is able to take the specific alert and use this to trigger an action - rather than needing to parse a generic alarm from `/system/alarms` and determine what the action is based on this free-form input.
  * Note that this change does not ask to deprecate `/system/alarms` but rather establishes a pattern for applying these alarms through the wider hierarchy.
* Adds a threshold configuration for these alarms to the `/system/thresholds` container, this allows for thresholds to be configured with a known type without needing to know the exact `/components` layout of the device (for example, every possible integrated circuit, or fan).

A discussion that is needed here is whether the thresholding should be done at a device-level, or whether this is something that would be better implemented off-device.

* Implementing a threshold on-device means that a consumer could just subscribe to the `-alarm` leaf in the context that they are interested (e.g., lookup utilisation) and not need to be aware of the wider subscription.
  * This is also a positive of having the alarm be in context, as today, a subscriber that **only** cares about lookup utilisation much subscribe to the generic `/system/alarms` container.
* Equally, the subscriber could just subscribe to the very specific leaf that it was interested in, and have its own thresholding value stored.

There seem to be pros and cons of each. This PR seeks to open that discussion - along with surveying where different implementations sit today.

## Mapping to vendor implementations

### Cisco IOS XE/XR

TLDR: XE and XR supports configurable thresholds for some resources. 

* XE:
  * Example taken: TCAM threshold alarm ([docs](https://www.cisco.com/c/en/us/td/docs/routers/asr903/software/guide/tcam-threshold-config-xe-3s-asr903-book/nt-tcam.html#task_777E99665BE842AE8ECA212CFA2D5F82))
  * `platform tcam-threshold enable all <%>` allows all TCAMs across the system to alert at `<%>` percent utilisation. This would correspond to a related alarm within this `/components/component/integrated-circuit` hierarchy. This change suggests to be more granular, and provide a breakdown based on what the table in question is being used for (e.g., lookup, or ACL).
* XR:
  * Example taken: TCAM utilisation.
  * `show prm server tcam summary ...` allows the breakdown of TCAM utilisation across different components to be shown, this breaks down to the subsets of the IC that the `/components/component/integrated-circuit` model describes. When these resources are exceeded, alarms are raised of the form `pfilter_ea[292]: %PKT_INFRA-FEA_DLL-3-TCAM_ERR : TCAM create region error: 'prm_server' detected the 'resource not available' condition 'TCAM resource exhausted.'`
  * The PM threshold monitoring allows for thresholds to be configured ([docs](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-monitoring/73x/b-system-monitoring-cg-cisco8k-73x/implementing_performance_management.html#concept_o5z_hdg_p3b)).


### Arista EOS

TLDR: Arista supports the alarms specified, but and support configurable thresholds today.

* `sh hardware capacity` shows breakdowns of the hardware capacity that is available on each platform. The proposal of the integrated-circuit model is to aggregate some of these. ([docs](https://eos.arista.com/understanding-table-sizes-7050x/))
* Threshold alarms are raised against utilisation of these resources, which would correspond to those that are proposed here (e.g., `host` routes would be aggregated to the next-hop threshold alarm).
* `hardware capacity alert table Host threshold 80` allows configuration for particular alarms today.

### Juniper JUNOS

JUNOS supports some thresholding, e.g., `edit system services resource monitor`. This currently does not seem as granular as might be suggested in this PR.

### Nokia SROS

SROS supports flexibly configured thresholds.

Nokia SROS supports defining arbitrary thresholds through `config>system>threshold` for example:

```
config>system>thresholds# memory-use-alarm rising-threshold
50000000 falling-threshold 45999999 interval 500 both startup-alarm
either
```

## Code changes

```
 * (M) yang/platform/openconfig-platform-pipeline-counters.yang
  - various fixes (to be proposed in public), including adding support
    for >1 error simultaneously within a block.
  - add contextual alarm leaves.
 * (M) yang/system/openconfig-system.yang
  - add support for configurable thresholds for system alarms.
```

