### PR TITLE
fix a spelling error of the retransmission-queue-length leaf

### DIFF
--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,12 +25,12 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
   revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,7 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
 
   revision "2021-07-28" {
     description
@@ -292,7 +298,7 @@ submodule openconfig-ospfv2-area-interface {
         neighbor has been through";
     }
 
-    leaf retranmission-queue-length {
+    leaf retransmission-queue-length {
       type uint32;
       description
         "The number of LSAs that are currently in the queue to be

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -30,7 +30,7 @@ submodule openconfig-ospfv2-area {
       "Fix spelling error in retransmission-queue-length leaf.";
     reference "0.3.2";
   }
-  
+ 
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,12 +23,12 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
    revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -30,7 +30,7 @@ submodule openconfig-ospfv2-area {
       "Fix spelling error in retransmission-queue-length leaf.";
     reference "0.3.2";
   }
- 
+
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,14 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
 
+   revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
+  
   revision "2021-07-28" {
     description
       "Add prefix to qualify when statements.";

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,7 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
 
   revision "2021-07-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,12 +17,12 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
   revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,7 +23,13 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
 
   revision "2021-07-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,12 +23,12 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
   revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,12 +22,12 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
   revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,7 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
 
   revision "2021-07-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,7 +34,13 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.3.2";
+  }
 
   revision "2021-07-28" {
     description

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,12 +34,12 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
 
   revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2021-07-28" {


### PR DESCRIPTION
Minor spelling error within ospfv2-area-interface-neighbor-state grouping.