### PR TITLE
Remove 'exclude-filter' from telemetry model

### DIFF
--- a/release/models/telemetry/openconfig-telemetry.yang
+++ b/release/models/telemetry/openconfig-telemetry.yang
@@ -22,7 +22,13 @@ module openconfig-telemetry {
     "Data model which creates the configuration for the telemetry
      systems and functions on the device.";
 
-  oc-ext:openconfig-version "0.5.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of legacy exclude-filter leaf.";
+    reference "1.0.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -507,14 +513,6 @@ module openconfig-telemetry {
         description
           "Path to a section of operational state of interest
            (the sensor).";
-      }
-
-      leaf exclude-filter {
-        type string;
-        description
-          "Filter to exclude certain values out of the state
-           values";
-          //May not be necessary. Could remove.
       }
   }
 


### PR DESCRIPTION
* Remnants from original YANG subscribe RPC that did not carry over to
  gNMI so no support for dynamic subscriptions
* No definition of filter language for opaque string value w/ marking
  for possible removal added some time back
