### PR TITLE
Field to enable EXTENDED_NEXTHOP_ENCODING negotiation

### DIFF
--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -144,6 +144,14 @@ submodule openconfig-bgp-neighbor {
           that this leaf is set to false, the BGP session should be
           ceased.";
     }
+
+    leaf extended-nexthop-enabled {
+        type boolean;
+        default false;
+        description
+          "Whether support for RFC 5549 is enabled and the
+          EXTENDED_NEXTHOP_ENCODING capability can be negotiated."
+    }
   }
 
   grouping bgp-neighbor-use-multiple-paths {


### PR DESCRIPTION
We would like to support forwarding of IPv4 routes with IPv6 next
hops (RFC 5549). Support generally needs to be enabled explicitly, and
this commit provides a flag with which to do so.