### PR TITLE
Add initial support for L2RIB EVPN state extensions

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -8,6 +8,7 @@ submodule openconfig-network-instance-l2 {
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-interfaces { prefix "oc-if"; }
   import ietf-yang-types { prefix "yang"; }
+  import ietf-inet-types { prefix "inet"; }
   import openconfig-evpn-types { prefix oc-evpn-types; }
   import openconfig-evpn { prefix "oc-evpn"; }
 
@@ -23,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2022-04-20" {
+    description
+      "Add support for l2rib state data";
+    reference "1.1.0";
+  }
 
   revision "2022-04-19" {
     description
@@ -217,6 +224,7 @@ submodule openconfig-network-instance-l2 {
        uses oc-evpn:evpn-mac-mobility-top;
        uses oc-evpn:evpn-arp-proxy-top;
        uses oc-evpn:evpn-nd-proxy-top;
+       uses l2ni-l2rib-top;
     }
   }
 
@@ -408,6 +416,316 @@ submodule openconfig-network-instance-l2 {
           }
         }
       }
+    }
+  }
+
+  grouping l2ni-l2rib-top {
+    description
+      "Top-level grouping for l2rib MAC and MAC-IP table list";
+
+    container l2rib {
+      config false;
+      description
+        "Operational state container for MAC address and MAC-IP address
+         information that is learned and installed into the MAC VRF Layer 2
+         Routing Information Base (L2RIB)";
+
+      container mac-table {
+        description
+          "Operational state container for MAC address information installed
+           into the MAC VRF of the L2RIB";
+
+        container entries {
+          description
+            "Enclosing container for list of MAC address entries";
+
+          list entry {
+            key "mac-address vlan";
+            description "List of learned MAC addresses";
+
+            leaf mac-address {
+              type leafref {
+                path "../state/mac-address";
+              }
+              description "Leafref of MAC address object";
+            }
+
+            leaf vlan {
+              type leafref {
+                path "../state/vlan";
+              }
+              description
+                "Leafref VLAN on which the MAC address is present";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state data for L2RIB MAC table object entry";
+              uses l2ni-l2rib-mac-table-state;
+            }
+
+            container producers {
+              description "Source producers for each MAC Table entry";
+              list producer {
+                key "producer";
+                description
+                  "List of producers for each MAC table entry";
+
+                leaf producer {
+                  type leafref {
+                    path "../state/producer";
+                  }
+                  description
+                    "Reference to producer list key";
+                }
+
+                container state {
+                  config false;
+                  description "State container for L2RIB MAC Table Entries";
+                  uses l2ni-l2rib-common-producer-state;
+                  uses l2ni-l2rib-mac-table-producer-state;
+                }
+              }
+            }
+          }
+        }
+        uses l2ni-l2rib-common-next-hop-state;
+      }
+
+      container mac-ip-table {
+        description
+          "Operational state container for MAC-IP address information installed
+           into the MAC VRF of the L2RIB";
+
+        container entries {
+          description
+            "Enclosing container for list of MAC-IP address entries";
+
+          list entry {
+            key "mac-address vlan host-ip";
+            description "List of learned MAC-IP addresses";
+
+            leaf mac-address {
+              type leafref {
+                path "../state/mac-address";
+              }
+              description "Leafref of MAC-IP address object";
+            }
+
+            leaf vlan {
+              type leafref {
+                path "../state/vlan";
+              }
+              description
+                "Leafref VLAN on which the MAC-IP address is present";
+            }
+
+            leaf host-ip {
+              type leafref {
+                path "../state/host-ip";
+              }
+              description "IP address of the Customer Edge device";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state data for L2RIB MAC-IP table object entry";
+              uses l2ni-l2rib-mac-ip-table-state;
+            }
+
+            container producers {
+              description "Source producers for each MAC-IP Table entry";
+              list producer {
+                key "producer";
+                description
+                  "List of producers for each MAC-IP table entry";
+
+                leaf producer {
+                  type leafref {
+                    path "../state/producer";
+                  }
+                  description
+                    "Reference to producer list key";
+                }
+
+                container state {
+                  config false;
+                  description "State container for L2RIB MAC Table Entries";
+                  uses l2ni-l2rib-common-producer-state;
+                }
+              }
+            }
+          }
+        }
+        uses l2ni-l2rib-common-next-hop-state;
+      }
+    }
+  }
+
+  grouping l2ni-l2rib-mac-table-state {
+    description "L2RIB MAC Table Operational State Grouping";
+    uses l2ni-l2rib-common-state;
+  }
+
+  grouping l2ni-l2rib-mac-ip-table-state {
+    description "L2RIB Mac-IP Table Operational State Grouping";
+    uses l2ni-l2rib-common-state;
+
+    leaf host-ip {
+      type inet:ip-address;
+      description
+        "Host IP address of the CE device for the L2RIB MAC-IP entry";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf l3-vni {
+      type oc-evpn-types:evi-id;
+      description
+        "Symmetric IRB uses the same forwarding semantics when routing
+         between IP subnets with VRF Lite or MPLS L3VPNs. With symmetric IRB,
+         all traffic egressing and returning from a VTEP uses the same VNI.
+         Specifically, the same Layer 3 VNI (L3VNI) associated with the VRF
+         is used for all routed traffic. Layer3 VNI used for inter-subnet
+         routing";
+    }
+  }
+
+  grouping l2ni-l2rib-common-state {
+    description "L2RIB Common Property Operational State Data Grouping";
+
+    leaf mac-address {
+        type yang:mac-address;
+        description "MAC address of the L2RIB MAC or MAC-IP entry";
+    }
+    leaf vlan {
+      type leafref {
+        path "../../../../../../../vlans/vlan/config/vlan-id";
+      }
+      description
+        "VLAN on which the MAC or MAC-IP address is present.";
+    }
+    leaf evi {
+      type oc-evpn-types:evi-id;
+      description "EVPN Instance Identifier for the MAC or MAC-IP";
+    }
+    leaf l2-vni {
+      type oc-evpn-types:evi-id;
+      description "Layer2 VNI segment mapped to given vlan-id";
+    }
+  }
+
+  grouping l2ni-l2rib-common-producer-state {
+    description "L2RIB Common Producer Attributes Operational State Data Grouping";
+
+    leaf producer {
+      type enumeration {
+        enum LOCAL {
+          description "local producer source";
+        }
+        enum STATIC {
+          description "static producer source";
+        }
+        enum BGP {
+          description "bgp producer source";
+        }
+      }
+      description "Source of the learned L2RIB route";
+    }
+
+    leaf seq-number {
+      type uint32;
+      description
+        "The sequence number is used to ensure that PEs retain the correct
+         MAC/IP Advertisement route when multiple updates occur for the same
+         MAC address";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf mobility-state {
+      type enumeration {
+        enum FROZEN {
+          description
+            "Permanently frozen mac-address";
+        }
+        enum DUPLICATE {
+          description
+            "Duplicate mac-address";
+        }
+      }
+      description
+        "Indicates if learned MAC address is duplicate or frozen";
+      reference "draft-ietf-bess-evpn-irb-extended-mobility-05";
+    }
+
+    leaf esi {
+      type oc-evpn-types:esi;
+      description "Ethernet Segment Identifier for local and remote routes";
+    }
+
+    leaf sticky {
+      type boolean;
+      description "MAC address is sticky and not subjected to MAC moves";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf next-hop {
+      type leafref {
+        path "../../../../../../next-hops/next-hop/index";
+      }
+      description "Leafref next-hop for the MAC-IP table entry";
+    }
+  }
+
+  grouping l2ni-l2rib-common-next-hop-state {
+    description "L2RIB Common Next Hop Attributes Operational State Data Grouping";
+
+    container next-hops {
+      description "A next-hop associated with the MAC or MAC-IP entry";
+      list next-hop {
+        key "index";
+        description "List of next hop attributes for each MAC or MAC-IP";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "A unique index identifying the next-hop entry for the
+             MAC or MAC-IP entry";
+        }
+        container state {
+          description "State container for common next-hop attributes";
+          config false;
+          leaf index {
+            type uint64;
+            description "A unique entry for the next-hop.";
+          }
+          leaf peer-ip {
+            type inet:ip-address;
+            description "Next hop peer address";
+          }
+          leaf label {
+            type oc-evpn-types:evi-id;
+            description "Next hop label representing the l2vni for the route";
+          }
+          uses oc-if:interface-ref-common;
+        }
+      }
+    }
+  }
+  grouping l2ni-l2rib-mac-table-producer-state {
+    description "L2RIB MAC Table Operational State Data Grouping";
+
+    leaf derived-from-mac-ip {
+      type boolean;
+      description "Derived from BGP MAC-IP route-type 2";
+    }
+
+    leaf directly-received {
+      type boolean;
+      description "BGP learned MAC route-type 2";
     }
   }
 }

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -440,7 +440,7 @@ submodule openconfig-network-instance-l2 {
             "Enclosing container for list of MAC address entries";
 
           list entry {
-            key "mac-address vlan";
+            key "mac-address";
             description "List of learned MAC addresses";
 
             leaf mac-address {
@@ -448,14 +448,6 @@ submodule openconfig-network-instance-l2 {
                 path "../state/mac-address";
               }
               description "Leafref of MAC address object";
-            }
-
-            leaf vlan {
-              type leafref {
-                path "../state/vlan";
-              }
-              description
-                "Leafref VLAN on which the MAC address is present";
             }
 
             container state {
@@ -503,7 +495,7 @@ submodule openconfig-network-instance-l2 {
             "Enclosing container for list of MAC-IP address entries";
 
           list entry {
-            key "mac-address vlan host-ip";
+            key "mac-address host-ip";
             description "List of learned MAC-IP addresses";
 
             leaf mac-address {
@@ -511,14 +503,6 @@ submodule openconfig-network-instance-l2 {
                 path "../state/mac-address";
               }
               description "Leafref of MAC-IP address object";
-            }
-
-            leaf vlan {
-              type leafref {
-                path "../state/vlan";
-              }
-              description
-                "Leafref VLAN on which the MAC-IP address is present";
             }
 
             leaf host-ip {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -47,7 +47,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2022-04-20" {
+    description
+      "Add support for l2rib state data";
+    reference "1.1.0";
+  }
 
   revision "2022-04-19" {
     description


### PR DESCRIPTION
**NOTE:**
  * This PR replaces https://github.com/openconfig/public/pull/436.  As discussed with @robshakir we are opening this PR because of the CLA issue with https://github.com/openconfig/public/pull/436.

This PR adds oper state containers for MAC address and MAC-IP address information that is learned and installed into the MAC VRF Layer 2 Routing Information Base (L2RIB).

This PR is part of a series of telemetry extensions following the release of initial configuration support for EVPN https://github.com/openconfig/public/commit/b39439b2a55681c5b5a0d59e4644499916eac294.
