### PR TITLE
Add Hello PDU padding type to IS-IS global configuration.

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.7.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
 
   revision "2022-01-19" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "0.7.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
 
   revision "2022-01-19" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -53,7 +53,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "0.7.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
 
   revision "2022-01-19" {
     description
@@ -166,7 +172,7 @@ module openconfig-isis {
 
   grouping isis-global-config {
     description
-      "This grouping defines lobal configuration options for ISIS router.";
+      "This grouping defines global configuration options for ISIS router.";
 
     // multi-instance
     leaf instance {
@@ -233,6 +239,13 @@ module openconfig-isis {
       description
         "When set to true, IS will always flood the LSP that triggered an SPF
      before the router actually runs the SPF computation.";
+    }
+
+    leaf hello-padding {
+      type oc-isis-types:hello-padding-type;
+      default "STRICT";
+      description
+        "Controls the padding type for IS-IS Hello PDUs on a global level.";
     }
   }
 
@@ -575,7 +588,7 @@ module openconfig-isis {
     leaf hello-padding {
       type oc-isis-types:hello-padding-type;
       description
-        "This leaf controls padding type for IS-IS Hello PDUs.";
+        "Controls the padding type for IS-IS Hello PDUs.";
     }
 
     leaf circuit-type {


### PR DESCRIPTION
### Original Problem

We need to be able to disable IS-IS Hello padding on a global level. This requires specifying the padding type for IS-IS Hello PDUs in global IS-IS configuration. This is currently only available on an interface level.

### Proposed Solution

Add a `hello-padding` leaf of type `oc-isis-types:hello-padding-type` to `isis-global-config`, set to `STRICT` by default.