### PR TITLE
User-defined defaults and description updates for list keys

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -23,7 +23,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "0.16.2";
+  oc-ext:openconfig-version "0.16.3";
+
+  revision "2022-03-07" {
+    description
+      "Description updates for DEFAULT_INSTANCE implementation
+      guidance and default value/guidance for protocol instances";
+    reference "0.16.3";
+  }
 
   revision "2021-11-17" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -47,7 +47,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "0.16.2";
+  oc-ext:openconfig-version "0.16.3";
+
+  revision "2022-03-07" {
+    description
+      "Description updates for DEFAULT_INSTANCE implementation
+      guidance and default value/guidance for protocol instances";
+    reference "0.16.3";
+  }
 
   revision "2021-11-17" {
     description
@@ -1135,8 +1142,10 @@ module openconfig-network-instance {
     leaf name {
       type string;
       description
-        "An operator-assigned unique name for the forwarding
-        instance";
+        "An operator-assigned unique name for the network instance.
+        If the operator does not designate a name for the instance of
+        type 'DEFAULT_INSTANCE' (e.g. config), the implementation
+        should use the name of 'DEFAULT' (e.g. state).";
     }
 
     leaf type {
@@ -1146,12 +1155,14 @@ module openconfig-network-instance {
       description
         "The type of network instance. The value of this leaf
         indicates the type of forwarding entries that should be
-        supported by this network instance. Signalling protocols
-        also use the network instance type to infer the type of
-        service they advertise; for example MPLS signalling
-        for an L2VSI network instance would infer a VPLS service
-        whereas a type of L2PTP would infer a VPWS (pseudo-wire)
-        service";
+        supported by this network instance. Signalling protocols also
+        use the network instance type to infer the type of service
+        they advertise; for example MPLS signalling for an L2VSI
+        network instance would infer a VPLS service whereas a type of
+        L2PTP would infer a VPWS (pseudo-wire) service.
+
+        An implementation must support only a single network-instance
+        of type 'DEFAULT_INSTANCE'.";
     }
 
     leaf enabled {
@@ -1204,8 +1215,16 @@ module openconfig-network-instance {
 
     leaf name {
       type string;
+      default "DEFAULT";
       description
-        "A unique name for the protocol instance";
+        "A unique name for the protocol instance.
+
+        If the operator does not designate a name for the protocol
+        instance (e.g. config), the implementation should use the
+        name of 'DEFAULT' (e.g. state).  In addition, for
+        implementations that support single protocol instances, the
+        default value is recommended for consistency and uniqueness
+        per protocol instance.";
     }
 
     leaf enabled {

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,9 +22,16 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.1.2";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-03-07" {
+    description
+      "Description and default value updates for grpc-server
+      implementation guidance.";
+    reference "0.1.2";
+  }
 
   revision "2021-06-16" {
     description
@@ -101,9 +108,16 @@ module openconfig-system-grpc {
 
     leaf name {
       type string;
+      default "DEFAULT";
       description
         "The name of the gRPC server instance that is running on
-        the local system.";
+        the local system.
+
+        If the operator does not designate a name for the protocol
+        instance (e.g. config), the implementation should use the
+        name of 'DEFAULT' (e.g. state).  In addition, for
+        implementations that support a single gRPC server instance,
+        the default value is recommended for consistency.";
     }
 
     leaf-list services {

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,15 +22,15 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "0.1.2";
+  oc-ext:openconfig-version "1.0.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  revision "2022-03-07" {
+  revision "2022-04-19" {
     description
       "Description and default value updates for grpc-server
       implementation guidance.";
-    reference "0.1.2";
+    reference "1.0.0";
   }
 
   revision "2021-06-16" {


### PR DESCRIPTION
  * (M) release/models/network-instance/openconfig-network-instance-l2.yang
  * (M) release/models/network-instance/openconfig-network-instance.yang
    - Update network-instance name description to provide implementation
      guidance on default name for DEFAULT_INSTANCE should OpenConfig
      schemas not be used for configuration but rather for state only as
      well as suggested name
    - Update protocol instance name with suggested value as well as
      default name should OpenConfig schemas not be used for
      configuration but rather for state only
  * (M) release/models/system/openconfig-system-grpc.yang
    - Update grpc server name with suggested value as well as default
      name should OpenConfig schemas not be used for configuration but
      rather for state only

This PR is to kick off the concept of embedding implementation suggestions (and
defaults where applicable) for where user-defined fields are used as list keys.
Most notably starting in areas where users have a hard time selecting an
appropriate value and where an implementation may only support single instances
in a multi-instance capable model structure.

The notion of implementation guidance and default values also caters to
scenarios where a client may want to consume OpenConfig modeled state data
without using OpenConfig modeled configuration.  These suggestions and defaults
enable the implementation to pack known values into list keys to formulate
compliant paths.
