### PR TITLE
Synchronise `openconfig/models` and `openconfig/public` [2022-02-22]

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -25,7 +25,13 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.12.0";
+  oc-ext:openconfig-version "2.12.1";
+
+  revision "2021-07-20" {
+    description
+      "Fix typo in hardware MAC address description.";
+    reference "2.12.1";
+  }
 
   revision "2021-07-07" {
     description
@@ -585,7 +591,7 @@ module openconfig-if-ethernet {
     leaf hw-mac-address {
       type oc-yang:mac-address;
       description
-        "Represenets the 'burned-in', or system-assigned, MAC
+        "Represents the 'burned-in', or system-assigned, MAC
         address for the Ethernet interface.";
     }
 

--- a/release/models/optical-transport/openconfig-terminal-device.yang
+++ b/release/models/optical-transport/openconfig-terminal-device.yang
@@ -77,7 +77,15 @@ module openconfig-terminal-device {
     ports per linecard, separate linecards for client and line ports,
     etc.).";
 
-  oc-ext:openconfig-version "1.8.0";
+  oc-ext:openconfig-version "1.9.0";
+
+  revision "2021-07-29" {
+    description
+      "Add several coherent performance monitors to optical channel.
+      Re-group and add PHY-related performance monitors to optical
+      channel and logical channel.";
+    reference "1.9.0";
+  }
 
   revision "2021-02-23" {
     description
@@ -245,6 +253,13 @@ module openconfig-terminal-device {
 
       uses oc-eth:ethernet-interface-state-counters;
       uses terminal-ethernet-protocol-state-counters;
+      uses terminal-phy-protocol-stats {
+        description
+          "When 400ZR/ZR+ transceivers are plugged in switches or routers,
+          this grouping will be attached to logical channel with Ethernet
+          protocol framing, in order to involve host-side fec-related
+          error performances.";
+      }
   }
 
   grouping terminal-ethernet-protocol-state-counters {
@@ -261,7 +276,7 @@ module openconfig-terminal-device {
         "The number of received bit interleaved parity (BIP) errors
         at the physical coding sublayer (PCS). If the interface
         consists of multiple lanes, this will be the sum of all
-	errors on the lane";
+        errors on the lane";
     }
 
     leaf in-pcs-errored-seconds {
@@ -547,12 +562,6 @@ module openconfig-terminal-device {
       reference "ITU-T Rec. G.826";
     }
 
-    leaf fec-uncorrectable-blocks {
-      type yang:counter64;
-      description
-        "The number of blocks that were uncorrectable by the FEC";
-    }
-
     leaf fec-uncorrectable-words {
       type yang:counter64;
       description
@@ -578,10 +587,17 @@ module openconfig-terminal-device {
     }
   }
 
-  grouping terminal-otn-protocol-multi-stats {
+  grouping terminal-phy-protocol-stats {
     description
-      "Multi-value statistics containers for logical channels using
-      OTN framing (e.g., max, min, avg, instant)";
+      "Counters and multi-value statistics for FEC-related error
+      performance";
+
+    leaf fec-uncorrectable-blocks {
+      type yang:counter64;
+      description
+        "The number of blocks or frames that were uncorrectable by
+        the FEC";
+    }
 
     container pre-fec-ber {
       description
@@ -656,7 +672,11 @@ module openconfig-terminal-device {
           "Remote defect indication (RDI) message received";
       }
       uses terminal-otn-protocol-counter-stats;
-      uses terminal-otn-protocol-multi-stats;
+      uses terminal-phy-protocol-stats {
+        description
+          "This grouping may be used when the logical-channel-type
+          is 'PROT_OTN.";
+      }
   }
 
   grouping terminal-otn-protocol-top {
@@ -1271,7 +1291,6 @@ module openconfig-terminal-device {
       // leaf to be a leafref to a r/o leaf.
     }
 
-
     leaf line-port {
       type leafref {
         path "/oc-platform:components/oc-platform:component/" +
@@ -1345,6 +1364,152 @@ module openconfig-terminal-device {
         instant value";
 
       uses oc-types:avg-min-max-instant-stats-precision2-dB;
+    }
+
+    container modulator-bias-xi {
+      description
+        "The bias on in-phase path and Polarization X of
+        the coherent modulator. This is represented as a percentage
+        with 2 decimal precision. This term is defined by OIF
+        Implementation Agreement for Coherent CMIS. Values include
+        the instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container modulator-bias-xq {
+      description
+        "The bias on quadrature path and Polarization X of
+        the coherent modulator. This is represented as a percentage
+        with 2 decimal precision. This term is defined by OIF
+        Implementation Agreement for Coherent CMIS. Values include
+        the instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container modulator-bias-yi {
+      description
+        "The bias on in-phase path and Polarization Y of
+        the coherent modulator. This is represented as a percentage
+        with 2 decimal precision. This term is defined by OIF
+        Implementation Agreement for Coherent CMIS. Values include
+        the instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container modulator-bias-yq {
+      description
+        "The bias on quadrature path and Polarization Y of
+        the coherent modulator. This is represented as a percentage
+        with 2 decimal precision. This term is defined by OIF
+        Implementation Agreement for Coherent CMIS. Values include
+        the instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container modulator-bias-x-phase {
+      description
+        "The X-Phase bias of the coherent modulator. This is
+        represented as a percentage with 2 decimal precision. This
+        term is defined by OIF Implementation Agreement for
+        Coherent CMIS. Values include the instantaneous, average,
+        minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply
+        the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container modulator-bias-y-phase {
+      description
+        "The Y-Phase bias of the coherent modulator. This is
+        represented as a percentage with 2 decimal precision. This
+        term is defined by OIF Implementation Agreement for
+        Coherent CMIS. Values include the instantaneous, average,
+        minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply
+        the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container osnr {
+      description
+        "Optical signal to noise ratio at 12.5GHz noise bandwidth
+        in dB with two decimal precision. Values include the
+        instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target
+        is expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-types:avg-min-max-instant-stats-precision2-dB;
+    }
+
+    container carrier-frequency-offset {
+      description
+        "Carrier frequency offset in MHz with 1 decimal precision.
+        Values include the instantaneous, average, minimum, and
+        maximum statistics. If avg/min/max statistics are not supported,
+        the target is expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision1-mhz;
+    }
+
+    container sop-roc {
+      description
+        "State-of-polarization rate-of-change (SOP-ROC) in krad/s with 1
+        decimal precision. This term is defined by OIF Implementation
+        Agreement for Coherent CMIS. Values include the instantaneous,
+        average, minimum, and maximum statistics. If avg/min/max
+        statistics are not supported, the target is expected to just
+        supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision1-krads;
+    }
+
+    container modulation-error-ratio {
+      description
+        "Modulation error ratio in dB with two decimal precision. Values
+        include the instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value.";
+
+      reference "IA OIF-C-CMIS-01.1 Table 7";
+
+      uses oc-types:avg-min-max-instant-stats-precision2-dB;
+    }
+
+    uses terminal-phy-protocol-stats {
+      description
+        "When there is no OTN framing e.g. 400ZR, this grouping will be used.";
     }
   }
 

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.14.0";
+  oc-ext:openconfig-version "0.15.0";
+
+  revision "2021-07-29" {
+    description
+      "Add several avg-min-max-instant-stats groupings";
+    reference "0.15.0";
+  }
 
   revision "2021-03-22" {
     description
@@ -433,6 +439,160 @@ module openconfig-transport-types {
     uses oc-types:stat-interval-state;
     uses oc-types:min-max-time;
   }
+
+  grouping avg-min-max-instant-stats-precision1-mhz {
+    description
+      "Common grouping for recording frequency values in MHz with
+      1 decimal precision. Values include the instantaneous, average,
+      minimum, and maximum statistics. Statistics are computed and
+      reported based on a moving time interval (e.g., the last 30s).
+      If supported by the device, the time interval over which the
+      statistics are computed, and the times at which the minimum and
+      maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision1-krads {
+    description
+      "Common grouping for recording kiloradian per second (krad/s) values
+      with 1 decimal precision. Values include the instantaneous,
+      average, minimum, and maximum statistics. Statistics are computed
+      and reported based on a moving time interval (e.g., the last 30s).
+      If supported by the device, the time interval over which the
+      statistics are computed, and the times at which the minimum and
+      maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-pct {
+    description
+      "Common grouping for percentage statistics with 2 decimal precision.
+      Values include the instantaneous, average, minimum, and maximum
+      statistics. Statistics are computed and reported based on a moving
+      time interval (e.g., the last 30s). If supported by the device,
+      the time interval over which the statistics are computed, and the
+      times at which the minimum and maximum values occurred, are also
+      reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
 
   // identity statements
 

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-01-19" {
+    description
+      "Fixed typo for aggregate field.";
+    reference "0.2.1";
+  }
 
   revision "2021-10-16" {
     description
@@ -794,7 +800,7 @@ module openconfig-platform-pipeline-counters {
         due to DF bit.";
     }
 
-    leaf lookup-aggregte {
+    leaf lookup-aggregate {
       type oc-yang:counter64;
       description
         "Packets dropped due to aggregate lookup drop counters - this counter

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -65,7 +65,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2021-07-29" {
+    description
+      "Add several media-lane-based VDM defined by CMIS to physical channel";
+    reference "0.9.0";
+  }
 
   revision "2021-02-23" {
     description
@@ -287,6 +293,59 @@ module openconfig-platform-transceiver {
       such as when the physical channel has a leafref to an optical
       channel component and the module-functional-type is
       TYPE_DIGITAL_COHERENT_OPTIC this grouping will NOT be used.";
+
+    leaf laser-age {
+      type oc-types:percentage;
+      description
+        "Laser age (0% at beginning of life, 100% end of life) in integer
+        percentage. This term is defined by Common Management Interface
+        Specification (CMIS).";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+    }
+
+    container laser-temperature {
+      description
+        "Laser temperature for the cooled laser in degrees Celsius with 1
+        decimal precision. This term is defined by Common Management
+        Interface Specification (CMIS). Values include the instantaneous,
+        average, minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply the
+        instant value.";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+
+      uses oc-platform-types:avg-min-max-instant-stats-precision1-celsius;
+    }
+
+    container target-frequency-deviation {
+      description
+        "The difference in MHz with 1 decimal precision between the target
+        center frequency and the actual current center frequency . This term
+        is defined by Common Management Interface Specification (CMIS) and
+        referred to as laser frequency error or laser ferquency deviation.
+        Values include the instantaneous, average, minimum, and maximum
+        statistics. If avg/min/max statistics are not supported, the target
+        is expected to just supply the instant value.";
+
+      reference "QSFP-DD CMIS 5.0 Section Table 8-122";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision1-mhz;
+    }
+
+    container tec-current {
+      description
+        "The amount of current flowing to the TC of a cooled laser in percentage
+        with 2 decimal precision. This term is defined by Common Management
+        Interface Specification (CMIS). Values include the instantaneous,
+        average, minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply the instant
+        value.";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
 
     uses physical-channel-state-extended {
       when "../../../state/module-functional-type = 'oc-opt-types:TYPE_STANDARD_OPTIC'" {
@@ -612,6 +671,17 @@ module openconfig-platform-transceiver {
         instant value";
 
       uses oc-opt-types:avg-min-max-instant-stats-precision18-ber;
+    }
+
+    container supply-voltage {
+      description
+        "Supply voltage to the transceiver in volts with 2 decimal
+        precision. Values include the instantaneous, average, minimum,
+        and maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the instant
+        value.";
+
+      uses oc-platform-types:avg-min-max-instant-stats-precision2-volts;
     }
 
     uses optical-power-state;

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2021-07-29" {
+    description
+      "Add several avg-min-max-instant-stats groupings";
+    reference "1.2.0";
+  }
 
   revision "2021-01-18" {
     description
@@ -127,6 +133,58 @@ module openconfig-platform-types {
         fraction-digits 1;
       }
       units celsius;
+      description
+        "The maximum value of the statistic over the sampling
+        period";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-volts {
+    description
+      "Common grouping for recording voltage values in
+      volts with 2 decimal precision. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the
+      minimum and maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The arithmetic mean value of the statistic over the
+        sampling period.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The minimum value of the statistic over the sampling
+        period";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
       description
         "The maximum value of the statistic over the sampling
         period";

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
 
   revision "2021-08-06" {
     description
@@ -299,6 +305,26 @@ submodule openconfig-pf-forwarding-policies {
         packets matching the match criteria for the forwarding rule
         should be forwarded to the next-hop IP address, bypassing any
         lookup on the local system.";
+    }
+
+    leaf decapsulate-mpls-in-udp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the UDP header from the packet matching the rule.
+        Following the decapsulation it should subsequently forward the
+        encapsulated packet according to the underlying MPLS label.";
+    }
+
+    leaf decapsulate-gue {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the Generic UDP Encapsulation (GUE) header from the packet matching
+        the rule. Following the decapsulation it should subsequently forward the
+        encapsulated packet according to the underlying IPv4 or IPv6 header.";
     }
   }
 

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,13 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,13 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
 
   revision "2021-08-06" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -81,7 +81,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
 
   revision "2021-08-06" {
     description


### PR DESCRIPTION
- Add performance monitors for ZR transceivers.
- Fix typo in hw-mac-address description.
- Applied PR #477 from public (Michael Wong <michael-a-wong@users.noreply.github.com>) (#1044)
- Add MPLS-in-UDP and GUE decap actions to policy-forwarding. (#1072)
