### PR TITLE
Remove top-level /bgp

### DIFF
--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -60,7 +60,13 @@ module openconfig-bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  oc-ext:openconfig-version "6.1.1";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
 
   revision "2021-06-16" {
     description
@@ -194,7 +200,5 @@ module openconfig-bgp {
       uses oc-bgprib:bgp-rib-top;
     }
   }
-
-  uses bgp-top;
 
 }


### PR DESCRIPTION
* /bgp has been re-rooted under /network-instances for a few years with
  no intention to support standalone at the top-level
* This causes confusion for support and deviations are necessary for
  various implementations
