### PR TITLE
Add p4rt interface/node-id relationship

### DIFF
--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -26,7 +26,13 @@ module openconfig-p4rt {
     The P4RT protocol specification is linkde from https://p4.org/specs/
     under the P4Runtime heading.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision 2021-12-15 {
+    description
+      "Add interface parent IC node identifier";
+    reference "0.3.0";
+  }
 
   revision 2021-07-20 {
     description
@@ -64,6 +70,21 @@ module openconfig-p4rt {
         interface is required, it does not replace the unique name assigned to
         the interface.";
     }
+
+    leaf node-id {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/" +
+             "oc-platform:integrated-circuit/oc-platform:config/" +
+             "oc-p4rt:node-id";
+      }
+      description
+        "The parent integrated circuit node identifier responsible for the
+        interface.  The interface node ID provides an explicit unique association
+        between an interface and its corresponding integrated circuit which may
+        also be referred to as a 'device', 'node' or 'target' according to the
+        P4RT specification.";
+    }
+
   }
 
   augment "/oc-if:interfaces/oc-if:interface/oc-if:config" {


### PR DESCRIPTION
* (M) release/models/p4rt/openconfig-p4rt.yang
  - Introduce leafref of the parent integrated-circuit to an interface

# Interface 'node-id' relationship

Introduce a leafref of the parent integrated-circuit `node-id` to the interface
to create a unique association for P4 programming.
