### PR TITLE
Auth 201 (#245)

### DIFF
--- a/yang/keychain/.spec.yml
+++ b/yang/keychain/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-keychain
+  docs:
+    - yang/keychain/openconfig-keychain-types.yang
+    - yang/keychain/openconfig-keychain.yang
+  build:
+    - yang/keychain/openconfig-keychain.yang
+  run-ci: true

--- a/yang/keychain/openconfig-keychain-types.yang
+++ b/yang/keychain/openconfig-keychain-types.yang
@@ -1,0 +1,140 @@
+module openconfig-keychain-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/oc-keychain-types";
+
+  prefix "oc-keychain-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains general data definitions for use in
+    keychain-based authentication.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2021-10-01" {
+    description
+      "Initial revision of types for keychain model";
+    reference "0.1.0";
+  }
+
+
+  identity AUTH_TYPE {
+    description
+    "Base identify to define the type of authentication";
+  }
+
+  identity NONE {
+    base AUTH_TYPE;
+    description
+    "NO authentication is used";
+  }
+
+  identity SIMPLE_KEY {
+    base AUTH_TYPE;
+    description
+    "Authentication is provided via a simple authentication key. The
+    key is configured at each end, and the exchange of the key may be
+    encrypted or not";
+  }
+
+  identity KEYCHAIN {
+    base AUTH_TYPE;
+    description
+    "This identity indicates that the authentication is selected
+    from a keychain.";
+  }
+
+  identity CRYPTO_TYPE {
+    description
+      "Base identify for the cryptographic algorithm";
+  }
+
+  identity CRYPTO_NONE{
+    base CRYPTO_TYPE;
+      description
+        "No encryption is used";
+  }
+
+  identity MD5 {
+    base CRYPTO_TYPE;
+      description
+        "MD5 message-digest algorithm produces a 128-bit hash value.";
+      reference
+        "RFC 1321 - The MD5 Message-Digest Algorithm";
+  }
+
+  identity HMAC_MD5 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-MD5 keyed hash algorithm constructed from MD5 hash
+        function and used as a HMAC.";
+      reference
+        "RFC 2104 - HMAC: Keyed-Hashing for Message Authentication";
+  }
+
+  identity SHA_1 {
+    base CRYPTO_TYPE;
+      description
+        "SHA-1 cryptographic hash function that produces a 160-bit hash value.";
+      reference
+        "RFC 3174 - US Secure Hash Algorithm 1 (SHA1)";
+  }
+  identity HMAC_SHA_1 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1 keyed hash algorithm constructed from SHA-1 hash
+        function and used as a HMAC.";
+  }
+
+  identity HMAC_SHA_1_12 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-12 algorithm";
+  }
+
+  identity HMAC_SHA_1_20 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-20 algorithm";
+  }
+
+  identity HMAC_SHA_1_96 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-96 keyed hash algorithm constructed from SHA-1 hash
+        function and used as a HMAC, operating on 64-byte blocks of data.";
+      reference
+        "RFC 2404 - The Use of HMAC-SHA-1-96 within ESP and AH";
+  }
+
+  identity HMAC_SHA_256 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-256 keyed hash algorithm constructed from the secure
+        SHA-256 hash function and used as a HMAC.";
+      reference
+        "RFC 6234 - US Secure Hash Algorithms (SHA and SHA-based
+        HMAC and HKDF)";
+  }
+
+  identity AES_28_CMAC_96 {
+    base CRYPTO_TYPE;
+      description
+        "AES-128-CMAC-96 keyed hash function based on a AES-128 block
+        cipher.";
+      reference
+        "RFC 4494 - The AES-CMAC-96 Algorithm and Its Use with IPsec";
+  }
+}

--- a/yang/keychain/openconfig-keychain.yang
+++ b/yang/keychain/openconfig-keychain.yang
@@ -1,0 +1,277 @@
+module openconfig-keychain {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/oc-keychain";
+
+  prefix "oc-keychain";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-keychain-types { prefix oc-keychain-types; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module describes a YANG model for keychain configuration
+    and management. These keys can be changed frequently to
+    increase security in long-lived connections. A keychain can be used
+    for authenticaion in a number of scenarios, including in routing protocols
+    (e.g. BGP, IS-IS, OSPF).  A keychain provides a solution for storing
+    a number of different keys, each key string value is associated with a
+    specific key id, name, the lifetime that the key is valid and an
+    encryption algorithm.
+
+    This model defines a central location for defining named keychains,
+    which may be then referenced by other models such as routing protocol
+    management.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2021-10-01" {
+    description
+      "Initial revision of keychain model.";
+    reference "0.1.0";
+  }
+
+  grouping valid-lifetime-config {
+    description
+      "This grouping defines key begin lifetime parameters.";
+
+    leaf start-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the key becomes valid for use.
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf end-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the key becomes invalid for use.
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+
+        Leaving this value unset, or setting it to 0, indicates that
+        the key remains valid forever (no end time).";
+    }
+  }
+
+  grouping lifetime-symmetry-config {
+    description
+      "Grouping to define configuration data for managing how
+      send and receive lifetime are specified.";
+
+    leaf send-and-receive {
+      type boolean;
+      description
+        "When this is set to true (the default value), the specified
+        send lifetime is also used in the receive direction.  When set
+        to false, the device should use the specified receive-lifetime
+        for the receive direction (asymmetric mode).  If send-and-receive
+        is false, and the device does not support asymmetric configuration,
+        the config should be rejected as unsupported.";
+      default true;
+    }
+  }
+
+  grouping lifetime-base {
+    description
+      "This grouping defines key lifetime parameters.";
+
+    container send-lifetime {
+      description
+        "Specifies the lifetime of the key for sending authentication
+        information to the peer.";
+
+      container config {
+        description
+          "Configuration data for key send lifetime.";
+
+        uses valid-lifetime-config;
+        uses lifetime-symmetry-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for key send lifetime.";
+
+        uses valid-lifetime-config;
+        uses lifetime-symmetry-config;
+      }
+    }
+
+    container receive-lifetime {
+      description
+        "Specify the validity lifetime of the key in the receive direction.
+        Some platforms may only support symmetric send and receive lifetimes,
+        in which case the receive-lifetime is typically not specified.";
+
+      container config {
+        description
+          "Configuration data for key receive lifetime.";
+
+        uses valid-lifetime-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for key receive lifetime.";
+
+        uses valid-lifetime-config;
+      }
+    }
+  }
+
+  grouping keychain-base-config {
+    description
+      "This grouping defines key-chain parameters.";
+
+    leaf name {
+      type string;
+      description
+        "Keychain name.";
+    }
+
+    leaf tolerance {
+      type union {
+        type enumeration {
+          enum FOREVER {
+            description
+              "Receive key does not expire (equivalent to infinite tolerance).";
+          }
+        }
+        type uint32;
+      }
+      description
+        "Tolerance (overlap time) that a receive key should be accepted.  May be
+        expressed as range in seconds, or using the FOREVER value to indicate
+        that the key does not expire.  The default value should be 0, i.e., no
+        tolerance.";
+    }
+  }
+
+  grouping keychain-key-config {
+    description "This grouping defines key-chain key parameters.";
+
+    leaf key-id {
+      type uint64;
+      description
+        "Identifier for the key within the keychain.";
+    }
+
+    leaf secret-key {
+      type string;
+      description
+        "Authentication key supplied as an encrypted value.  The system should store and
+        return the key in encrypted form.";
+    }
+
+    leaf crypto-algorithm {
+      type identityref {
+        base oc-keychain-types:CRYPTO_TYPE;
+      }
+      description
+        "Cryptographic algorithm associated with the key.  Note that not all cryptographic
+        algorithms are available in all contexts (e.g., across different protocols).";
+    }
+  }
+
+  grouping keychain-key-base {
+    description
+      "This grouping defines keychain parameters";
+
+  container keys {
+    description
+    "list of keys to be stored";
+      list key {
+        key "key-id";
+        description
+          "List of configured keys for the keychain.";
+
+        leaf key-id {
+          type leafref {
+            path "../config/key-id";
+          }
+          description
+            "Reference to key id.";
+        }
+
+        container config {
+          description
+            "This container defines keychain key configuration.";
+
+          uses keychain-key-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines keychain key state.";
+
+          uses keychain-key-config;
+        }
+
+        uses lifetime-base;
+        }
+    }
+  }
+
+  grouping keychain-common-base {
+    description
+      "This grouping defines keychain parameters";
+
+    container config {
+      description
+        "This container defines keychain configuration.";
+
+      uses keychain-base-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines keychain state information.";
+
+      uses keychain-base-config;
+    }
+  }
+
+  grouping keychain-top {
+    description
+      "This grouping define top level structure.";
+
+    container keychains {
+      description
+        "This container defines keychains.";
+
+      list keychain {
+        key "name";
+        description
+          "List of defined keychains.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to configured keychain name";
+        }
+
+        uses keychain-common-base;
+        uses keychain-key-base;
+      }
+    }
+  }
+
+  uses keychain-top;
+}


### PR DESCRIPTION
* Update openconfig-keychain.yang

* Update openconfig-authentication-types.yang

* Update openconfig-keychain.yang

* Update openconfig-authentication-types.yang

* Formatting and syntax fixes in routing auth model.

  * (M) yang/authentication/openconfig-keychain.yang
    - Formatting and indentation fixes
    - Syntax fixes in when statements

* Update openconfig-authentication-types

Removed protocol-specific identities (such as IS-IS) and add more AUTH-TYPES

* added -spec.yml to authentication directory

* Revert "Merge branch 'auth-201' of github.com:openconfig/models into auth-201"

This reverts commit bcc4fade107ee40cbc2b11767c3da89614819203, reversing
changes made to a5728f9955ce8bc9d3025e54458494ec3bdd1c10.

* fixed keychain

* fixed whitespace errors

* Revert "Revert "Merge branch 'auth-201' of github.com:openconfig/models into auth-201""

This reverts commit 92ed683efc76b4f4791f5cfa574e361686c290cf.

* update oc-auth-types by oc-types

* update to fix miscelaneus validation

* update to fix miscelanius changes

* add uses keychain-top to have a top container

* Changed directory name and update description of keychain

* Removed PLAIN TEXT as there is CRYPTO_NONE

* update tolerance time

* Updated description of the keychain module

* Updates to keychain authentication model (#201)

  * (A) yang/keychain/.spec.yml
  * (D) yang/protocol-authentication/.spec.yml
    - Updated to match new filenames and location
  * (A) yang/keychain/openconfig-keychain-types.yang
  * (D) yang/protocol-authentication/openconfig-authentication-types.yang
    - renamed and moved to openconfig-keychain-types
    - removed time-entry-type
    - improved descriptons for crypto type identities
  * (R) yang/protocol-authentication/openconfig-keychain.yang
    - renamed and moved to openconfig-keychain
    - removed leaves that call for time-entry-type
    - updated model and leaf descriptions

* Minor fixes in keychain model (#201)

  * (M) yang/keychain/.spec.yml
  * (M) yang/keychain/openconfig-keychain-types.yang
  * (M) yang/keychain/openconfig-keychain.yang
    - Fix linter errors (whitespace)

* Update keychain model based on review (#201)

  * (M) yang/keychain/.spec.yml
    - minor formatting fixes
  * (M) yang/keychain/openconfig-keychain.yang
    - Simplified model to use a single start and end
      leaf for send/receive lifetime
    - Changed time types to use timeticks rather than
      date-and-time
    - Updated some leaf names and descriptions

* Updates keychain model (#201)

  * (M) yang/keychain/openconfig-keychain-types.yang
    - Fixed namepsace to match filename

* Updates to keychain model to address reviews (#201)

  * (M) yang/keychain/openconfig-keychain-types.yang
    - formatting fixes
  * (M) yang/keychain/openconfig-keychain.yang
    - Clarified behavior or not setting end lifetime
    - other minor edits

* Updates to keychain model to clarify key lifetime (#201)

  * (M) yang/keychain/openconfig-keychain.yang
    - Added send-and-receive leaf to specify asymmetric
      lifetime behavior.

Co-authored-by: Rob Shakir <robjs@google.com>
Co-authored-by: Anees Shaikh <aashaikh@google.com>
Co-authored-by: Óscar González de Dios <oscar.gonzalezdedios@telefonica.com>
Co-authored-by: Óscar González de Dios <ogondio@gmail.com>
Co-authored-by: sbarguil <samir.barguil@gmail.com>