### PR TITLE
Add a CODEOWNERS for openconfig/public.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Definition of code OWNERS for the openconfig/public repository.
+#
+# default approvers:
+* @aashaikh @robshakir 
+
+# the release/models directory (all YANG content)
+# is maintained by the public-writers OpenConfig team. 
+/release/models/ @openconfig/public-writers


### PR DESCRIPTION
```
 * (A) .github/CODEOWNERS
   - Initialise CODEOWNERS in openconfig/public repo.
```
