### PR TITLE
Add vni-label and tunnel-src-ip-address properties under afts next-hops to support vxlan

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,8 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2022-01-26" {
     description
-      "Add vni-label property under next-hops for forwarding entries
-      that are learned from a remote VNI";
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
     reference "0.9.0";
   }
 
@@ -244,6 +243,13 @@ submodule openconfig-aft-common {
         network identifier (VNI) for the forwarding entry. This leaf is
         applicable only to next-hops which include VXLAN encapsulation
         header information";
+    }
+
+    leaf tunnel-src-ip-address {
+      type oc-inet:ip-address;
+      description
+        "Where applicable this represents the tunnel source ip address.
+        For VXLAN this represents the source VTEP ip address";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -10,6 +10,7 @@ submodule openconfig-aft-common {
   import openconfig-mpls-types { prefix "oc-mplst"; }
   import openconfig-policy-types { prefix "oc-pol-types"; }
   import openconfig-aft-types { prefix "oc-aftt"; }
+  import openconfig-evpn-types { prefix "oc-evpn-types"; }
 
   organization
     "OpenConfig working group";
@@ -22,7 +23,14 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label property under next-hops for forwarding entries
+      that are learned from a remote VNI";
+    reference "0.9.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -136,6 +144,7 @@ submodule openconfig-aft-common {
 
           uses aft-common-entry-nexthop-state;
           uses aft-labeled-entry-state;
+          uses aft-evpn-entry-state;
         }
 
         container ip-in-ip {
@@ -221,6 +230,20 @@ submodule openconfig-aft-common {
         forwarding entry. This leaf is applicable only to next-hops
         which include MPLS label information, and its value typically
         corresponds to the RSVP-TE LSP name.";
+    }
+  }
+
+  grouping aft-evpn-entry-state {
+    description
+      "Operational state for evpn related information in forwarding entry";
+
+    leaf vni-label {
+      type oc-evpn-types:evi-id;
+      description
+        "Where applicable, the next hop label representing the virtual
+        network identifier (VNI) for the forwarding entry. This leaf is
+        applicable only to next-hops which include VXLAN encapsulation
+        header information";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,12 +23,12 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
 
   revision "2022-01-26" {
     description
       "Add vni-label and tunnel-src-ip-address properties under next-hops";
-    reference "0.9.0";
+    reference "0.10.0";
   }
 
   revision "2021-08-06" {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description


### PR DESCRIPTION
This is a follow on PR now that VXLAN encapsulation support under `/network-instances/network-instance/afts/next-hops/next-hop/state` has been published

Commit: https://github.com/openconfig/public/commit/016a5aa279e40c4f5f15b838a63ec404c6372404

This PR adds two new properties:
  * `vni-label`: Where applicable, the next hop label representing the virtual
        network identifier (VNI) for the forwarding entry. This leaf is
        applicable only to next-hops which include VXLAN encapsulation
        header information
  * `tunnel-src-ip-address`: Where applicable this represents the tunnel source ip address.
        For VXLAN this represents the source VTEP ip address

**Here are two references (Cisco and Arista) to EVPN implementations which support this data:**

These two properties display important operational data for routing table entries that are installed into the forwarding information base (FIB) for the VXLAN BGP EVPN solution.

The model that represents FIB data in the current `network-instance` model is the `afts` container.

`/network-instances/network-instance/afts`

Our proposal adds the 2 properties under the `/network-instances/network-instance/afts/next-hops/next-hop/state` container

**CISCO:**

Here is an example of a host route that is learned and advertised over a VXLAN BGP EVPN fabric on Cisco NXOS devices

* The `vni-label` in this case is `470000`
* The `tunnel-src-ip-address` would be `10.3.0.1` and is derived from the `nve1` interface
    * NOTE: The nve interface is the Cisco abstraction for the tunnel interface.

```shell
n9k# show ip route 192.168.55.244/32 vrf green_red 
IP Route Table for VRF "green_red"
'*' denotes best ucast next-hop
'**' denotes best mcast next-hop
'[x/y]' denotes [preference/metric]
'%<string>' in via output denotes VRF <string>

192.168.55.244/32, ubest/mbest: 1/0
    *via 10.3.0.2%default, [200/0], 20:00:06, bgp-2408, internal, tag 2408, segid: 470000 tunnelid: 0xa030002 encap: VXLAN
 
n9k# 
```

```
n9k# show forwarding route 192.168.55.244/32 platform vrf green_red 

slot  1
=======


Prefix 192.168.55.244/32, No of paths: 1, Update time: Mon Apr  4 18:31:17 2022
   10.3.0.2           nve1        vni:   470000    
HH:0xb1ce0078  Flags:0x0  Holder:0x1  Next_obj_type:24
    Hw-idx L3 tunnel: unit-0:0xd0005 unit-1:0x0 unit-2:0x0, cmn-index: 500007, LIF:0 buf-idx 0(0)
    PfxLoc: unit-0:0x40019 unit-1:0x0,  flags 0x0

n9k# 
```

The tunnel source ip is configured using a loopback and sourced under the nve interface

```shell
interface nve1
  no shutdown
  host-reachability protocol bgp
  source-interface loopback1

interface loopback1
  description VTEP loopback interface
  ip address 10.3.0.1/32
  ip router ospf UNDERLAY area 0.0.0.0
  ip pim sparse-mode
```

**ARISTA:**

The [show ip route](https://www.arista.com/um-eos/eos-ipv4#xx1145358) command displays routing table entries that are in the forwarding information base (FIB)

Here is an example of a host route that is learned and advertised over a VXLAN BGP EVPN fabric on Arista devices

* The `vni-label` in this case is `20000`
* The `tunnel-src-ip-address` would be `10.0.0.20` and is derived from the `vxlan1` interface
    * NOTE: The vxlan1 interface is the Arista abstraction for the tunnel interface.


```shell
switch#show ip route vrf red 20.0.20.2/32

VRF: red
Codes: C - connected, S - static, K - kernel,
 O - OSPF, IA - OSPF inter area, E1 - OSPF external type 1,
 E2 - OSPF external type 2, N1 - OSPF NSSA external type 1,
 N2 - OSPF NSSA external type2, B - BGP, B I - iBGP, B E - eBGP,
 R - RIP, I L1 - IS-IS level 1, I L2 - IS-IS level 2,
 O3 - ospfv3, A B - BGP Aggregate, A O - OSPF Summary,
 NG - Nexthop Group Static Route, V - VXLAN Control Service,
 DH - DHCP client installed default route, M - Martian,
 DP - Dynamic Policy Route, L - VRF Leaked

 B E20.0.20.2/32 [200/0] via VTEP 10.255.0.0 VNI 20000 router-mac 00:00:78:01:00:00
 via VTEP 10.255.0.1 VNI 20000 router-mac 00:00:78:04:00:00
```

The tunnel source ip is configured using a loopback and sourced under the vxlan interface

```shell
interface Vxlan1
 vxlan source-interface Loopback0

interface Loopback0
 ip address 10.0.0.20/32
```


**DOC REFERENCES:**

* https://www.arista.com/en/um-eos/eos-evpn-vxlan-single-gateway-centralized-routing?searchword=eos%20section%2032%204%20ospfv3%20configuration%20examples
* https://www.arista.com/en/um-eos/eos-ipv4
* https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/92x/vxlan-92x/configuration/guide/b-cisco-nexus-9000-series-nx-os-vxlan-configuration-guide-92x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_9x_chapter_0100.html