### PR TITLE
Add support for SFP28 and SFP56 form factor identities

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.14.0";
+  oc-ext:openconfig-version "0.15.0";
+
+  revision "2022-01-24" {
+    description
+      "Add SFP28 and SFP56 form factor identities.";
+    reference "0.15.0";
+  }
 
   revision "2021-03-22" {
     description
@@ -667,6 +673,20 @@ module openconfig-transport-types {
     description
       "Enhanced small form-factor pluggable transceiver supporting
       up to 16 Gb/s signals, including 10 GbE and OTU2";
+  }
+
+  identity SFP28 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      25 Gb/s signal";
+  }
+
+  identity SFP56 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      50 Gb/s signal";
   }
 
   identity XFP {


### PR DESCRIPTION
SFP28 and SFP56 transceiver form-factor identities are missing from
OpenConfig.