### PR TITLE
Add dot1p leaf as configuration option on L2 conditions and terms

### DIFF
--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -27,7 +27,13 @@ module openconfig-packet-match {
     field is omitted from a match expression, the effect is a
     wildcard ('any') for that field.";
 
-  oc-ext:openconfig-version "1.3.1";
+  oc-ext:openconfig-version "1.3.2";
+
+  revision "2021-11-11" {
+    description
+      "Add dot1p configuation option to Ethernet.";
+    reference "1.3.2";
+  }
 
   revision "2021-06-16" {
     description

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -118,6 +118,17 @@ module openconfig-packet-match {
       description
         "Ethertype field to match in Ethernet packets";
     }
+
+    leaf dot1p {
+      type uint8;
+      description
+        "Sets the 3-bit class-of-service value in the
+        Ethernet packet header for 802.1Q VLAN-tagged packets,
+        also known as PCP (priority code point).";
+      reference
+        "IEEE 802.1Q-2014 - IEEE Standard for Local and metropolitan
+        area networks--Bridges and Bridged Networks";
+    }
   }
 
   grouping ethernet-header-state {


### PR DESCRIPTION
### Original Problem

We need to support the class-of-service value on Ethernet packets as specified in dot1p.

### Proposed Solution

Add a `dot1p` leaf as a configuration option to `ethernet-header-config`, used in the `l2` container under the `ethernet-header-top` grouping.

### Note

This is my first contribution to the codebase and to Yang code in general, so I am still ramping up on proper dev practices. Please comment with any improvements I can make!