### PR TITLE
Initial commit of gNMI authorization policy proto.

### DIFF
--- a/release/authorization/README.md
+++ b/release/authorization/README.md
@@ -1,0 +1,366 @@
+# gNMI Authorization Protocol
+
+## Objective
+
+This proto and the reference code(to be delivered seperately) serve to describe
+an authorization framework for controlling which OpenConfig paths of a network
+device specific users can access using a gNMI micro-serivice. The authorization
+policy is initially intended to be deployed to a device, with the ability to
+define:
+
+*   Policy rules - each rule defines a single authorization policy.
+*   Groups of users - as a method to logically group users in the administrative
+    domain, for instance: operators or administrators.
+*   Users which are individual users as part of either rules or in groups.
+    Authentication information is not included in this Authorization
+    configuration.
+
+Policy rules are matched based on the best match for the authorization request,
+not the first match against a policy rule. Best match enables a configuration
+which permits a user or group access to particular OpenConfig paths while
+denying subordinate portions of the permitted paths, or the converse.
+
+Match rules permit a match against:
+
+*   User or Group (not both)
+*   an OpenConfig path
+
+An implicit deny is assumed, if there is no matching rule in the policy. Logging
+may be specified on a per-policy-rule basis as well as a default for the whole
+authorization policy.
+
+[OpenConfig paths](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths)
+are heirarchical, rooted at a defined "origin". OpenConfig may contain paths
+such as:
+
+```proto
+    /a/b/c/d
+```
+
+Paths may also have attributes associated with the path elements such as:
+
+```proto
+    /a/b[key=foo]/c/d
+```
+
+Attributes may be wildcarded in the policy, such as:
+
+```proto
+    /a/b[key=*]/c/d
+```
+
+Wildcards are only valid in policy rules when applied to attributes.
+Permitted use:
+
+```proto
+    /a/b[key=*]/c/d
+```
+
+Not permitted use:
+```proto
+    /a/b[key=foo]/*/d
+```
+
+## Bootstrap / Install Options
+
+System bootstrap, or install, operations may include an authorization policy
+delivered during bootstrap operations. It is suggested that the bootstrap
+process include the complete authorization policy so all production tools
+and services have immediate authorized access to finish installation and
+move devices into production in a timely manner.
+
+Using the Secure Zero Touch Provisioning (sZTP - RFC8572) process for
+bootstrap/installation provides a method to accomplish this delivery, and
+the delivery of all other bootstrap artifacts in a secure manner.
+
+## Conflict Resolution
+
+Policy evalyation should end with a single best match policy for the provided
+user / path. If there is more than one 'best match', an error must be logged
+and evaluation should return a failure.
+
+## An Example Authorization Protobuf
+
+```proto
+# proto-file: //experimental/users/morrowc/gnXi/proto/authorization.proto
+# proto-message: Policies
+version: "UUID-1234-123123-123123"
+created_on: 1234567890
+# Define 2 groups.
+group {
+  name: "family-group"
+  members { name: "stevie" }
+  members { name: "brian" }
+}
+group {
+  name: "test-group"
+  members { name: "crusty" }
+  members { name: "the-clown" }
+}
+# Action stevie to access /this/is/a/message_path
+policy {
+  id: "one"
+  log_level: LOG_NONE
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  user { name: "stevie" }
+}
+# Action members of family-group to access /this/is/a/different/message_path
+policy {
+  id: "two"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem { name: "different" }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "family-group" }
+}
+# Demonstrate a key with an attribute defined.
+policy {
+  id: "key"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem {
+      name: "keyed"
+      key{
+        key: "Ethernet"
+        value: "1/2/3"
+      }
+    }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "test-group" }
+}
+# Demonstrate a key with a wildcard attribute.
+policy {
+  id: "wyld"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem {
+      name: "keyed"
+      key{
+        key: "Ethernet"
+        value: "*"
+      }
+    }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "family-group" }
+}
+# Demonstrate a key with a wildcard attribute and a user specific match.
+# The previous policy matches all family-group users and permits a command
+# path, the policy rule below specifically denies brian access to these paths.
+policy {
+  id: "wyld-stallions"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem {
+      name: "keyed"
+      key{
+        key: "Ethernet"
+        value: "*"
+      }
+    }
+    elem { name: "message_path" }
+  }
+  action: DENY
+  group { name: "brian" }
+}
+# Add a final rule which is an explicit deny rule.
+policy {
+  id: "explicit-deny"
+  log_level: LOG_FULL
+  action: DENY
+}
+```
+
+The example first policy rule:
+
+```proto
+# Action stevie to access /this/is/a/message_path
+policy {
+  id: "one"
+  log_level: LOG_NONE
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  user { name: "stevie" }
+}
+```
+
+permits the singular user "stevie" to access the path:
+
+```shell
+    /this/is/a/message_path
+```
+
+Additionally, "stevie" is permitted access to all paths below the defined path,
+such as:
+
+```shell
+    /this/is/a/message_path/the
+    /this/is/a/message_path/the/one
+    /this/is/a/message_path/the/one/that
+    /this/is/a/message_path/the/one/that/knocks
+```
+
+The second policy rule:
+
+```proto
+# Action memberss of family-group to run /this/is/a/different/message_path
+policy {
+  id: "two"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem { name: "different" }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "family-group" }
+}
+```
+
+example policy permits members or the family-group access to a single path:
+
+```shell
+    /this/is/a/different/message_path
+```
+
+and all path elements beyond "message_path":
+
+```shell
+    /this/is/a/different/message_path/foo
+    /this/is/a/different/message_path/bar
+    /this/is/a/different/message_path/foo/baz/bing/boop
+```
+
+The third policy rule:
+
+```proto
+# Demonstrate a key with an attribute defined.
+policy {
+  id: "key"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem {
+      name: "keyed"
+      key{
+        key: "name"
+        value: "Ethernet1/2/3"
+      }
+    }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "test-group" }
+}
+```
+
+Permits access by the "test-group" users to the keyed path:
+
+```shell
+    /this/is/a/keyed[name=Ethernet1/2/3]/message_path
+```
+
+and all path elementas as beyond "message_path". The final policy rule:
+
+```proto
+# Demonstrate a key with a wildcard attribute.
+policy {
+  id: "wyld"
+  log_level: LOG_BRIEF
+  path {
+    origin: "foo"
+    elem { name: "this" }
+    elem { name: "is" }
+    elem { name: "a" }
+    elem {
+      name: "keyed"
+      key{
+        key: "name"
+        value: "*"
+      }
+    }
+    elem { name: "message_path" }
+  }
+  action: PERMIT
+  group { name: "family-group" }
+}
+```
+
+permits access by the "family-group" users to the keyed path, with no
+restrictions on the key values:
+
+```shell
+    /this/is/a/keyed[name=Ethernet1/2/3]/message_path
+    /this/is/a/keyed[name=POS3]/message_path
+    /this/is/a/keyed[name=Serial4/1]/message_path
+    /this/is/a/keyed[name=HSSI2]/message_path
+```
+
+Additionally, the path elements beyond "message_path" are available for access
+to this group as well.
+
+The wildcard character "*" (asterisk) is only able to be used as a value in
+keyed elements. The wildcard is only used to mask out all possible values but
+not portions of values, for instance:
+
+```shell
+    /this/is/a/keyed[name=*]/things - permitted usage of wildcard
+    /this/is/a/keyed[name=Ethernet1/*/3]/things - NOT permitted usage of wildcard
+```
+
+The policy rule:
+
+```proto
+# Add a final rule which is an explicit deny rule.
+policy {
+  id: "explicit-deny"
+  log_level: LOG_FULL
+  action: DENY
+}
+```
+
+provides an explcit deny for any request wich does not match any other policy
+rule. This rule also requests that the result be logged in full fidelity.
+
+Hopefully this illustrates the acceptable usage of the wildcard character in
+path elements of authorization policy rules.

--- a/release/authorization/authorization.proto
+++ b/release/authorization/authorization.proto
@@ -1,0 +1,115 @@
+// Authorization for gnXi operations.
+//
+// Define a list of policies, where the most specific policy is applied
+// on the device authorizing the action.
+//
+// Users may be referenced by user name, or as a group with a group name.
+// Groups are defined and managed in the authorization policy itself.
+//
+// Paths may be referenced in whole or in complete parts, ie:
+//   /interfaces/interface[name=Ethernet1/2/3]/state/counters
+//   /interfaces/interface[name=*]/state/oper-status
+//   /network-instances/network-instance/tables/table[protocol=BGP][address-family=*]
+//
+// Paths are gnmi.Path protobufs.
+//
+// The most specific match is returned for a request, this means the longest
+// path and the most specific user match (user preferred over group).
+//
+// Additionally, the policy maintains a timestamp of creation
+// and version number from the underlying version control system.
+// The version/timestamp are available to requestors to verify which version
+// of policy is being applied at the time of the request.
+//
+syntax = "proto3";
+
+package authorization.proto;
+
+import "third_party/openconfig/gnmi/proto/gnmi/gnmi.proto";
+
+option java_multiple_files = true;
+option go_api_flag = "OPAQUE_V0";
+
+// User is a singular username used only in the matching criteria.
+message User {
+  string name = 1;
+}
+
+// Group is a group of users, groups are a construct of the policy configuration
+// as a method to collect many users with the same authorizations together.
+message Group {
+  string name = 1;
+  repeated User members = 2;
+}
+
+// LogLevel is set for all RPCs (via default_log_level, or per-RPC specifically.
+enum LogLevel {
+  LOG_NONE = 0;   // Don't pollute the logs with high volume RPCs.
+  LOG_BRIEF = 1;  // RPC name and calling Principal name.
+  LOG_FULL = 2;   // RPC, Principal, Request, and Response.
+}
+
+// Action is the defined action for an AuthorizationPolicy.
+enum Action {
+  UNKNOWN = 0;
+  DENY = 1;
+  PERMIT = 2;
+}
+
+message AuthorizationPolicy {
+  // Policy Identifier, a unique string per policy/rule, eg: uuid.
+  string id = 1;
+  LogLevel log_level = 2;
+
+  oneof principal {
+    User user = 3;
+    Group group = 4;
+  }
+
+  // Path is the request path, longest prefix (by path elements from left
+  // to right).
+  gnmi.Path path = 5;
+
+  // Permit or deny the user/group access to the path specified.
+  Action action = 6;
+}
+
+message AuthorizationPolicies {
+  repeated AuthorizationPolicy policies = 1;
+  // Version string of this policy, a UUID4 or equivalent locally significant
+  // value.
+  string version = 2;
+  // Release created-on (in seconds since epoch) for this policy.
+  int64 created_on = 3;
+  // Default RPC log level, used only if an RPC has no defined logging level.
+  LogLevel default_log_level = 4;
+  // Groups of usernames collected for simplicity of policy expression.
+  repeated Group groups = 5;
+}
+
+// AuthorizationRequest contains a single user name and
+// gnmi Path being attempted. Data returned to an RPC Caller should
+// adhere to the policy.
+message AuthorizationRequest {
+  string user = 1;
+  gnmi.Path path = 2;
+}
+
+// AuthorizationReply returns the ack/nack for a single user request
+// as evaluated against the current policy, along with the policy id
+// and current policy version.
+message AuthorizationReply {
+  Action action = 1;
+  string id = 2;
+  string version = 3;
+}
+
+// VersionRequest requires no content, this is a simple status request.
+message VersionRequest {}
+
+// VersionReply returns only the version string and timestamp
+// of policy creation.
+message VersionReply {
+  string version = 1;
+  int64 created_on = 2;
+}


### PR DESCRIPTION
Documentation (README.md) for the Authorization policy has been
included along with the initial protobuf definition.