### PR TITLE
Add atomic annotations to containers in openconfig-aft.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,7 +22,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -152,6 +158,7 @@ submodule openconfig-aft-common {
         }
 
         uses oc-if:interface-ref-state;
+	oc-ext:telemetry-atomic;
       }
     }
   }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -26,7 +26,7 @@ submodule openconfig-aft-common {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to the next-hops container.";
     reference "0.9.0";
   }
 
@@ -121,6 +121,7 @@ submodule openconfig-aft-common {
       list next-hop {
         key "index";
 
+	oc-ext:telemetry-atomic;
         description
           "A next-hop associated with the forwarding instance.";
 
@@ -158,7 +159,6 @@ submodule openconfig-aft-common {
         }
 
         uses oc-if:interface-ref-state;
-	oc-ext:telemetry-atomic;
       }
     }
   }

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ethernet {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to Ethernet container.";
     reference "0.9.0";
   }
 
@@ -105,6 +105,7 @@ submodule openconfig-aft-ethernet {
     list mac-entry {
       key "mac-address";
 
+      oc-ext:telemetry-atomic;
       description
         "List of the Ethernet entries within the abstract
         forwarding table. This list is keyed by the outer MAC address
@@ -126,7 +127,6 @@ submodule openconfig-aft-ethernet {
           entry.";
         uses aft-ethernet-entry-state;
       }
-      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -120,6 +126,7 @@ submodule openconfig-aft-ethernet {
           entry.";
         uses aft-ethernet-entry-state;
       }
+      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv4 {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to the IPv4 container.";
     reference "0.9.0";
   }
 
@@ -105,6 +105,7 @@ submodule openconfig-aft-ipv4 {
     list ipv4-entry {
       key "prefix";
 
+      oc-ext:telemetry-atomic;
       description
         "List of the IPv4 unicast entries within the abstract
         forwarding table. This list is keyed by the destination IPv4
@@ -126,7 +127,6 @@ submodule openconfig-aft-ipv4 {
           entry.";
         uses aft-ipv4-unicast-entry-state;
       }
-      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -120,6 +126,7 @@ submodule openconfig-aft-ipv4 {
           entry.";
         uses aft-ipv4-unicast-entry-state;
       }
+      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv6 {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to the IPv6 container.";
     reference "0.9.0";
   }
 
@@ -105,6 +105,7 @@ submodule openconfig-aft-ipv6 {
     list ipv6-entry {
       key "prefix";
 
+      oc-ext::telemetry-atomic;
       description
         "List of the IPv6 unicast entries within the abstract
         forwarding table. This list is keyed by the destination IPv6
@@ -126,7 +127,6 @@ submodule openconfig-aft-ipv6 {
           entry.";
         uses aft-ipv6-unicast-entry-state;
       }
-      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -120,6 +126,7 @@ submodule openconfig-aft-ipv6 {
           entry.";
         uses aft-ipv6-unicast-entry-state;
       }
+      oc-ext::telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -126,7 +126,7 @@ submodule openconfig-aft-ipv6 {
           entry.";
         uses aft-ipv6-unicast-entry-state;
       }
-      oc-ext::telemetry-atomic;
+      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -25,7 +25,7 @@ submodule openconfig-aft-mpls {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to the MPLS container.";
     reference "0.9.0";
   }
 
@@ -106,6 +106,7 @@ submodule openconfig-aft-mpls {
     list label-entry {
       key "label";
 
+      oc-ext::telemetry-atomic;
       description
         "List of the MPLS entries within the abstract
         forwarding table. This list is keyed by the top-most MPLS
@@ -127,7 +128,6 @@ submodule openconfig-aft-mpls {
           entry.";
         uses aft-mpls-entry-state;
       }
-      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -121,6 +127,7 @@ submodule openconfig-aft-mpls {
           entry.";
         uses aft-mpls-entry-state;
       }
+      oc-ext::telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -127,7 +127,7 @@ submodule openconfig-aft-mpls {
           entry.";
         uses aft-mpls-entry-state;
       }
-      oc-ext::telemetry-atomic;
+      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -139,7 +139,7 @@ submodule openconfig-aft-pf {
           AFT entry.";
         uses aft-pf-entry-state;
       }
-      oc-ext::telemetry-atomic;
+      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -32,7 +32,7 @@ submodule openconfig-aft-pf {
 
   revision "2021-10-20" {
     description
-      "Add atomic attribute to this container.";
+      "Add atomic attribute to the policy forwarding container.";
     reference "0.9.0";
   }
 
@@ -113,6 +113,7 @@ submodule openconfig-aft-pf {
     list policy-forwarding-entry {
       key "index";
 
+      oc-ext::telemetry-atomic;
       description
         "List of the policy forwarding entries within the abstract
         forwarding table. Each entry is uniquely identified by an
@@ -139,7 +140,6 @@ submodule openconfig-aft-pf {
           AFT entry.";
         uses aft-pf-entry-state;
       }
-      oc-ext:telemetry-atomic;
     }
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-10-20" {
+    description
+      "Add atomic attribute to this container.";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -133,6 +139,7 @@ submodule openconfig-aft-pf {
           AFT entry.";
         uses aft-pf-entry-state;
       }
+      oc-ext::telemetry-atomic;
     }
   }
 


### PR DESCRIPTION
 On branch aft-atomic-508
 Changes to be committed:
	modified:   openconfig-aft-common.yang
	modified:   openconfig-aft-ethernet.yang
	modified:   openconfig-aft-ipv4.yang
	modified:   openconfig-aft-ipv6.yang
	modified:   openconfig-aft-mpls.yang
	modified:   openconfig-aft-pf.yang

Add the atomic attribute to the above aft yang containers.