### PR TITLE
2022-01-25: Sync models and public repos

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,7 +48,7 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    branch=$(git tag -l 'v6*' | sort -V | tail -1)
+    branch=$(git tag -l 'v7*' | sort -V | tail -1)
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,7 +22,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -260,6 +266,17 @@ submodule openconfig-aft-common {
       description
         "The MAC address of the next-hop if resolved by the local
         network instance.";
+    }
+
+    leaf pop-top-label {
+      type boolean;
+      default false;
+      description
+        "Flag that controls pop action, i.e., the top-most MPLS label
+         should be popped from the packet when switched by the system.
+
+        The top-most MPLS label associated with pop action is equal to
+        the label key used in 'mpls' AFT 'label-entry' list.";
     }
 
     leaf-list pushed-mpls-label-stack {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "0.3.4";
+  oc-ext:openconfig-version "0.3.5";
+
+  revision "2021-08-24" {
+    description
+      "Add vxlan to next-hops encapsulation-header-type.";
+    reference "0.3.5";
+  }
 
   revision "2019-11-07" {
     description
@@ -72,6 +78,10 @@ module openconfig-aft-types {
         description
           "The encapsulation header is one or more MPLS labels indicated
           by the pushed and popped label stack lists.";
+      }
+      enum VXLAN {
+        description
+          "The encapsulation header is a VXLAN packet header";
       }
     }
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,25 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
 
   revision "2019-07-10" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,25 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
 
   revision "2019-07-10" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,25 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
 
   revision "2019-07-10" {
     description

--- a/release/models/bgp/openconfig-bgp-errors.yang
+++ b/release/models/bgp/openconfig-bgp-errors.yang
@@ -18,7 +18,46 @@ submodule openconfig-bgp-errors {
     "This module defines BGP NOTIFICATION message error codes
     and subcodes";
 
-  oc-ext:openconfig-version "5.0.2";
+  oc-ext:openconfig-version "5.3.1";
+
+  revision "2021-08-06" {
+    description
+      "Fix pattern regexes to allow full 4-byte private ASN range including
+       42xxxxxxxx in extended communities
+
+      Types impacted:
+      - bgp-ext-community-type";
+    reference "5.3.1";
+  }
+
+  revision "2021-01-07" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC7950.
+
+      Types impacted:
+      - bgp-std-community-type
+      - bgp-ext-community-type";
+    reference "5.3.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "5.2.1";
+  }
+
+  revision "2020-06-17" {
+    description
+      "Add RFC5549 capability identity.";
+    reference "5.2.0";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Add FlowSpec, BGP-LS and LSVR AFI-SAFI identities.";
+    reference "5.1.0";
+  }
 
   revision "2018-11-21" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,25 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
 
   revision "2019-07-10" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,19 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "6.1.0";
+  oc-ext:openconfig-version "7.0.0";
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
 
   revision "2021-03-17" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,8 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "6.1.1";
+  oc-ext:openconfig-version "7.0.0";
 
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
 
   revision "2021-06-16" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.6.2";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
 
   revision "2021-06-16" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.7.1";
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
 
   revision "2021-12-31" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,13 +20,25 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.7.1";
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
 
   revision "2021-12-31" {
     description
       "Add support for per-interface hello authentication, and per-level
       *SNP authentication.";
     reference "0.7.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.6.2";
   }
 
   revision "2021-03-17" {

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,14 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
 
   revision "2021-03-17" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -8,19 +8,16 @@ module openconfig-isis {
   prefix "oc-isis";
 
   // import some basic types
-  import ietf-inet-types { prefix "inet"; }
-  import ietf-yang-types { prefix "yang"; }
   import openconfig-types { prefix "oc-types"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
   import openconfig-isis-types { prefix "oc-isis-types"; }
   import openconfig-routing-policy { prefix "oc-rpol"; }
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-interfaces { prefix "oc-if"; }
   import openconfig-segment-routing { prefix "oc-sr"; }
   import openconfig-bfd { prefix "oc-bfd"; }
-  // TODO(robjs): Import authentication and keychain following merge of these
-  // modules.
-  //import openconfig-authentication-types { prefix "oc-auth-types"; }
-  //import openconfig-keychain { prefix "oc-keychain"; }
+  import openconfig-keychain { prefix "oc-keychain"; }
 
   // Include submodules:
   // IS-IS LSP is the LSDB for IS-IS.
@@ -56,7 +53,14 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "0.6.2";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
 
   revision "2021-06-16" {
     description
@@ -263,136 +267,24 @@ module openconfig-isis {
     }
   }
 
-  grouping authentication-key-config {
-    description
-      "This grouping defines authentication key configuration.";
-
-    leaf auth-password {
-      type oc-types:routing-password;
-      description
-        "Authentication key string.";
-    }
-  }
-
-  grouping keychain-base-group {
-    description
-      "This grouping defines keychain configuration.";
-
-    container keychain {
-      description
-        "This container defines keychain parameters.";
-
-      // TODO(robjs): Import keychain parameters following merge of the auth
-      // models.
-      //uses oc-keychain:keychain-common-base;
-      //uses oc-keychain:tolerance-base;
-      //uses oc-keychain:keychain-key-base;
-    }
-  }
-
-  grouping isis-authentication-config {
-    description
-      "This grouping defines ISIS authentication configuration.";
-
-    // TODO(robjs): Add authentication following merge of auth modules.
-    //leaf auth-type {
-    //  type oc-auth-types:auth-type;
-    //  description
-    //    "ISIS authentication type (key, key-chain).";
-    //}
-
-    leaf csnp-authentication {
-      type boolean;
-      default false;
-      description
-        "Enable or disable for IS-IS CSNPs.";
-    }
-
-    leaf psnp-authentication {
-      type boolean;
-      default false;
-      description
-        "Enable or disable authentication for IS-IS PSNPs.";
-    }
-
-    leaf lsp-authentication {
-      type boolean;
-      default false;
-      description
-        "Enable or disable authentication for IS-IS LSPs.";
-    }
-  }
-
-  grouping isis-authentication-group {
-   description
-     "This grouping defines ISIS authentication.";
-
-    container config {
-      description
-        "This container defines ISIS authentication configuration.";
-
-      uses isis-authentication-config;
-    }
-
-    container state {
-      config false;
-      description
-        "This container defines ISIS authentication state.";
-
-      uses isis-authentication-config;
-    }
-
-    container key {
-      description
-        "This container defines ISIS authentication key";
-      container config {
-        description
-          "This container defines ISIS authentication key configuration.";
-
-        uses authentication-key-group-config {
-          // TODO(aashaikh):  Add auth-type conditions after merge of
-          // auth models.
-          // when "../auth-type = 'KEY'";
-        }
-      }
-
-      container state {
-        config false;
-        description
-          "This container defines ISIS authentication key state.";
-
-        uses authentication-key-group-config {
-          // TODO(aashaikh):  Add auth-type conditions after merge of
-          // auth models.
-          // when "../auth-type = 'KEY'";
-        }
-      }
-    }
-
-    uses keychain-base-group  {
-      // TODO(aashaikh):  Add auth-type conditions after merge of
-      // auth models.
-      // when "../auth-type = 'KEY_CHAIN'";
-    }
-  }
-
   grouping isis-hello-authentication-config {
     description
       "Configuration options for IS-IS hello authentication.";
 
-    leaf hello-authentication {
+    leaf enabled {
       type boolean;
       default false;
       description
-        "Enabled or disable ISIS Hello authentication.";
+        "Enabled or disable ISIS Hello authentication. Hello authentication
+        is used on a per-interface basis to authenticate adjacencies on the
+        interface.";
     }
 
-    // TODO(robjs): Add hello-auth-type following merge of auth models.
-    //leaf hello-auth-type {
-    //  type oc-auth-types:auth-type;
-    //  description
-    //    "ISIS authentication type (key, key-chain).";
-    //}
+    leaf keychain {
+      type oc-keychain:keychain-ref;
+      description
+        "Reference to a keychain that should be used for hello authentication.";
+    }
   }
 
   grouping isis-hello-authentication-group {
@@ -412,40 +304,6 @@ module openconfig-isis {
         "This container defines ISIS authentication state.";
 
       uses isis-hello-authentication-config;
-    }
-
-    container key {
-      description
-        "This container defines ISIS authentication key";
-
-      container config {
-        description
-          "This container defines ISIS authentication key configuration.";
-
-        uses authentication-key-group-config {
-          // TODO(aashaikh):  Add auth-type conditions after merge of
-          // auth models.
-          // when "../auth-type = 'KEY'";
-        }
-      }
-
-      container state {
-        config false;
-        description
-          "This container defines ISIS authentication key state.";
-
-        uses authentication-key-group-config {
-          // TODO(aashaikh):  Add auth-type conditions after merge of
-          // auth models.
-          // when "../auth-type = 'KEY'";
-        }
-      }
-    }
-
-    uses keychain-base-group  {
-      // TODO(aashaikh):  Add auth-type conditions after merge of
-      // auth models.
-      // when "../auth-type = 'KEY_CHAIN'";
     }
   }
 
@@ -477,13 +335,13 @@ module openconfig-isis {
       "This grouping defines ISIS Traffic Engineering configuration.";
 
     leaf ipv4-router-id {
-      type inet:ipv4-address-no-zone;
+      type oc-inet:ipv4-address;
       description
         "IPv4 MPLS Traffic Engineering Router-ID.";
     }
 
     leaf ipv6-router-id {
-      type inet:ipv6-address-no-zone;
+      type oc-inet:ipv6-address;
       description
         "IPv6 MPLS Traffic Engineering Router-ID.";
     }
@@ -922,22 +780,6 @@ module openconfig-isis {
       "Policy governing the propagation of prefixes between levels.";
 
     uses oc-rpol:apply-policy-import-config;
-  }
-
-  grouping authentication-key-group-config {
-    description
-      "This grouping defines ISIS authentication key configuration.";
-
-    uses authentication-key-config;
-
-    // TODO(robjs): Add crypto-algorithm after merge of authentication modules.
-    //leaf crypto-algorithm {
-    //  type identityref {
-    //    base oc-auth-types:CRYPTO_TYPE;
-    //  }
-    //  description
-    //    "Authentication key cryptographic algorithm to be used for key encryption.";
-    //}
   }
 
   grouping isis-mpls-config {
@@ -1486,9 +1328,77 @@ module openconfig-isis {
     container authentication {
       description
         "This container defines ISIS authentication.";
-      uses isis-authentication-group;
+      uses isis-level-authentication-group;
+    }
+  }
+
+  grouping isis-level-authentication-group {
+    description
+      "Grouping containing structural elements for authentication in IS-IS.";
+
+    container config {
+      description
+        "Configuration parameters relating to IS-IS authentication.";
+
+      uses isis-level-authentication-config;
     }
 
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to IS-IS authentication.";
+      uses isis-level-authentication-config;
+    }
+  }
+
+  grouping isis-level-authentication-config {
+    description
+      "Configuration leaves for IS-IS authentication.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication of IS-IS PSNP, CSNP and
+        LSP packets is enabled using the authentication details specified in
+        the keychain in the sibling leaf.
+
+        The simbling 'disable-<type>' leaves can be used to override the value
+        of this leaf and disable authentication for a specific packet type.";
+    }
+
+    leaf disable-csnp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for CSNP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf disable-psnp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for PSNP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf disable-lsp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for LSP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf keychain {
+      type oc-keychain:keychain-ref;
+      description
+        "Reference to the keychain that should be used for authenticating IS-IS
+        packets - the keychain may contain either a simple password, or
+        HMAC-MD5 key that is used for authenticating CSNP, PSNP and LSP packets
+        within the specified IS-IS level.";
+    }
   }
 
   grouping isis-interface-level-group {
@@ -1630,13 +1540,13 @@ module openconfig-isis {
     }
 
     leaf neighbor-ipv4-address {
-      type inet:ipv4-address-no-zone;
+      type oc-inet:ipv4-address;
       description
         "ISIS Neighbor IPv4 address.";
     }
 
     leaf neighbor-ipv6-address {
-      type inet:ipv6-address-no-zone;
+      type oc-inet:ipv6-address;
       description
         "ISIS Neighbor IPv6 address.";
     }
@@ -1691,18 +1601,12 @@ module openconfig-isis {
       reference "RFC4303. TLV 240.";
     }
 
-    leaf remaining-hold-time {
-      type uint16;
-      units seconds;
+    leaf up-timestamp {
+      type oc-types:timeticks64;
       description
-        "Holding time in seconds for adjacency. This value is based on received
-        hello PDUs and the elapsed time since receipt.";
-    }
-
-    leaf up-time {
-      type yang:timestamp;
-      description
-        "Adjacency up time.";
+        "Time at which the adjacency transitioned into the up state, expressed
+        as number of nanoseconds since the Unix epoch (Jan 1, 1970 00:00:00
+        UTC).";
     }
 
     leaf multi-topology {
@@ -1784,32 +1688,32 @@ module openconfig-isis {
       "Operational state parameters relating to LSP packet counters.";
 
     leaf received {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of the specified type of PDU received on the interface.";
     }
     leaf processed {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of the specified type of PDU received on the interface
         that have been processed by the local system.";
     }
     leaf dropped {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of the specified type of PDU received on the interface
         that have been dropped.";
     }
 
     leaf sent {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of the specified type of PDU that have been sent by the
         local system on the interface.";
     }
 
     leaf retransmit {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of the specified type of PDU that that have been
         retransmitted by the local system on the interface.";
@@ -1917,7 +1821,7 @@ module openconfig-isis {
       "IS-IS counters that are relevant to the system IS-IS context.";
 
     leaf corrupted-lsps {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of corrupted in-memory LSPs detected. LSPs received from the
         wire with a bad checksum are silently dropped and not counted. LSPs
@@ -1926,7 +1830,7 @@ module openconfig-isis {
     }
 
     leaf database-overloads {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times the database has become
         overloaded.
@@ -1934,27 +1838,27 @@ module openconfig-isis {
     }
 
     leaf manual-address-drop-from-areas {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times a manual address has been dropped from area.
         MIB Entry: SysManAddrDropFromAreas.";
     }
 
     leaf exceed-max-seq-nums {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of times the system has attempted to exceed the maximum
         sequence number. MIB Entry: SysAttmptToExMaxSeqNums.";
     }
     leaf seq-num-skips {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times a sequence number skip has occurred. MIB Entry:
         SysSeqNumSkips.";
     }
 
     leaf own-lsp-purges {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times a zero-aged copy of the system's
         own LSP is received from some other node.
@@ -1962,7 +1866,7 @@ module openconfig-isis {
     }
 
     leaf id-len-mismatch {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times a PDU is received with a different value for ID field
         length from that of the receiving system. MIB Entry:
@@ -1970,13 +1874,13 @@ module openconfig-isis {
     }
 
     leaf part-changes {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of partition changes detected. MIB Entry: SysPartChanges.";
     }
 
     leaf max-area-address-mismatches {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times a PDU is received with a different value for
         MaximumAreaAddresses from that of the receiving system. MIB Entry:
@@ -1984,26 +1888,26 @@ module openconfig-isis {
     }
 
     leaf auth-fails {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of authentication key failures.
          MIB Entry: SysAuthFails.";
     }
 
     leaf spf-runs {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of times SPF was ran at this level.";
     }
 
     leaf auth-type-fails {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of authentication type mismatches.";
     }
 
     leaf lsp-errors {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "The number of received LSPs with errors.";
     }
@@ -2028,28 +1932,28 @@ module openconfig-isis {
       interface or circuit.";
 
     leaf adj-changes {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an adjacency state change has occurred on this circuit.
         MIB Entry: CircAdjChanges.";
     }
 
     leaf init-fails {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times initialization of this circuit has failed. This counts
         events such as PPP NCP failures. MIB Entry: CircInitFails.";
     }
 
     leaf rejected-adj {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an adjacency has been rejected on this circuit. MIB
         Entry: CircRejAdjs.";
     }
 
     leaf id-field-len-mismatches {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an IS-IS control PDU with an ID field length different
         from that for this system has been received.
@@ -2057,7 +1961,7 @@ module openconfig-isis {
     }
 
     leaf max-area-address-mismatches {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an IS-IS control PDU with a max area address field
         different from that for this system has been received. MIB Entry:
@@ -2065,7 +1969,7 @@ module openconfig-isis {
     }
 
     leaf auth-type-fails {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an IS-IS control PDU with an auth type field different
         from that for this system has been received. MIB Entry:
@@ -2073,14 +1977,14 @@ module openconfig-isis {
     }
 
     leaf auth-fails {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times an IS-IS control PDU with the correct auth type has
         failed to pass authentication validation. MIB Entry: CircAuthFails.";
     }
 
     leaf lan-dis-changes {
-      type yang:counter32;
+      type oc-yang:counter32;
       description
         "Number of times the Designated IS has changed on this circuit at this
         level. If the circuit is point to point, this count is zero. MIB Entry:

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -53,7 +53,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.7.1";
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
 
   revision "2021-12-31" {
     description

--- a/release/models/keychain/openconfig-keychain.yang
+++ b/release/models/keychain/openconfig-keychain.yang
@@ -32,12 +32,27 @@ module openconfig-keychain {
     which may be then referenced by other models such as routing protocol
     management.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2021-12-31" {
+    description
+      "Add keychain-ref type to allow for a resuable reference to a keychain.";
+    reference "0.2.0";
+  }
 
   revision "2021-10-01" {
     description
       "Initial revision of keychain model.";
     reference "0.1.0";
+  }
+
+  typedef keychain-ref {
+    type leafref {
+      path "/keychains/keychain/config/name";
+    }
+    description
+      "A reference to a keychain defined on the system that can be used by
+      modules that require access to keychains.";
   }
 
   grouping valid-lifetime-config {

--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,31 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.0.1";
+  oc-ext:openconfig-version "3.2.2";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.2.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
 
   revision "2018-11-21" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -23,7 +23,31 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.0.1";
+  oc-ext:openconfig-version "3.2.2";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.2.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
 
   revision "2018-11-21" {
     description

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -29,12 +29,12 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.1.2";
+  oc-ext:openconfig-version "3.2.2";
 
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";
-    reference "3.1.2";
+    reference "3.2.2";
   }
 
   revision "2021-06-16" {

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -23,7 +23,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "0.16.1";
+  oc-ext:openconfig-version "0.16.2";
+
+  revision "2021-11-17" {
+    description
+      "Add prefix to qualification prefix to when statements
+      at identifier level.";
+    reference "0.16.2";
+  }
 
   revision "2021-07-22" {
     description

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,7 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
 
   revision "2021-03-17" {
     description

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,7 +23,19 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.2.2";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
 
   revision "2019-11-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,7 +17,19 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.2.2";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
 
   revision "2019-11-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,7 +23,19 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.2.2";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
 
   revision "2019-11-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,12 +22,18 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.2.3";
+  oc-ext:openconfig-version "0.3.1";
 
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";
-    reference "0.2.3";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
   }
 
   revision "2019-11-28" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,18 +34,18 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.2.4";
+  oc-ext:openconfig-version "0.3.1";
 
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";
-    reference "0.2.4";
+    reference "0.3.1";
   }
 
   revision "2021-03-17" {
     description
       "Add bfd support without augmentation.";
-    reference "0.2.3";
+    reference "0.3.0";
   }
 
   revision "2019-11-28" {

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -24,7 +24,13 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.1.1";
+  oc-ext:openconfig-version "3.2.1";
+
+  revision "2021-12-10" {
+    description
+      "Add INSTALL_PROTOCOL_TYPE gRIBI.";
+    reference "3.2.1";
+  }
 
   revision "2018-11-21" {
     description
@@ -227,5 +233,10 @@ module openconfig-policy-types {
       "Internet Group Management Protocol";
     reference
       "RFC 3376";
+  }
+
+  identity GRIBI {
+    base INSTALL_PROTOCOL_TYPE;
+    description "gRPC Routing Information Base Interface";
   }
 }

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2021-08-28" {
+    description
+      "Revision updating memory management profile WRED and RED configuration.";
+    reference "0.5.0";
+  }
 
   revision "2021-04-28" {
     description

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2021-08-28" {
+    description
+      "Revision updating memory management profile WRED and RED configuration.";
+    reference "0.5.0";
+  }
 
   revision "2021-04-28" {
     description

--- a/release/models/rib/openconfig-rib-bgp-table-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-table-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-table-attributes {
     "This submodule contains common data definitions for data
     related to a RIB entry, or RIB table.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
 
   revision "2019-04-25" {
     description


### PR DESCRIPTION
Included changes 

* Add gRIBI as an install protocol. (#1073)
* Adding pop-top-label in NH AFT entry state. (#1070)
* Fix Modules and Submodules to have the same version string. (#1057)
* Add support for authentication in IS-IS. (#1069)
* Add VXLAN as an encapsulation header type.
