### PR TITLE
Route programming state module

### DIFF
--- a/release/models/route-programming/.spec.yml
+++ b/release/models/route-programming/.spec.yml
@@ -1,0 +1,6 @@
+- name: openconfig-platform
+  docs:
+    - yang/route-programming/openconfig-route-programming-state.yang
+  build:
+    - yang/route-programming/openconfig-route-programming-state.yang
+  run-ci: true

--- a/release/models/route-programming/.spec.yml
+++ b/release/models/route-programming/.spec.yml
@@ -1,4 +1,4 @@
-- name: openconfig-platform
+- name: openconfig-route-programming
   docs:
     - yang/route-programming/openconfig-route-programming-state.yang
   build:

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -157,6 +157,7 @@ module openconfig-route-programming-state {
 
     leaf reason {
       type enumeration {
+        "The IPv4 or IPv6 prefix that the route state corresponds to.";
         enum INVALID {
           description
             "The reason for failure was that route, or its dependencies, was
@@ -172,6 +173,8 @@ module openconfig-route-programming-state {
             "The programming failure occurred for an unknown reason.";
         }
       }
+      description
+        "The reason for failure";
     }
   }
 

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -1,0 +1,184 @@
+module openconfig-route-programming-state {
+  prefix "oc-rtstate";
+
+  namespace "http://openconfig.net/yang/route-programming";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-types { prefix "oc-types"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module provides detailed information as to the programming
+    state of routes within a particular network instance. It can be used to
+    track where there are routing programming errors on a device.";
+
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2021-10-16" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  grouping route-state-top {
+    description
+      "Top-level grouping for route state in OpenConfig.";
+
+    container route-programming {
+      config false;
+      description
+        "The programming status of routes within the network-instance. Route
+        programming reports are divided into a set of sub-categories:
+
+         - failed programming -- these routes are those that were attempted to be
+           programed to the hardware, but the programming operation failed.
+         - stale programming -- these routes are those that are programmed into
+           hardware, but some failure occurred in updating to a new state.
+         - drop programming - these routes are explicitly programmed into hardware
+           to point to a destination that discards packets.";
+
+      container failed-routes {
+        description
+          "Surrounding container for the list of routes that fail programming.";
+
+        list failed {
+          key "prefix";
+
+          description
+            "A prefix that was attempted to the programmed into hardware, but the
+            programming operation failed.";
+
+          leaf prefix {
+            type leafref {
+              path "../state/prefix";
+            }
+            description
+              "Reference to the prefix that keys the failed list.";
+          }
+
+          container state {
+            description
+              "Operational state parameters relating to a failed programming
+              operation.";
+            uses route-state-common;
+          }
+        }
+      }
+
+      container stale-routes {
+        description
+          "Surrounding container for the list of routes that are currently in
+          a stale state.";
+
+        list stale {
+          key "prefix";
+
+          description
+            "A prefix that is currently installed in hardware, but a subsequent
+            operation to update its programming failed - such that the entry in
+            hardware is stale.";
+
+          leaf prefix {
+            type leafref {
+              path "../state/prefix";
+            }
+            description
+              "Reference to the prefix that keys the stale list.";
+          }
+
+          container state {
+            description
+              "Operational state parameters relating to a stale route.";
+            uses route-state-common;
+          }
+        }
+      }
+
+      container drop-routes {
+        description
+          "Surrounding container for the list of routes that are currently in
+          a drop state.";
+
+        list drop {
+          key "prefix";
+
+          description
+            "A prefix that is currently installed in hardware but with an explicit
+            instruction that it should discard packets that are destined towards
+            it.";
+
+          leaf prefix {
+            type leafref {
+              path "../state/prefix";
+            }
+            description
+              "Reference to the prefix that keys the drop list.";
+          }
+
+          container state {
+            description
+              "Operational state parameters relating to a drop route.";
+            uses route-state-common;
+          }
+        }
+      }
+    }
+  }
+
+ grouping route-state-common {
+    description
+      "Common state parameters that correspond to a particular route
+      type.";
+
+    leaf prefix {
+      type oc-inet:ip-prefix;
+      description
+        "The IPv4 or IPv6 prefix that the route state corresponds to.";
+    }
+
+    leaf time {
+      type oc-types:timeticks64;
+      description
+        "Time that the route was programmed, or the programming attempt was made
+        expressed as nanoseconds since the Unix epoch.";
+    }
+
+    leaf reason {
+      type enumeration {
+        enum INVALID {
+          description
+            "The reason for failure was that route, or its dependencies, was
+            deemed to be invalid.";
+        }
+        enum HW_PROGRAMMING_FAILED {
+          description
+            "The reason for the failure was that the hardware programming
+            failed.";
+        }
+        enum UNKNOWN {
+          description
+            "The programming failure occurred for an unknown reason.";
+        }
+      }
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance" {
+    description
+      "Augment the network-instance model with the route-programming container.";
+
+    uses route-state-top;
+  }
+}

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -157,7 +157,6 @@ module openconfig-route-programming-state {
 
     leaf reason {
       type enumeration {
-        "The IPv4 or IPv6 prefix that the route state corresponds to.";
         enum INVALID {
           description
             "The reason for failure was that route, or its dependencies, was

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -160,6 +160,14 @@ module openconfig-route-programming-state {
         monitoring subsystem expressed as nanoseconds since the Unix epoch.";
     }
 
+    leaf dest-component {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component";
+      }
+      description
+        "The destination component for the route programming";
+     }
+ 
     leaf reason {
       type enumeration {
         enum INVALID {

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -42,10 +42,15 @@ module openconfig-route-programming-state {
         "The programming status of routes within the network-instance. Route
         programming reports are divided into a set of sub-categories:
 
-         - failed programming -- these routes are those that were attempted to be
-           programed to the hardware, but the programming operation failed.
-         - stale programming -- these routes are those that are programmed into
-           hardware, but some failure occurred in updating to a new state.
+         - failed programming -- A prefix which is not present in the AFT is
+           attempted to be added into the AFT but failed.  Traffic destined for
+           this prefix will not be matched.
+
+         - stale programming -- A prefix is already in the AFT is requested to
+           be updated but failed.  Traffic destined for this prefix will be
+           forwarded to the old next-hop.  AFT telemetry should continue to
+           reflect the old next-hop for the prefix.
+
          - drop programming - these routes are explicitly programmed into hardware
            to point to a destination that discards packets.";
 

--- a/release/models/route-programming/openconfig-route-programming-state.yang
+++ b/release/models/route-programming/openconfig-route-programming-state.yang
@@ -151,8 +151,8 @@ module openconfig-route-programming-state {
     leaf time {
       type oc-types:timeticks64;
       description
-        "Time that the route was programmed, or the programming attempt was made
-        expressed as nanoseconds since the Unix epoch.";
+        "Represents the time the route programming state change was detected by the 
+        monitoring subsystem expressed as nanoseconds since the Unix epoch.";
     }
 
     leaf reason {


### PR DESCRIPTION
Initial proposal to model the state of routes in a network instance to hardware programming.

Note the model only defines leaves for routing programming errors 