### PR TITLE
Add ATE telemetry modules for BGP, ISIS, interface

### DIFF
--- a/release/models/ate/.spec.yml
+++ b/release/models/ate/.spec.yml
@@ -2,7 +2,11 @@
   docs:
     - yang/ate/openconfig-ate-flow.yang
     - yang/ate/openconfig-ate-intf.yang
+    - yang/ate/openconfig-ate-bgp.yang
+    - yang/ate/openconfig-ate-isis.yang
   build:
     - yang/ate/openconfig-ate-flow.yang
     - yang/ate/openconfig-ate-intf.yang
+    - yang/ate/openconfig-ate-bgp.yang
+    - yang/ate/openconfig-ate-isis.yang
   run-ci: true

--- a/release/models/ate/openconfig-ate-bgp.yang
+++ b/release/models/ate/openconfig-ate-bgp.yang
@@ -6,7 +6,7 @@ module openconfig-ate-bgp {
 
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-yang-types { prefix "oc-yang"; }
-  
+
   organization
     "OpenConfig working group";
 
@@ -15,8 +15,8 @@ module openconfig-ate-bgp {
      netopenconfig@googlegroups.com";
 
   description
-    "This module defines telemetry that relates to BGP sessions that 
-    are controlled by automated test equipment (ATE) whose definition 
+    "This module defines telemetry that relates to BGP sessions that
+    are controlled by automated test equipment (ATE) whose definition
     is outside of the context of this module.";
 
   oc-ext:openconfig-version "0.1.0";
@@ -31,7 +31,7 @@ module openconfig-ate-bgp {
 
   grouping bgp-top {
     description
-      "Top-level structural grouping for BGP session telemetry 
+      "Top-level structural grouping for BGP session telemetry
       entries.";
 
     container bgp-peers {
@@ -44,7 +44,7 @@ module openconfig-ate-bgp {
         config false;
 
         description
-          "Each BGP peer is identified by an arbitrary string 
+          "Each BGP peer is identified by an arbitrary string
           identifier.";
 
         leaf name {
@@ -52,7 +52,7 @@ module openconfig-ate-bgp {
             path "../state/name";
           }
           description
-            "Reference to the BGP peer's name, acting as a key of the 
+            "Reference to the BGP peer's name, acting as a key of the
             BGP peer list.";
         }
 
@@ -82,7 +82,7 @@ module openconfig-ate-bgp {
     leaf name {
       type string;
       description
-        "An arbitary name of the BGP peer determined by the ATE 
+        "An arbitary name of the BGP peer determined by the ATE
         configuration.";
     }
 
@@ -116,7 +116,7 @@ module openconfig-ate-bgp {
           }
           enum ESTABLISHED {
             description
-              "Neighbor is up. The BGP session with the peer is 
+              "Neighbor is up. The BGP session with the peer is
               established";
           }
         }
@@ -132,7 +132,7 @@ module openconfig-ate-bgp {
     leaf flaps {
       type oc-yang:counter64;
       description
-        "The total number of times the BGP session went from an 
+        "The total number of times the BGP session went from an
         ESTABLISHED state to an IDLE state.";
     }
 

--- a/release/models/ate/openconfig-ate-bgp.yang
+++ b/release/models/ate/openconfig-ate-bgp.yang
@@ -1,0 +1,213 @@
+module openconfig-ate-bgp {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/ate-bgp";
+  prefix "oc-ate-bgp";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     netopenconfig@googlegroups.com";
+
+  description
+    "This module defines telemetry that relates to BGP sessions that 
+    are controlled by automated test equipment (ATE) whose definition 
+    is outside of the context of this module.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2022-01-21 {
+    description "Initial revision.";
+    reference "0.1.0";
+  }
+
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping bgp-top {
+    description
+      "Top-level structural grouping for BGP session telemetry 
+      entries.";
+
+    container bgp-peers {
+      description
+        "BGP peer session telemetry collected by the ATE device.";
+
+      list bgp-peer {
+        key "name";
+
+        config false;
+
+        description
+          "Each BGP peer is identified by an arbitrary string 
+          identifier.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the BGP peer's name, acting as a key of the 
+            BGP peer list.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state of an individual BGP peer.";
+
+          uses bgp-state;
+
+          container counters {
+            description
+              "Counters of an individual BGP peer.";
+
+            uses bgp-counters;
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-state {
+    description
+      "Operational state of the individual BGP peer.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of the BGP peer determined by the ATE 
+        configuration.";
+    }
+
+    leaf session-state {
+      type enumeration {
+          enum IDLE {
+            description
+              "Neighbor is down, and in the Idle state of the
+              FSM";
+          }
+          enum CONNECT {
+            description
+              "Neighbor is down, and the session is waiting for
+              the underlying transport session to be established";
+          }
+          enum ACTIVE {
+            description
+              "Neighbor is down, and the local system is awaiting
+              a connection from the remote peer";
+          }
+          enum OPEN_SENT {
+            description
+              "Neighbor is in the process of being established.
+              The local system has sent an OPEN message";
+          }
+          enum OPEN_CONFIRM {
+            description
+              "Neighbor is in the process of being established.
+              The local system is awaiting a NOTIFICATION or
+              KEEPALIVE message";
+          }
+          enum ESTABLISHED {
+            description
+              "Neighbor is up. The BGP session with the peer is 
+              established";
+          }
+        }
+        description
+          "Operational state of the BGP peer";
+    }
+  }
+
+  grouping bgp-counters {
+    description
+      "Counters of an indivdual BGP session.";
+
+    leaf flaps {
+      type oc-yang:counter64;
+      description
+        "The total number of times the BGP session went from an 
+        ESTABLISHED state to an IDLE state.";
+    }
+
+    leaf in-routes {
+      type oc-yang:counter64;
+      description
+        "The total number of routes received.";
+    }
+
+    leaf out-routes {
+      type oc-yang:counter64;
+      description
+        "The total number of routes advertised.";
+    }
+
+    leaf in-route-withdraw {
+      type oc-yang:counter64;
+      description
+        "The total number of route withdraws received.";
+    }
+
+    leaf out-route-withdraw {
+      type oc-yang:counter64;
+      description
+        "The total number of route withdraws sent.";
+    }
+
+    leaf in-updates {
+      type oc-yang:counter64;
+      description
+        "The total number of UPDATE messages received.";
+    }
+
+    leaf out-updates {
+      type oc-yang:counter64;
+      description
+        "The total number of UPDATE messages sent.";
+    }
+
+    leaf in-opens {
+      type oc-yang:counter64;
+      description
+        "The total number of OPEN messages received.";
+    }
+
+    leaf out-opens {
+      type oc-yang:counter64;
+      description
+        "The total number of OPEN messages sent.";
+    }
+
+    leaf in-keepalives {
+      type oc-yang:counter64;
+      description
+        "The total number of KEEPALIVE messages received.";
+    }
+
+    leaf out-keepalives {
+      type oc-yang:counter64;
+      description
+        "The total number of KEEPALIVE messages sent.";
+    }
+
+    leaf in-notifications {
+      type oc-yang:counter64;
+      description
+        "The total number of NOTIFICATION messages received.";
+    }
+
+    leaf out-notifications {
+      type oc-yang:counter64;
+      description
+        "The total number of NOTIFICATION messages sent.";
+    }
+  }
+
+  uses bgp-top;
+}

--- a/release/models/ate/openconfig-ate-intf.yang
+++ b/release/models/ate/openconfig-ate-intf.yang
@@ -2,11 +2,12 @@ module openconfig-ate-intf {
   yang-version "1";
 
   namespace "http://openconfig.net/yang/ate-intf";
-  prefix "oc-atei";
+  prefix "oc-ate-if";
 
   import openconfig-extensions { prefix  "oc-ext"; }
   import openconfig-types { prefix "oc-types"; }
-  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
 
   organization
     "OpenConfig working group";
@@ -16,11 +17,18 @@ module openconfig-ate-intf {
      netopenconfig@googlegroups.com";
 
   description
-    "This module defines augments to the OpenConfig tree specifically for
-    automated test equipment (ATE) devices. These parameters are not widely
-    supported by non-ATE devices.";
+    "This module defines telemetry that relates to interfaces that are 
+    defined by automated test equipment (ATE). The definition of ATE 
+    interfaces is outside of the context of this module.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision 2022-01-21 {
+    description 
+      "Migrate ATE interface to standalone module and add discovery
+      models.";
+    reference "0.2.0";
+  }
 
   revision 2019-08-07 {
     description "Initial revision.";
@@ -31,32 +39,213 @@ module openconfig-ate-intf {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  grouping interface-rate {
+  grouping interface-top {
     description
-      "Calculated rate parameters for interfaces supported directly by
-      ATE devices.";
+      "Top-level structural grouping for ATE interface entries.";
+
+    container interfaces {
+      description
+        "Interfaces defined by an ATE.";
+
+      list interface {
+        key "name";
+
+        config false;
+
+        description
+          "An individual interface defined by an ATE.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the interface's name, acting as a key of 
+            the interfaces list.";
+        }
+
+        container state {
+          description 
+            "Operational state of an individual ATE interface.";
+          uses state;
+        }
+
+        container neighbors {
+          description
+            "Discovered neighbors of an ATE interface";
+          uses neighbors;
+        }
+      }
+    }
+  }
+
+  grouping state {
+    description
+      "Operational state of an ATE interface.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of an ATE interface determined by the ATE 
+        configuration.";
+    }
+
+    leaf link {
+      type enumeration {
+        enum UP {
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          description
+            "Not ready to pass packets.";
+        }
+      }
+
+      description
+        "The current state of an ATE interface.";
+    }
 
     leaf out-rate {
       type oc-types:ieeefloat32;
       units "bps";
       description
-        "The calculated transmitted rate of the interface, measured in bits
-        per second.";
+        "The current transmit rate of an ATE interface, measured in 
+        bits per second.";
     }
 
     leaf in-rate {
       type oc-types:ieeefloat32;
       units "bps";
       description
-        "The calculate received rate of the interface, measured in bits
-        per second.";
+        "The current receive rate of an ATE interface, measured in 
+        bits per second.";
+    }
+
+    container counters {
+      description
+        "Counters of an ATE interface.";
+      uses counters;
     }
   }
 
-  augment "/oc-if:interfaces/oc-if:interface/oc-if:state" {
+  grouping counters {
     description
-      "Augment the OpenConfig interfaces base model with ATE specific
-      state parameters.";
-    uses interface-rate;
+      "Counters of an ATE interface.";
+
+      leaf out-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets transmitted on the interface.";
+      }
+
+      leaf in-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets received on the interface.";
+      }
+
+      leaf out-frames {
+        type oc-yang:counter64;
+        description
+          "The total number of packets transmitted on the interface.";
+      }
+
+      leaf in-frames {
+        type oc-yang:counter64;
+        description
+          "The total number of packets received on the interface.";
+      }
   }
+
+  grouping neighbors {
+    description
+      "Structural grouping of discovered neighbors.";
+
+    list ipv4-neighbor {
+      key ipv4-address;
+
+      description
+        "The interface neighbor state or ARP cache entry.";
+
+      leaf ipv4-address {
+        type leafref {
+          path "../state/ipv4-address";
+        }
+
+        description
+          "The IPv4 address of the neighbor.";
+      }
+
+      uses neighbor-ipv4-state;
+    }
+
+    list ipv6-neighbor {
+      key ipv6-address;
+
+      description
+        "The interface neighbor state or NDISC cache entry.";
+
+      leaf ipv6-address {
+        type leafref {
+          path "../state/ipv6-address";
+        }
+
+        description
+          "The IPv6 address of the neighbor.";
+      }
+
+      uses neighbor-ipv6-state;
+    }
+  }
+
+  grouping neighbor-ipv4-state {
+    description
+      "Structural grouping of IPv4 neighbor information.";
+
+    container state {
+      description
+        "State of IPv4 neighbor information";
+
+      leaf ipv4-address {
+        type oc-inet:ipv4-address;
+
+        description
+          "The IPv4 address of the neighbor.";
+      }
+
+      leaf link-layer-address {
+        type oc-yang:mac-address;
+
+        description
+          "The link layer address or MAC address of the neighbor.";
+      }
+    }
+  }
+
+  grouping neighbor-ipv6-state {
+    description
+      "Structural grouping of IPv6 neighbor information.";
+
+    container state {
+      description
+        "State of IPv6 neighbor information";
+
+      leaf ipv6-address {
+        type oc-inet:ipv6-address;
+
+        description
+          "The IPv6 address of the neighbor.";
+      }
+
+      leaf link-layer-address {
+        type oc-yang:mac-address;
+
+        description
+          "The link layer address or MAC address of the neighbor.";
+      }
+    }
+  }
+
+  uses interface-top;
 }

--- a/release/models/ate/openconfig-ate-intf.yang
+++ b/release/models/ate/openconfig-ate-intf.yang
@@ -70,10 +70,16 @@ module openconfig-ate-intf {
           uses interface-state;
         }
 
-        container neighbors {
+        container ipv4-neighbors {
           description
             "Discovered neighbors of an ATE interface";
-          uses interface-neighbors;
+          uses ipv4-neighbors;
+        }
+
+        container ipv6-neighbors {
+          description
+            "Discovered neighbors of an ATE interface";
+          uses ipv6-neighbors;
         }
       }
     }
@@ -158,12 +164,13 @@ module openconfig-ate-intf {
       }
   }
 
-  grouping interface-neighbors {
+  grouping ipv4-neighbors {
     description
-      "Structural grouping of an interface's discovered neighbors.";
+      "Structural grouping of an interface's discovered IPv4
+      neighbors.";
 
     list ipv4-neighbor {
-      key ipv4-address;
+      key "ipv4-address";
 
       description
         "The interface neighbor state or ARP cache entry.";
@@ -179,9 +186,15 @@ module openconfig-ate-intf {
 
       uses neighbor-ipv4-state;
     }
+  }
+
+  grouping ipv6-neighbors {
+    description
+      "Structural grouping of an interface's discovered IPv6
+      neighbors.";
 
     list ipv6-neighbor {
-      key ipv6-address;
+      key "ipv6-address";
 
       description
         "The interface neighbor state or NDISC cache entry.";

--- a/release/models/ate/openconfig-ate-intf.yang
+++ b/release/models/ate/openconfig-ate-intf.yang
@@ -67,19 +67,19 @@ module openconfig-ate-intf {
         container state {
           description 
             "Operational state of an individual ATE interface.";
-          uses state;
+          uses interface-state;
         }
 
         container neighbors {
           description
             "Discovered neighbors of an ATE interface";
-          uses neighbors;
+          uses interface-neighbors;
         }
       }
     }
   }
 
-  grouping state {
+  grouping interface-state {
     description
       "Operational state of an ATE interface.";
 
@@ -125,11 +125,11 @@ module openconfig-ate-intf {
     container counters {
       description
         "Counters of an ATE interface.";
-      uses counters;
+      uses interface-counters;
     }
   }
 
-  grouping counters {
+  grouping interface-counters {
     description
       "Counters of an ATE interface.";
 
@@ -158,9 +158,9 @@ module openconfig-ate-intf {
       }
   }
 
-  grouping neighbors {
+  grouping interface-neighbors {
     description
-      "Structural grouping of discovered neighbors.";
+      "Structural grouping of an interface's discovered neighbors.";
 
     list ipv4-neighbor {
       key ipv4-address;

--- a/release/models/ate/openconfig-ate-intf.yang
+++ b/release/models/ate/openconfig-ate-intf.yang
@@ -60,25 +60,25 @@ module openconfig-ate-intf {
             path "../state/name";
           }
           description
-            "Reference to the interface's name, acting as a key of
+            "Reference to an interface's name, acting as a key of
             the interfaces list.";
         }
 
         container state {
           description
-            "Operational state of an individual ATE interface.";
+            "Operational state of an individual interface.";
           uses interface-state;
         }
 
         container ipv4-neighbors {
           description
-            "Discovered neighbors of an ATE interface";
+            "Discovered neighbors of an interface";
           uses ipv4-neighbors;
         }
 
         container ipv6-neighbors {
           description
-            "Discovered neighbors of an ATE interface";
+            "Discovered neighbors of an interface";
           uses ipv6-neighbors;
         }
       }

--- a/release/models/ate/openconfig-ate-intf.yang
+++ b/release/models/ate/openconfig-ate-intf.yang
@@ -17,14 +17,14 @@ module openconfig-ate-intf {
      netopenconfig@googlegroups.com";
 
   description
-    "This module defines telemetry that relates to interfaces that are 
-    defined by automated test equipment (ATE). The definition of ATE 
+    "This module defines telemetry that relates to interfaces that are
+    defined by automated test equipment (ATE). The definition of ATE
     interfaces is outside of the context of this module.";
 
   oc-ext:openconfig-version "0.2.0";
 
   revision 2022-01-21 {
-    description 
+    description
       "Migrate ATE interface to standalone module and add discovery
       models.";
     reference "0.2.0";
@@ -60,12 +60,12 @@ module openconfig-ate-intf {
             path "../state/name";
           }
           description
-            "Reference to the interface's name, acting as a key of 
+            "Reference to the interface's name, acting as a key of
             the interfaces list.";
         }
 
         container state {
-          description 
+          description
             "Operational state of an individual ATE interface.";
           uses interface-state;
         }
@@ -86,7 +86,7 @@ module openconfig-ate-intf {
     leaf name {
       type string;
       description
-        "An arbitary name of an ATE interface determined by the ATE 
+        "An arbitary name of an ATE interface determined by the ATE
         configuration.";
     }
 
@@ -110,7 +110,7 @@ module openconfig-ate-intf {
       type oc-types:ieeefloat32;
       units "bps";
       description
-        "The current transmit rate of an ATE interface, measured in 
+        "The current transmit rate of an ATE interface, measured in
         bits per second.";
     }
 
@@ -118,7 +118,7 @@ module openconfig-ate-intf {
       type oc-types:ieeefloat32;
       units "bps";
       description
-        "The current receive rate of an ATE interface, measured in 
+        "The current receive rate of an ATE interface, measured in
         bits per second.";
     }
 

--- a/release/models/ate/openconfig-ate-isis.yang
+++ b/release/models/ate/openconfig-ate-isis.yang
@@ -6,7 +6,7 @@ module openconfig-ate-isis {
 
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-yang-types { prefix "oc-yang"; }
-  
+
   organization
     "OpenConfig working group";
 
@@ -15,8 +15,8 @@ module openconfig-ate-isis {
      netopenconfig@googlegroups.com";
 
   description
-    "This module defines telemetry that relates to ISIS sessions that 
-    are controlled by automated test equipment (ATE) whose definition 
+    "This module defines telemetry that relates to ISIS sessions that
+    are controlled by automated test equipment (ATE) whose definition
     is outside of the context of this module.";
 
   oc-ext:openconfig-version "0.1.0";
@@ -31,7 +31,7 @@ module openconfig-ate-isis {
 
   grouping isis-top {
     description
-      "Top-level structural grouping for ISIS router telemetry 
+      "Top-level structural grouping for ISIS router telemetry
       entries.";
 
     container isis-routers {
@@ -44,7 +44,7 @@ module openconfig-ate-isis {
         config false;
 
         description
-          "Each ISIS router is identified by an arbitrary string 
+          "Each ISIS router is identified by an arbitrary string
           identifier.";
 
         leaf name {
@@ -52,12 +52,12 @@ module openconfig-ate-isis {
             path "../state/name";
           }
           description
-            "Reference to the ISIS router's name, acting as a key of 
+            "Reference to the ISIS router's name, acting as a key of
             the ISIS router list.";
         }
 
         container state {
-          description 
+          description
             "Operational state of an individual ISIS router.";
           uses state;
         }
@@ -72,7 +72,7 @@ module openconfig-ate-isis {
     leaf name {
       type string;
       description
-        "An arbitary name of the ISIS router determined by the ATE 
+        "An arbitary name of the ISIS router determined by the ATE
         configuration.";
     }
 
@@ -120,7 +120,7 @@ module openconfig-ate-isis {
     leaf database-size {
       type oc-yang:counter64;
       description
-        "The total number of link state updates (LSPs) in the LSP 
+        "The total number of link state updates (LSPs) in the LSP
         databases.";
     }
 
@@ -139,56 +139,56 @@ module openconfig-ate-isis {
     leaf out-p2p-hellos {
       type oc-yang:counter64;
       description
-        "The total number of point to point (P2P) HELLO messages 
+        "The total number of point to point (P2P) HELLO messages
         sent.";
     }
 
     leaf in-p2p-hellos {
       type oc-yang:counter64;
       description
-        "The total number of point to point (P2P) HELLO messages 
+        "The total number of point to point (P2P) HELLO messages
         received.";
     }
 
     leaf out-psnp {
       type oc-yang:counter64;
       description
-        "The total number of partial sequence number packet (PSNPs) 
+        "The total number of partial sequence number packet (PSNPs)
         messages sent.";
     }
 
     leaf in-psnp {
       type oc-yang:counter64;
       description
-        "The total number of partial sequence number packet (PSNPs) 
+        "The total number of partial sequence number packet (PSNPs)
         messages received.";
     }
 
     leaf out-csnp {
       type oc-yang:counter64;
       description
-        "The total number of complete sequence number packet (CSNPs) 
+        "The total number of complete sequence number packet (CSNPs)
         messages sent.";
     }
 
     leaf in-csnp {
       type oc-yang:counter64;
       description
-        "The total number of complete sequence number packet (CSNPs) 
+        "The total number of complete sequence number packet (CSNPs)
         messages received.";
     }
 
     leaf out-lsp {
       type oc-yang:counter64;
       description
-        "The total number of link state protocol data units (LSPs) 
+        "The total number of link state protocol data units (LSPs)
         sent.";
     }
 
     leaf in-lsp {
       type oc-yang:counter64;
       description
-        "The total number of link state protocol data units (LSPs) 
+        "The total number of link state protocol data units (LSPs)
         received.";
     }
   }

--- a/release/models/ate/openconfig-ate-isis.yang
+++ b/release/models/ate/openconfig-ate-isis.yang
@@ -1,0 +1,197 @@
+module openconfig-ate-isis {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/ate-isis";
+  prefix "oc-ate-isis";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     netopenconfig@googlegroups.com";
+
+  description
+    "This module defines telemetry that relates to ISIS sessions that 
+    are controlled by automated test equipment (ATE) whose definition 
+    is outside of the context of this module.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2022-01-21 {
+    description "Initial revision.";
+    reference "0.1.0";
+  }
+
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping isis-top {
+    description
+      "Top-level structural grouping for ISIS router telemetry 
+      entries.";
+
+    container isis-routers {
+      description
+        "ISIS router telemetry collected by the ATE device.";
+
+      list isis-router {
+        key "name";
+
+        config false;
+
+        description
+          "Each ISIS router is identified by an arbitrary string 
+          identifier.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the ISIS router's name, acting as a key of 
+            the ISIS router list.";
+        }
+
+        container state {
+          description 
+            "Operational state of an individual ISIS router.";
+          uses state;
+        }
+      }
+    }
+  }
+
+  grouping state {
+    description
+      "Operational state of an individual ISIS router.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of the ISIS router determined by the ATE 
+        configuration.";
+    }
+
+    container level1 {
+      description
+        "Level1 state of the ISIS router.";
+      uses isis-state;
+    }
+
+    container level2 {
+      description
+        "Level2 state of the ISIS router.";
+      uses isis-state;
+    }
+  }
+
+  grouping isis-state {
+    description
+      "Operational state of the ISIS router.";
+
+    container counters {
+      description
+        "Counters of the ISIS router.";
+
+      uses isis-counters;
+    }
+  }
+
+  grouping isis-counters {
+    description
+      "Counters of the ISIS router.";
+
+    leaf sessions-up {
+      type oc-yang:counter64;
+      description
+        "The total number of sessions that are fully up.";
+    }
+
+    leaf sessions-flap {
+      type oc-yang:counter64;
+      description
+        "The total number of sessions flap.";
+    }
+
+    leaf database-size {
+      type oc-yang:counter64;
+      description
+        "The total number of link state updates (LSPs) in the LSP 
+        databases.";
+    }
+
+    leaf out-bcast-hellos {
+      type oc-yang:counter64;
+      description
+        "The total number of broadcast HELLO messages sent.";
+    }
+
+    leaf in-bcast-hellos {
+      type oc-yang:counter64;
+      description
+        "The total number of broacast HELLO messages received.";
+    }
+
+    leaf out-p2p-hellos {
+      type oc-yang:counter64;
+      description
+        "The total number of point to point (P2P) HELLO messages 
+        sent.";
+    }
+
+    leaf in-p2p-hellos {
+      type oc-yang:counter64;
+      description
+        "The total number of point to point (P2P) HELLO messages 
+        received.";
+    }
+
+    leaf out-psnp {
+      type oc-yang:counter64;
+      description
+        "The total number of partial sequence number packet (PSNPs) 
+        messages sent.";
+    }
+
+    leaf in-psnp {
+      type oc-yang:counter64;
+      description
+        "The total number of partial sequence number packet (PSNPs) 
+        messages received.";
+    }
+
+    leaf out-csnp {
+      type oc-yang:counter64;
+      description
+        "The total number of complete sequence number packet (CSNPs) 
+        messages sent.";
+    }
+
+    leaf in-csnp {
+      type oc-yang:counter64;
+      description
+        "The total number of complete sequence number packet (CSNPs) 
+        messages received.";
+    }
+
+    leaf out-lsp {
+      type oc-yang:counter64;
+      description
+        "The total number of link state protocol data units (LSPs) 
+        sent.";
+    }
+
+    leaf in-lsp {
+      type oc-yang:counter64;
+      description
+        "The total number of link state protocol data units (LSPs) 
+        received.";
+    }
+  }
+
+  uses isis-top;
+}


### PR DESCRIPTION
These are new proposed models for automated test equipment (ATE) telemetry.

The intent is to provide separate and specific models targeted for ATE telemetry.

- Interface telemetry (includes neighbor discovery)

```text
module: openconfig-ate-intf
  +--rw interfaces
     +--ro interface* [name]
        +--ro name              -> ../state/name
        +--ro state
        |  +--ro name?       string
        |  +--ro link?       enumeration
        |  +--ro out-rate?   oc-types:ieeefloat32
        |  +--ro in-rate?    oc-types:ieeefloat32
        |  +--ro counters
        |     +--ro out-octets?   oc-yang:counter64
        |     +--ro in-octets?    oc-yang:counter64
        |     +--ro out-frames?   oc-yang:counter64
        |     +--ro in-frames?    oc-yang:counter64
        +--ro ipv4-neighbors
        |  +--ro ipv4-neighbor* [ipv4-address]
        |     +--ro ipv4-address    -> ../state/ipv4-address
        |     +--ro state
        |        +--ro ipv4-address?         oc-inet:ipv4-address
        |        +--ro link-layer-address?   oc-yang:mac-address
        +--ro ipv6-neighbors
           +--ro ipv6-neighbor* [ipv6-address]
              +--ro ipv6-address    -> ../state/ipv6-address
              +--ro state
                 +--ro ipv6-address?         oc-inet:ipv6-address
                 +--ro link-layer-address?   oc-yang:mac-address
```  

- BGP telemetry
```text
module: openconfig-ate-bgp
  +--rw bgp-peers
     +--ro bgp-peer* [name]
        +--ro name     -> ../state/name
        +--ro state
           +--ro name?            string
           +--ro session-state?   enumeration
           +--ro counters
              +--ro flaps?                oc-yang:counter64
              +--ro in-routes?            oc-yang:counter64
              +--ro out-routes?           oc-yang:counter64
              +--ro in-route-withdraw?    oc-yang:counter64
              +--ro out-route-withdraw?   oc-yang:counter64
              +--ro in-updates?           oc-yang:counter64
              +--ro out-updates?          oc-yang:counter64
              +--ro in-opens?             oc-yang:counter64
              +--ro out-opens?            oc-yang:counter64
              +--ro in-keepalives?        oc-yang:counter64
              +--ro out-keepalives?       oc-yang:counter64
              +--ro in-notifications?     oc-yang:counter64
              +--ro out-notifications?    oc-yang:counter64
```

- ISIS telemetry
```text
module: openconfig-ate-isis
  +--rw isis-routers
     +--ro isis-router* [name]
        +--ro name     -> ../state/name
        +--ro state
           +--ro name?     string
           +--ro level1
           |  +--ro counters
           |     +--ro sessions-up?        oc-yang:counter64
           |     +--ro sessions-flap?      oc-yang:counter64
           |     +--ro database-size?      oc-yang:counter64
           |     +--ro out-bcast-hellos?   oc-yang:counter64
           |     +--ro in-bcast-hellos?    oc-yang:counter64
           |     +--ro out-p2p-hellos?     oc-yang:counter64
           |     +--ro in-p2p-hellos?      oc-yang:counter64
           |     +--ro out-psnp?           oc-yang:counter64
           |     +--ro in-psnp?            oc-yang:counter64
           |     +--ro out-csnp?           oc-yang:counter64
           |     +--ro in-csnp?            oc-yang:counter64
           |     +--ro out-lsp?            oc-yang:counter64
           |     +--ro in-lsp?             oc-yang:counter64
           +--ro level2
              +--ro counters
                 +--ro sessions-up?        oc-yang:counter64
                 +--ro sessions-flap?      oc-yang:counter64
                 +--ro database-size?      oc-yang:counter64
                 +--ro out-bcast-hellos?   oc-yang:counter64
                 +--ro in-bcast-hellos?    oc-yang:counter64
                 +--ro out-p2p-hellos?     oc-yang:counter64
                 +--ro in-p2p-hellos?      oc-yang:counter64
                 +--ro out-psnp?           oc-yang:counter64
                 +--ro in-psnp?            oc-yang:counter64
                 +--ro out-csnp?           oc-yang:counter64
                 +--ro in-csnp?            oc-yang:counter64
                 +--ro out-lsp?            oc-yang:counter64
                 +--ro in-lsp?             oc-yang:counter64
```
