### PR TITLE
adds extended next-hop encoding config/state for BGP

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -476,6 +476,7 @@ submodule openconfig-bgp-common-multiprotocol {
       // configuration options that are specific to IPv4 unicast
       uses bgp-common-mp-afi-safi-extended-next-hop-encoding-config;
     }
+
     container state {
       config false;
       description

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description
@@ -151,6 +157,20 @@ submodule openconfig-bgp-common-multiprotocol {
     }
   }
 
+  grouping bgp-common-mp-afi-safi-extended-next-hop-encoding-config {
+    description
+      "BGP extended next-hop encoding parameters that apply on a per-AFI-SAFI
+      basis";
+
+    leaf extended-next-hop-encoding {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether extended next-hop encoding is enabled for
+        this AFI-SAFI";
+    }
+  }
+
   grouping bgp-common-mp-afi-safi-config {
     description
       "Configuration parameters used for all BGP AFI-SAFIs";
@@ -206,11 +226,7 @@ submodule openconfig-bgp-common-multiprotocol {
       }
 
       description "IPv4 unicast configuration options";
-
-      // include common IPv[46] unicast options
-      uses bgp-common-mp-ipv4-ipv6-unicast-common;
-
-      // placeholder for IPv4 unicast  specific configuration
+      uses bgp-common-mp-ipv4-unicast-common;
     }
   }
 
@@ -226,12 +242,7 @@ submodule openconfig-bgp-common-multiprotocol {
       }
 
       description "IPv6 unicast configuration options";
-
-      // include common IPv[46] unicast options
-      uses bgp-common-mp-ipv4-ipv6-unicast-common;
-
-      // placeholder for IPv6 unicast specific configuration
-      // options
+      uses bgp-common-mp-ipv6-unicast-common;
     }
   }
 
@@ -449,10 +460,34 @@ submodule openconfig-bgp-common-multiprotocol {
     }
   }
 
-  grouping bgp-common-mp-ipv4-ipv6-unicast-common {
+  grouping bgp-common-mp-ipv4-unicast-common {
     description
-      "Common configuration that is applicable for IPv4 and IPv6
-      unicast";
+      "Configuration that is applicable for IPv4 unicast";
+
+    // include common afi-safi options.
+    uses bgp-common-mp-all-afi-safi-common;
+
+    container config {
+      description
+        "Configuration parameters for IPv4 unicast AFI-SAFI options";
+      // configuration options that are common to IPv[46] unicast
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+
+      // configuration options that are specific to IPv4 unicast
+      uses bgp-common-mp-afi-safi-extended-next-hop-encoding-config;
+    }
+    container state {
+      config false;
+      description
+        "State information for IPv4 parameters";
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+      uses bgp-common-mp-afi-safi-extended-next-hop-encoding-config;
+    }
+  }
+
+  grouping bgp-common-mp-ipv6-unicast-common {
+    description
+      "Configuration that is applicable for IPv6 unicast";
 
     // include common afi-safi options.
     uses bgp-common-mp-all-afi-safi-common;
@@ -460,15 +495,16 @@ submodule openconfig-bgp-common-multiprotocol {
     // configuration options that are specific to IPv[46] unicast
     container config {
       description
-        "Configuration parameters for common IPv4 and IPv6 unicast
-        AFI-SAFI options";
+        "Configuration parameters for IPv6 unicast AFI-SAFI options";
+      // configuration options that are common to IPv[46] unicast
       uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+
+      // placholder for IPv6 unicast specific options
     }
     container state {
       config false;
       description
-        "State information for common IPv4 and IPv6 unicast
-        parameters";
+        "State information for IPv6 unicast parameters";
       uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
     }
   }

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description
@@ -65,7 +71,6 @@ submodule openconfig-bgp-common-structure {
       "Normalise timestamp units to nanoseconds.";
     reference "6.0.0";
   }
-
 
   revision "2019-05-28" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -60,7 +60,13 @@ module openconfig-bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  oc-ext:openconfig-version "9.0.0";
+  oc-ext:openconfig-version "9.1.0";
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
 
   revision "2022-04-26" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -191,7 +191,7 @@ module openconfig-bgp {
     reference "2.0.1";
   }
 
-    // OpenConfig specific extensions for module metadata.
+  // OpenConfig specific extensions for module metadata.
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";


### PR DESCRIPTION
adds support for RFC5549 extended next-hop encoding
 * (M) bgp/openconfig-bgp-common-multiprotocol.yang
  - slightly restructures the mp-ipv4-ipv6-unicast-common groupings to allow for
    the addition of the extended-next-hop-encoding leaf in the top-level IPv4
    unicast config/state containers. 