### PR TITLE
Create openconfig-manifest-file-terminal-device.yang

### DIFF
--- a/doc/terminal-device-properties-guide.md
+++ b/doc/terminal-device-properties-guide.md
@@ -1,0 +1,39 @@
+# Openconfig Terminal Device Manifest files guidelines
+
+**Contributors:** Arturo Mayoral López de Lerma
+
+This page documents the purpose and usability guidelines for the openconfig-terminal-device-properties.yang and openconfig-terminal-device-property-types.yang models included in openconfig/devices-manifest folder. These models enter in the category of devices manifest files, which is a new category of openconfig models which are intended to expose the static properties of a devices, which are traditionally documented by the device's manufacturers in the product datasheets. These properties are typically required by network planning teams to plan the network deployments.
+
+# Motivation
+
+Current optical transport networks are evolving into new degrees of openness and flexibility, where the optical terminal units become more and more independent from the rest of the DWDM line system, management and control. This means for instance that an optical terminal device, i.e., a transponder/muxponder device can be deployed as a standalone unit and connected to the line system of a third-party provider. In order, to make this type of integrations efficient, the optical channel signal characteristics can be exposed through the management interface (i.e., through OpenConfig models in this case), to allow the remote controller entity to ingest the required data for successful optical planning and impairment validation of the end-to-end transmission across the Optical Line System (OLS). This intends to remove ambiguity on how suppliers expose data required for network planning and physical impairment validation of end-to-end Optical Channels (OCh/OTSi) and foster openness across the optical transport industry.
+
+Currently in OpenConfig, the optical channels characteristics are opaque to some extent and the model only offers an abstraction named 'operational-mode', which allows the manufactures to encode the different transmission modes supported by the device into a single integer value. While this may be sufficient in some cases (the manufacturer can offer the related mode details offline to its customers), and very practical for configuration purposes, it becomes cucumbersome for an network operator to encode this information into their network controller application, specially if the network contains many different vendor solutions which may expose their signal characteristics in different formats, adding or omitting some information in each case. Thus, this model intends to provide uniformity on the way operational-modes are characterized by including a set of static attributes associated to each mode.
+
+This proposal was submitted by the Telecom Infra Project (TIP) Mandatory Use Cases for SDN Transport (MUST) sub-group. This is an operator centric initiative which intends to achieve a wider consensus about the SDN standards to use on the network transport segment.
+
+# Model content
+The model contains two main building blocks:
+* **operational-mode-capabilities** this set of attributes contains all characteristic information of the signal (modulation format, FEC, bit rate...), relevant information for the physical impairment validation (OSNR Rx sensitivity, CD/PMD tolerance and penalties).
+* **optical-channel-config-value-constrains** which contains the transmission configuration constrains/ranges of the optical-channel's attributes characterized by the operational-mode, i.e., the central frequency range, the frequency grid and the configurable transmitted power.
+
+
+# Model logic
+
+1. **Terminal device manufacturing – Operational modes hardcoding**
+Terminal device manufacturer encodes supported transmission modes characteristic information into the terminal-device's manifest file which is hardcoded into the device firmware. This process shall takes into account the transmission modes supported third-party transceiver pluggable modules compatible with the terminal device.
+
+2. **Terminal device w/o pluggable – Initial setup**
+When the device is started, the operational modes list is complete and contains all the information about the compatible transceivers and their associated operational modes. The manifest file defined by the openconfig-terminal-device-properties.yang model is static and will remain available and invariant through the terminal device's management interface which exposes openconfig models.
+
+3. **Terminal device with equipped pluggable – Running State**
+Once the line-card module is successfully equipped with the fixed or pluggable transceiver and the module is discovered by the Terminal Device, the operational data store is updated with the actual modes available (see openconfig-terminal-device.yang module). The list of modes present in the terminal-device/operational-modes list represents the actual modes which are available in runtime by the device and which can be configured as part of the optical-channel configuration. Please note, that this information can be dynamically updated if the pluggable unit changes. For each operational-mode/mode-id present in the operational data store, there should be an operational-modes/mode-descriptor item with the same mode-id, included in the manifest file.
+
+# Model implementation guidelines
+
+Manifest files are a special OpenConfig model category since they do not represent operational data. Thus, this category of models will be included within the "models/tree/master/yang/devices-manifest" folder.
+
+In order to keep separated them from the rest of operational models, the following openconfig extension is included in the model, to enrich the module metadata:
+```
+  oc-ext:origin "openconfig-properties";
+```

--- a/release/models/devices-manifest/.spec.yml
+++ b/release/models/devices-manifest/.spec.yml
@@ -10,4 +10,3 @@
   build:
     - yang/devices-manifest/openconfig-terminal-device-property-types.yang
   run-ci: true
-  

--- a/release/models/devices-manifest/.spec.yml
+++ b/release/models/devices-manifest/.spec.yml
@@ -10,3 +10,4 @@
   build:
     - yang/devices-manifest/openconfig-terminal-device-property-types.yang
   run-ci: true
+  

--- a/release/models/devices-manifest/.spec.yml
+++ b/release/models/devices-manifest/.spec.yml
@@ -10,4 +10,3 @@
   build:
     - yang/devices-manifest/openconfig-terminal-device-property-types.yang
   run-ci: true
-

--- a/release/models/devices-manifest/.spec.yml
+++ b/release/models/devices-manifest/.spec.yml
@@ -4,3 +4,10 @@
   build:
     - yang/devices-manifest/openconfig-terminal-device-properties.yang
   run-ci: true
+- name: openconfig-terminal-device-property-types
+  docs:
+    - yang/devices-manifest/openconfig-terminal-device-property-types.yang
+  build:
+    - yang/devices-manifest/openconfig-terminal-device-property-types.yang
+  run-ci: true
+

--- a/release/models/devices-manifest/.spec.yml
+++ b/release/models/devices-manifest/.spec.yml
@@ -1,0 +1,6 @@
+- name: openconfig-terminal-device-properties
+  docs:
+    - yang/devices-manifest/openconfig-terminal-device-properties.yang
+  build:
+    - yang/devices-manifest/openconfig-terminal-device-properties.yang
+  run-ci: true

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -444,16 +444,16 @@ module openconfig-terminal-device-properties {
         "The Forward Error Coding (FEC) coding schema used,
         including the name, overhead, pre-fec-ber threshold and
         gain properties.";
-      
+
       container state {
         config false;
         description
           "FEC state attributes top container.";
-          
+
         uses fec-codes-attributes;
       }
     }
-    
+
     list penalties {
       key "parameter-and-unit up-to-boundary";
       description
@@ -464,7 +464,7 @@ module openconfig-terminal-device-properties {
         values, penalty could be linearly interpolated.
         - For parameter values above highest up-to-boundary value, the penalty is the one
         included within penalty-value attribute associated to the highest up-to-boundary";
-      
+
       leaf parameter-and-unit {
         type leafref {
           path "../state/parameter-and-unit";
@@ -481,12 +481,11 @@ module openconfig-terminal-device-properties {
           "defines the upper (for positive values) and lower (for negative values)
            limit for which the penalty value is valid.";
       }
-      
+
       container state {
         config false;
         description
           "Penalties list element's state attributes top container.";
-          
         uses penalties-list-element-attributes;
       }
     }
@@ -495,12 +494,11 @@ module openconfig-terminal-device-properties {
       description
         "This container includes information which characterises the filter at
         transceiver transmission for the given operational-mode.";
-      
+
       container state {
         config false;
         description
-          "Filter's state attributes top container.";
-          
+          "Filter's state attributes top container.";   
         uses filter-attributes-top;
       }
     }
@@ -526,7 +524,6 @@ module openconfig-terminal-device-properties {
         mode, an organizational mode or an explicit mode.";
     }
     uses standard-mode-features-description-top;
-
     uses explicit-mode-features-description-top;
   }
 

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -117,7 +117,70 @@ module openconfig-terminal-device-properties {
           description
             "Operational-mode explicit mode capabilities state top container.";
 
-          uses operational-mode-capabilities-top;
+          uses operational-mode-capabilities-attributes-top;
+        }
+        container fec {
+          description
+            "The Forward Error Coding (FEC) coding schema used,
+            including the name, overhead, pre-fec-ber threshold and
+            gain properties.";
+
+          container state {
+            config false;
+            description
+              "FEC state attributes top container.";
+
+            uses fec-codes-attributes;
+          }
+        }
+
+        list penalties {
+          key "parameter-and-unit up-to-boundary";
+          description
+            "Penalties includes contributions from different impairments including
+            cd, pmd, low RX Power, pdl,...
+            - For parameter values below lowest up-to-boundary value, the penalty is 0.
+            - For parameter values between lowest and highest up-to-boundary
+            values, penalty could be linearly interpolated.
+            - For parameter values above highest up-to-boundary value, the penalty is the one
+            included within penalty-value attribute associated to the highest up-to-boundary";
+
+          leaf parameter-and-unit {
+            type leafref {
+              path "../state/parameter-and-unit";
+            }
+            description
+              "Impairment and unit leading to the penalty (i.e., cd-ps)";
+          }
+
+          leaf up-to-boundary {
+            type leafref {
+              path "../state/up-to-boundary";
+            }
+            description
+              "defines the upper (for positive values) and lower (for negative values)
+               limit for which the penalty value is valid.";
+          }
+
+          container state {
+            config false;
+            description
+              "Penalties list element's state attributes top container.";
+            uses penalties-list-element-attributes;
+          }
+        }
+
+        container filter {
+          description
+            "This container includes information which characterises the filter at
+            transceiver transmission for the given operational-mode.";
+
+          container state {
+            config false;
+            description
+              "Filter's state attributes top container.";
+            uses filter-attributes-top;
+          }
         }
       }
 
@@ -433,77 +496,6 @@ module openconfig-terminal-device-properties {
     }
   }
 
-  grouping operational-mode-capabilities-top {
-    description
-      "Operational-mode explicit-mode capabilities grouping.";
-
-    uses operational-mode-capabilities-attributes-top;
-
-    container fec {
-      description
-        "The Forward Error Coding (FEC) coding schema used,
-        including the name, overhead, pre-fec-ber threshold and
-        gain properties.";
-
-      container state {
-        config false;
-        description
-          "FEC state attributes top container.";
-
-        uses fec-codes-attributes;
-      }
-    }
-
-    list penalties {
-      key "parameter-and-unit up-to-boundary";
-      description
-        "Penalties includes contributions from different impairments including
-        cd, pmd, low RX Power, pdl,...
-        - For parameter values below lowest up-to-boundary value, the penalty is 0.
-        - For parameter values between lowest and highest up-to-boundary
-        values, penalty could be linearly interpolated.
-        - For parameter values above highest up-to-boundary value, the penalty is the one
-        included within penalty-value attribute associated to the highest up-to-boundary";
-
-      leaf parameter-and-unit {
-        type leafref {
-          path "../state/parameter-and-unit";
-        }
-        description
-          "Impairment and unit leading to the penalty (i.e., cd-ps)";
-      }
-
-      leaf up-to-boundary {
-        type leafref {
-          path "../state/up-to-boundary";
-        }
-        description
-          "defines the upper (for positive values) and lower (for negative values)
-           limit for which the penalty value is valid.";
-      }
-
-      container state {
-        config false;
-        description
-          "Penalties list element's state attributes top container.";
-        uses penalties-list-element-attributes;
-      }
-    }
-
-    container filter {
-      description
-        "This container includes information which characterises the filter at
-        transceiver transmission for the given operational-mode.";
-
-      container state {
-        config false;
-        description
-          "Filter's state attributes top container.";   
-        uses filter-attributes-top;
-      }
-    }
-  }
-
   grouping operational-mode-features-top{
     description
       "Top-level operational-mode-features grouping definitions";
@@ -523,8 +515,6 @@ module openconfig-terminal-device-properties {
         "Indicates whether the transceiver's mode is a standard
         mode, an organizational mode or an explicit mode.";
     }
-    uses standard-mode-features-description-top;
-    uses explicit-mode-features-description-top;
   }
 
   grouping operational-mode-top{
@@ -560,6 +550,8 @@ module openconfig-terminal-device-properties {
 
           uses operational-mode-features-top;
         }
+        uses standard-mode-features-description-top;
+        uses explicit-mode-features-description-top;
       }
     }
   }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -39,9 +39,9 @@ module openconfig-terminal-device-properties {
 
 
   // Revisions
-  revision "2022-04-19" {
+  revision "2022-04-26" {
       description "Initial manifest fine to extend the information
-      related to the operational modes supported by a terminal device";
+      related to the operational modes supported by a terminal device.";
       reference "0.1.0";
   }
 

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -83,8 +83,13 @@ module openconfig-terminal-device-properties {
       configured to this mode.";
 
     container explicit-mode {
+      description
+        "Explicit defition of the operational-mode. Typically this is used
+        for non-standard/propietary modes defined by the terminal-device
+        vendor and it is self described by the capabilities included in
+        the subtree underneath.";
+
       container operational-mode-capabilities {
-        uses operational-mode-features-description;
         description
           "Set of attributes which charaterizes the operational-mode for optimal
           optical-channel transmission and receiver functions. This attributes
@@ -92,19 +97,17 @@ module openconfig-terminal-device-properties {
           network planning phase, to estimate the physical-impairment
           tolerances which can be introduced by the DWDM optical path,
           while assuring optimal transmission function.";
+
+        uses operational-mode-capabilities-top;
       }
       container optical-channel-config-value-constrains{
-        uses config-value-constrains-top;
         description
           "Set of constrains of the configuration attributes
           of the optical-channel associated to the selected
           operational-mode.";
+
+        uses config-value-constrains-top;
       }
-      description
-        "Explicit defition of the operational-mode. Typically this is used
-        for non-standard/propietary modes defined by the terminal-device
-        vendor and it is self described by the capabilities included in
-        the subtree underneath.";
     }
   }
 
@@ -176,8 +179,86 @@ module openconfig-terminal-device-properties {
     }
   }
 
+  grouping penalties-list-element-attributes {
+    description
+      "OSNR penalties grouping, including the set of attributes
+      which defines each element of the penalties list.";
 
-  grouping operational-mode-features-description {
+    leaf parameter-and-unit {
+      type oc-opt-term-prop-types:impairment-type;
+      description
+        "Impairment and unit leading to the penalty (i.e., cd-ps)";
+    }
+
+    leaf up-to-boundary {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      description
+        "defines the upper (for positive values) and lower (for negative values)
+         limit for which the penalty value is valid.";
+    }
+
+    leaf penalty-value {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "OSNR penalty associated to the given values, expressed in dB.";
+    }
+  }
+
+  grouping fec-codes-attributes {
+    description
+      "FEC codes attributes grouping, including the set of attributes
+      which defines the FEC code employed on the tranmission represented
+      by the operational-mode.";
+
+    leaf fec-coding {
+      type union {
+        type string;
+        type oc-opt-term-prop-types:fec-coding;
+      }
+      description
+        "Forward error correction (FEC) coding schema used in the
+        tramission mode. Type union of string (for propietary codes)
+        and a set of standard codes encoded as identityrefs";
+    }
+
+    leaf coding-overhead {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      description
+        "Coding overhead rate in %.";
+    }
+
+    leaf coding-gain {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      default 0.00;
+      units dB;
+      description
+        "Net coding gain (NCG) in dB units at 10E-15 bit error rate.
+        It may vary depending on the modulation format used in the
+        associated transmission mode (operational-mode).";
+    }
+    leaf pre-fec-ber-threshold {
+      type decimal64 {
+        fraction-digits 18;
+      }
+      units bit-errors-per-second;
+      description
+        "Threshold on the PRE-FEC-BER, for which FEC code is able to
+        correct errors.";
+    }
+  }
+
+  grouping operational-mode-capabilities-top {
+    description
+      "Operational-mode features top container";
     leaf modulation-format {
       type union {
         type string;
@@ -217,50 +298,12 @@ module openconfig-terminal-device-properties {
     }
 
     container fec {
-      leaf fec-coding {
-        type union {
-          type string;
-          type oc-opt-term-prop-types:fec-coding;
-        }
-        description
-          "Forward error correction (FEC) coding schema used in the
-          tramission mode. Type union of string (for propietary codes)
-          and a set of standard codes encoded as identityrefs";
-      }
-
-      leaf coding-overhead {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        description
-          "Coding overhead rate in %.";
-      }
-
-      leaf coding-gain {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        default 0.00;
-        units dB;
-        description
-          "Net coding gain (NCG) in dB units at 10E-15 bit error rate.
-          It may vary depending on the modulation format used in the
-          associated transmission mode (operational-mode).";
-      }
-      leaf pre-fec-ber-threshold {
-        type decimal64 {
-          fraction-digits 18;
-        }
-        units bit-errors-per-second;
-        description
-          "Threshold on the PRE-FEC-BER, for which FEC code is able to
-          correct errors.";
-      }
-
       description
         "The Forward Error Coding (FEC) coding schema used,
         including the name, overhead, pre-fec-ber threshold and gain
         properties.";
+
+      uses fec-codes-attributes;
     }
 
     //sensitivity specs.
@@ -352,32 +395,14 @@ module openconfig-terminal-device-properties {
         - For paramter values above highest up-to-boundary value, the penalty is the one
         included within penalty-value attribute associated to the highest up-to-boundary";
 
-      leaf parameter-and-unit {
-        type oc-opt-term-prop-types:impairment-type;
-        description
-          "Impairment and unit leading to the penalty (i.e., cd-ps)";
-      }
-
-      leaf up-to-boundary {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        description
-          "defines the upper (for positive values) and lower (for negative values)
-           limit for which the penalty value is valid.";
-      }
-
-      leaf penalty-value {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        units dB;
-        description
-          "OSNR penalty associated to the given values, expressed in dB.";
-      }
+      uses penalties-list-element-attributes;
     }
 
     container filter {
+      description
+        "This container includes information which characterises the filter at
+        transceiver transmission for the given operational-mode.";
+
       leaf roll-off {
         description
           "Decimal fraction between 0 and 1. Roll-off parameter (𝛽) of the TX pulse
@@ -409,37 +434,42 @@ module openconfig-terminal-device-properties {
 
     uses explicit-mode-features-description;
   }
+
   grouping operational-mode-top{
-    list mode-descriptor {
-      key "mode-id";
+    description
+      "top-level operational-mode definitions";
+
+    container operational-modes {
       config false;
       description
-        "List of operational modes supported by the platform.
-        The operational mode provides a platform-defined summary
-        of information such as symbol rate, modulation, pulse
-        shaping, etc.";
+        "Indicates the transceiver's list of supported operational
+         modes and its assoiated transmission features";
 
-      leaf mode-id {
-        type leafref {
-          path "../features/mode-id";
+      list mode-descriptor {
+        key "mode-id";
+        description
+          "List of operational modes supported by the platform.
+          The operational mode provides a platform-defined summary
+          of information such as symbol rate, modulation, pulse
+          shaping, etc.";
+
+        leaf mode-id {
+          type leafref {
+            path "../features/mode-id";
+          }
+          description
+            "Reference to mode-id";
         }
-        description
-          "Reference to mode-id";
-      }
 
-      container features {
-        description
-          "Features supported by the operational mode.";
+        container features {
+          description
+            "Features supported by the operational mode.";
 
-        uses operational-mode-features;
+          uses operational-mode-features;
+        }
       }
     }
   }
 
-  container operational-modes {
-    description
-      "Indicates the transceiver's list of supported operational
-       modes and its assoiated transmission features";
-    uses operational-mode-top;
-  }
+  uses operational-mode-top;
 }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -78,7 +78,7 @@ module openconfig-terminal-device-properties {
       uniformly characterized by the set of attributes included in their
       operational-mode-capabilities which defines the related signal physical
       impairment related aspects such Rx and Tx associated attributes and tolerances,
-      ; and its optical-channel-config-value-constrains, which defines what are the
+      ; and its optical-channel-config-value-constraints, which defines what are the
       allowed values to be configured at the oc-component:optical-channel instance
       configured to this mode.";
 
@@ -100,20 +100,20 @@ module openconfig-terminal-device-properties {
 
         uses operational-mode-capabilities-top;
       }
-      container optical-channel-config-value-constrains{
+      container optical-channel-config-value-constraints{
         description
-          "Set of constrains of the configuration attributes
+          "Set of constraints of the configuration attributes
           of the optical-channel associated to the selected
           operational-mode.";
 
-        uses config-value-constrains-top;
+        uses config-value-constraints-top;
       }
     }
   }
 
-  grouping config-value-constrains-top {
+  grouping config-value-constraints-top {
     description
-      "Configuration value constrains for optical channels
+      "Configuration value constraints for optical channels
       configured on the target operational mode.";
 
     leaf min-central-frequency {

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -317,7 +317,7 @@ module openconfig-terminal-device-properties {
         "Minimum back-to-back OSNR measured over 0.1nm@193.7Thz or
         12.5GHz noise resolution bandwidth at the min-input-power.
         If received OSNR at min-input-power is lower than this value,
-        an increased level of bit-errors post-FEC needs to be 
+        an increased level of bit-errors post-FEC needs to be
         expected.";
     }
 
@@ -328,7 +328,7 @@ module openconfig-terminal-device-properties {
       units dBm;
       description
         "Minimum value required input power in dBm of an optical channel
-        at the receiver (Rx) according to the given min-osnr value. If
+        at the receiver (Rx) according to the given min-rx-osnr value. If
         the input-power is lower it is expected to introduce an OSNR
         penalty.";
     }
@@ -339,8 +339,8 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Maximum tolerated input power in dBm at the receiver (Rx) 
-        of the coherence transceiver, which if exceeded can cause an 
+        "Maximum tolerated input power in dBm at the receiver (Rx)
+        of the coherence transceiver, which if exceeded can cause an
         overload.";
     }
 
@@ -419,7 +419,10 @@ module openconfig-terminal-device-properties {
     }
   }
 
-  grouping operational-mode-features{
+  grouping operational-mode-features-top{
+    description
+      "Top-level operational-mode-features grouping definitions";
+
     leaf mode-id {
       type uint16;
       description
@@ -470,7 +473,7 @@ module openconfig-terminal-device-properties {
           description
             "Features supported by the operational mode.";
 
-          uses operational-mode-features;
+          uses operational-mode-features-top;
         }
       }
     }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -53,223 +53,6 @@ module openconfig-terminal-device-properties {
 
   // grouping statements
 
-  grouping standard-mode-features-attributes {
-    description
-      "Standard mode features attributes grouping.";
-
-    leaf standard-mode {
-      type oc-opt-term-prop-types:standard-mode;
-      description
-        "G.698.2 (11/18) standard mode";
-    }
-  }
-
-  grouping standard-mode-features-description-top {
-    description
-      "Standard mode features description grouping. It is used if the
-      'mode-type' attribute is set to 'TRANSCEIVER_MODE_TYPE_STANDARD";
-
-    container G.698.2 {
-      description
-        "ITU-T G.698.2 (11/18) standard mode that guarantees interoperability.
-        It must be an string with the following format:
-        B-DScW-ytz(v) where all these attributes are conformant
-        to the ITU-T G.698.2 (11/18) recommendation.";
-
-      container state {
-          config false;
-          description
-            "Operational-mode standard mode state top container.";
-
-          uses standard-mode-features-attributes;
-      }
-    }
-  }
-
-  grouping explicit-mode-features-description-top {
-    description
-      "Definition of proprietary or non-standard operational-modes, which can be
-      uniformly characterized by the set of attributes included in their
-      operational-mode-capabilities which defines the related signal physical
-      impairment related aspects such Rx and Tx associated attributes and tolerances;
-      and its optical-channel-config-value-constraints, which defines what are the
-      allowed values to be configured at the oc-component:optical-channel instance
-      configured to this mode.";
-
-    container explicit-mode {
-      description
-        "Explicit definition of the operational-mode. Typically this is used
-        for non-standard/proprietary modes defined by the terminal-device
-        vendor and it is self-described by the capabilities included in
-        the subtree underneath.";
-
-      container operational-mode-capabilities{
-        description
-            "Set of attributes which characterizes the operational-mode for optimal
-            optical-channel transmission and receiver functions. This attributes
-            are intending to describe all the relevant data used during the
-            network planning phase, to estimate the physical-impairment
-            tolerances which can be introduced by the DWDM optical path,
-            while assuring optimal transmission function.";
-
-        container state {
-          config false;
-          description
-            "Operational-mode explicit mode capabilities state top container.";
-
-          uses operational-mode-capabilities-attributes-top;
-        }
-        container fec {
-          description
-            "The Forward Error Coding (FEC) coding schema used,
-            including the name, overhead, pre-fec-ber threshold and
-            gain properties.";
-
-          container state {
-            config false;
-            description
-              "FEC state attributes top container.";
-
-            uses fec-codes-attributes;
-          }
-        }
-
-        list penalties {
-          key "parameter-and-unit up-to-boundary";
-          description
-            "Penalties includes contributions from different impairments including
-            cd, pmd, low RX Power, pdl,...
-            - For parameter values below lowest up-to-boundary value, the penalty is 0.
-            - For parameter values between lowest and highest up-to-boundary
-            values, penalty could be linearly interpolated.
-            - For parameter values above highest up-to-boundary value, the penalty is the one
-            included within penalty-value attribute associated to the highest up-to-boundary";
-
-          leaf parameter-and-unit {
-            type leafref {
-              path "../state/parameter-and-unit";
-            }
-            description
-              "Impairment and unit leading to the penalty (i.e., cd-ps)";
-          }
-
-          leaf up-to-boundary {
-            type leafref {
-              path "../state/up-to-boundary";
-            }
-            description
-              "defines the upper (for positive values) and lower (for negative values)
-               limit for which the penalty value is valid.";
-          }
-
-          container state {
-            config false;
-            description
-              "Penalties list element's state attributes top container.";
-            uses penalties-list-element-attributes;
-          }
-        }
-
-        container filter {
-          description
-            "This container includes information which characterises the filter at
-            transceiver transmission for the given operational-mode.";
-
-          container state {
-            config false;
-            description
-              "Filter's state attributes top container.";
-            uses filter-attributes-top;
-          }
-        }
-      }
-
-      container optical-channel-config-value-constraints{
-        description
-          "Set of constraints of the configuration attributes
-          of the optical-channel associated to the selected
-          operational-mode.";
-
-        container state {
-          config false;
-          description
-            "Operational-mode explicit mode config value constrains state top
-            container.";
-
-          uses config-value-constraints-top;
-        }
-      }
-    }
-  }
-
-  grouping config-value-constraints-top {
-    description
-      "Configuration value constraints for optical channels
-      configured on the target operational mode.";
-
-    leaf min-central-frequency {
-      type oc-opt-types:frequency-type;
-      description
-        "The lowest configurable central frequency in MHz.";
-    }
-
-    leaf max-central-frequency {
-      type oc-opt-types:frequency-type;
-      description
-        "The highest configurable central frequency in MHz.";
-    }
-
-    leaf grid-type {
-      type oc-opt-term-prop-types:grid-type;
-      description
-        "Frequency  ITU-T G.694.1 (10/2020) grid specification attribute.";
-    }
-
-    leaf adjustment-granularity {
-      type oc-opt-term-prop-types:adjustment-granularity;
-      description
-        "Adjustment granularity in Gigahertz. As per  ITU-T G.694.1
-        (10/2020), it is used to calculate nominal central frequency of an
-        optical channel. It defines the minimum granularity supporting by the
-        optical channel's central frequency setting.";
-    }
-
-    leaf min-channel-spacing {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units GHz;
-      description
-       "Minimum recommended spectrum spacing between the central frequency of two
-        adjacent optical channels of the same mode. In case of two adjacent optical
-        channels with different operational-modes, it is up to the path computation
-        engine to determine the minimum distance between the central frequencies of
-        these two optical channels.";
-    }
-
-    leaf min-output-power {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm;
-      description
-        "Minimum target output optical power level of the optical channel,
-        configurable according to the optical transceiver mode properties,
-        expressed in increments of 0.01 dBm (decibel-milliwats)";
-    }
-
-    leaf max-output-power {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm;
-      description
-        "Maximum target output optical power level of the optical channel,
-        configurable according to the optical transceiver mode properties,
-        expressed in increments of 0.01 dBm (decibel-milliwatts)";
-    }
-  }
-
   grouping penalties-list-element-attributes {
     description
       "OSNR penalties grouping, including the set of attributes
@@ -374,7 +157,75 @@ module openconfig-terminal-device-properties {
     }
   }
 
-  grouping operational-mode-capabilities-attributes-top {
+  grouping operational-mode-descriptor-explicit-config-constraints-state {
+    description
+      "Configuration value constraints for optical channels
+      configured on the target operational mode.";
+
+    leaf min-central-frequency {
+      type oc-opt-types:frequency-type;
+      description
+        "The lowest configurable central frequency in MHz.";
+    }
+
+    leaf max-central-frequency {
+      type oc-opt-types:frequency-type;
+      description
+        "The highest configurable central frequency in MHz.";
+    }
+
+    leaf grid-type {
+      type oc-opt-term-prop-types:grid-type;
+      description
+        "Frequency  ITU-T G.694.1 (10/2020) grid specification attribute.";
+    }
+
+    leaf adjustment-granularity {
+      type oc-opt-term-prop-types:adjustment-granularity;
+      description
+        "Adjustment granularity in Gigahertz. As per  ITU-T G.694.1
+        (10/2020), it is used to calculate nominal central frequency of an
+        optical channel. It defines the minimum granularity supporting by the
+        optical channel's central frequency setting.";
+    }
+
+    leaf min-channel-spacing {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units GHz;
+      description
+       "Minimum recommended spectrum spacing between the central frequency of two
+        adjacent optical channels of the same mode. In case of two adjacent optical
+        channels with different operational-modes, it is up to the path computation
+        engine to determine the minimum distance between the central frequencies of
+        these two optical channels.";
+    }
+
+    leaf min-output-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Minimum target output optical power level of the optical channel,
+        configurable according to the optical transceiver mode properties,
+        expressed in increments of 0.01 dBm (decibel-milliwats)";
+    }
+
+    leaf max-output-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Maximum target output optical power level of the optical channel,
+        configurable according to the optical transceiver mode properties,
+        expressed in increments of 0.01 dBm (decibel-milliwatts)";
+    }
+  }
+
+  grouping operational-mode-descriptor-explicit-capabilities-state {
     description
       "Operational-mode capabilities leafs.";
 
@@ -496,7 +347,161 @@ module openconfig-terminal-device-properties {
     }
   }
 
-  grouping operational-mode-features-top{
+  grouping operational-mode-descriptor-explicit-top {
+    description
+      "Definition of proprietary or non-standard operational-modes, which can be
+      uniformly characterized by the set of attributes included in their
+      operational-mode-capabilities which defines the related signal physical
+      impairment related aspects such Rx and Tx associated attributes and tolerances;
+      and its optical-channel-config-value-constraints, which defines what are the
+      allowed values to be configured at the oc-component:optical-channel instance
+      configured to this mode.";
+
+    container explicit-mode {
+      description
+        "Explicit definition of the operational-mode. Typically this is used
+        for non-standard/proprietary modes defined by the terminal-device
+        vendor and it is self-described by the capabilities included in
+        the subtree underneath.";
+
+      container operational-mode-capabilities{
+        description
+            "Set of attributes which characterizes the operational-mode for optimal
+            optical-channel transmission and receiver functions. This attributes
+            are intending to describe all the relevant data used during the
+            network planning phase, to estimate the physical-impairment
+            tolerances which can be introduced by the DWDM optical path,
+            while assuring optimal transmission function.";
+
+        container state {
+          config false;
+          description
+            "Operational-mode explicit mode capabilities state container.";
+
+          uses operational-mode-descriptor-explicit-capabilities-state;
+        }
+        container fec {
+          description
+            "The Forward Error Coding (FEC) coding schema used,
+            including the name, overhead, pre-fec-ber threshold and
+            gain properties.";
+
+          container state {
+            config false;
+            description
+              "FEC state attributes top container.";
+
+            uses fec-codes-attributes;
+          }
+        }
+
+        container penalties {
+          description
+            "Enconsing list's container.";
+
+          list penalty {
+            key "parameter-and-unit up-to-boundary";
+            description
+              "Penalties includes contributions from different impairments including
+              cd, pmd, low RX Power, pdl,...
+              - For parameter values below lowest up-to-boundary value, the penalty is 0.
+              - For parameter values between lowest and highest up-to-boundary
+              values, penalty could be linearly interpolated.
+              - For parameter values above highest up-to-boundary value, the penalty is the one
+              included within penalty-value attribute associated to the highest up-to-boundary";
+
+            leaf parameter-and-unit {
+              type leafref {
+                path "../state/parameter-and-unit";
+              }
+              description
+                "Impairment and unit leading to the penalty (i.e., cd-ps)";
+            }
+
+            leaf up-to-boundary {
+              type leafref {
+                path "../state/up-to-boundary";
+              }
+              description
+                "defines the upper (for positive values) and lower (for negative values)
+                 limit for which the penalty value is valid.";
+            }
+
+            container state {
+              config false;
+              description
+                "Penalties list element's state attributes top container.";
+              uses penalties-list-element-attributes;
+            }
+          }
+        }
+
+        container filter {
+          description
+            "This container includes information which characterises the filter at
+            transceiver transmission for the given operational-mode.";
+
+          container state {
+            config false;
+            description
+              "Filter's state attributes top container.";
+            uses filter-attributes-top;
+          }
+        }
+      }
+
+      container optical-channel-config-value-constraints{
+        description
+          "Set of constraints of the configuration attributes
+          of the optical-channel associated to the selected
+          operational-mode.";
+
+        container state {
+          config false;
+          description
+            "Operational-mode explicit mode config value constrains state top
+            container.";
+
+          uses operational-mode-descriptor-explicit-config-constraints-state;
+        }
+      }
+    }
+  }
+
+  grouping operational-mode-descriptor-standard-state {
+    description
+      "Standard mode features attributes grouping.";
+
+    leaf standard-mode {
+      type oc-opt-term-prop-types:standard-mode;
+      description
+        "G.698.2 (11/18) standard mode";
+    }
+  }
+
+  grouping operational-mode-descriptor-standard-top {
+    description
+      "Standard mode features description grouping. It is used if the
+      'mode-type' attribute is set to 'TRANSCEIVER_MODE_TYPE_STANDARD";
+
+    container G.698.2 {
+      description
+        "ITU-T G.698.2 (11/18) standard mode that guarantees interoperability.
+        It must be an string with the following format:
+        B-DScW-ytz(v) where all these attributes are conformant
+        to the ITU-T G.698.2 (11/18) recommendation.";
+
+      container state {
+          config false;
+          description
+            "Operational-mode standard mode state top container.";
+
+          uses operational-mode-descriptor-standard-state;
+      }
+    }
+  }
+
+  grouping operational-mode-descriptor-state{
     description
       "Top-level operational-mode-features grouping definitions";
 
@@ -548,10 +553,10 @@ module openconfig-terminal-device-properties {
             "Static features or properties which characterize the
             operational mode.";
 
-          uses operational-mode-features-top;
+          uses operational-mode-descriptor-state;
         }
-        uses standard-mode-features-description-top;
-        uses explicit-mode-features-description-top;
+        uses operational-mode-descriptor-standard-top;
+        uses operational-mode-descriptor-explicit-top;
       }
     }
   }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -173,7 +173,7 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Maximum arget output optical power level of the optical channel,
+        "Maximum target output optical power level of the optical channel,
         configurable according to the optical transceiver mode properties,
         expressed in increments of 0.01 dBm (decibel-milliwatts)";
     }
@@ -293,7 +293,7 @@ module openconfig-terminal-device-properties {
       }
       description
         "Optical modulation format associated to the mode. The
-        modulation format associated to the optical signal ";
+        modulation format associated to the optical signal.";
     }
 
     leaf bit-rate {

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -53,32 +53,46 @@ module openconfig-terminal-device-properties {
 
   // grouping statements
 
-  grouping standard-mode-features-description {
+  grouping standard-mode-features-attributes {
+    description
+      "Standard mode features attributes grouping.";
+
+    leaf standard-mode {
+      type oc-opt-term-prop-types:standard-mode;
+      description
+        "G.698.2 (11/18) standard mode";
+    }
+  }
+
+  grouping standard-mode-features-description-top {
     description
       "Standard mode features description grouping. It is used if the
       'mode-type' attribute is set to 'TRANSCEIVER_MODE_TYPE_STANDARD";
 
     container G.698.2 {
-      leaf standard-mode {
-        type oc-opt-term-prop-types:standard-mode;
-        description
-          "G.698.2 (11/18) standard mode";
-      }
       description
         "ITU-T G.698.2 (11/18) standard mode that guarantees interoperability.
         It must be an string with the following format:
         B-DScW-ytz(v) where all these attributes are conformant
         to the ITU-T G.698.2 (11/18) recommendation.";
+
+      container state {
+          config false;
+          description
+            "Operational-mode standard mode state top container.";
+
+          uses standard-mode-features-attributes;
+      }
     }
   }
 
-  grouping explicit-mode-features-description {
+  grouping explicit-mode-features-description-top {
     description
       "Definition of proprietary or non-standard operational-modes, which can be
       uniformly characterized by the set of attributes included in their
       operational-mode-capabilities which defines the related signal physical
-      impairment related aspects such Rx and Tx associated attributes and tolerances,
-      ; and its optical-channel-config-value-constraints, which defines what are the
+      impairment related aspects such Rx and Tx associated attributes and tolerances;
+      and its optical-channel-config-value-constraints, which defines what are the
       allowed values to be configured at the oc-component:optical-channel instance
       configured to this mode.";
 
@@ -89,24 +103,38 @@ module openconfig-terminal-device-properties {
         vendor and it is self-described by the capabilities included in
         the subtree underneath.";
 
-      container operational-mode-capabilities {
+      container operational-mode-capabilities{
         description
-          "Set of attributes which characterizes the operational-mode for optimal
-          optical-channel transmission and receiver functions. This attributes
-          are intending to describe all the relevant data used during the
-          network planning phase, to estimate the physical-impairment
-          tolerances which can be introduced by the DWDM optical path,
-          while assuring optimal transmission function.";
+            "Set of attributes which characterizes the operational-mode for optimal
+            optical-channel transmission and receiver functions. This attributes
+            are intending to describe all the relevant data used during the
+            network planning phase, to estimate the physical-impairment
+            tolerances which can be introduced by the DWDM optical path,
+            while assuring optimal transmission function.";
 
-        uses operational-mode-capabilities-top;
+        container state {
+          config false;
+          description
+            "Operational-mode explicit mode capabilities state top container.";
+
+          uses operational-mode-capabilities-top;
+        }
       }
+
       container optical-channel-config-value-constraints{
         description
           "Set of constraints of the configuration attributes
           of the optical-channel associated to the selected
           operational-mode.";
 
-        uses config-value-constraints-top;
+        container state {
+          config false;
+          description
+            "Operational-mode explicit mode config value constrains state top
+            container.";
+
+          uses config-value-constraints-top;
+        }
       }
     }
   }
@@ -119,13 +147,13 @@ module openconfig-terminal-device-properties {
     leaf min-central-frequency {
       type oc-opt-types:frequency-type;
       description
-        "The lowest configurable central frequency in MHz";
+        "The lowest configurable central frequency in MHz.";
     }
 
     leaf max-central-frequency {
       type oc-opt-types:frequency-type;
       description
-        "The highest configurable central frequency in MHz";
+        "The highest configurable central frequency in MHz.";
     }
 
     leaf grid-type {
@@ -283,9 +311,10 @@ module openconfig-terminal-device-properties {
     }
   }
 
-  grouping operational-mode-capabilities-top {
+  grouping operational-mode-capabilities-attributes-top {
     description
-      "Operational-mode features top container";
+      "Operational-mode capabilities leafs.";
+
     leaf modulation-format {
       type union {
         type string;
@@ -323,17 +352,6 @@ module openconfig-terminal-device-properties {
        "Spectrum width of the optical channel associated to this
         operational mode, calculated as the baud-rate*(1+roll-off).";
     }
-
-    container fec {
-      description
-        "The Forward Error Coding (FEC) coding schema used,
-        including the name, overhead, pre-fec-ber threshold and
-        gain properties.";
-
-      uses fec-codes-attributes;
-    }
-
-    //sensitivity specs.
 
     leaf min-tx-osnr {
       type decimal64 {
@@ -413,7 +431,29 @@ module openconfig-terminal-device-properties {
         optical channel associated to the associated transmission mode
         (operational model), expressed in decibels (dB)";
     }
+  }
 
+  grouping operational-mode-capabilities-top {
+    description
+      "Operational-mode explicit-mode capabilities grouping.";
+
+    uses operational-mode-capabilities-attributes-top;
+
+    container fec {
+      description
+        "The Forward Error Coding (FEC) coding schema used,
+        including the name, overhead, pre-fec-ber threshold and
+        gain properties.";
+      
+      container state {
+        config false;
+        description
+          "FEC state attributes top container.";
+          
+        uses fec-codes-attributes;
+      }
+    }
+    
     list penalties {
       key "parameter-and-unit up-to-boundary";
       description
@@ -424,16 +464,45 @@ module openconfig-terminal-device-properties {
         values, penalty could be linearly interpolated.
         - For parameter values above highest up-to-boundary value, the penalty is the one
         included within penalty-value attribute associated to the highest up-to-boundary";
+      
+      leaf parameter-and-unit {
+        type leafref {
+          path "../state/parameter-and-unit";
+        }
+        description
+          "Impairment and unit leading to the penalty (i.e., cd-ps)";
+      }
 
-      uses penalties-list-element-attributes;
+      leaf up-to-boundary {
+        type leafref {
+          path "../state/up-to-boundary";
+        }
+        description
+          "defines the upper (for positive values) and lower (for negative values)
+           limit for which the penalty value is valid.";
+      }
+      
+      container state {
+        config false;
+        description
+          "Penalties list element's state attributes top container.";
+          
+        uses penalties-list-element-attributes;
+      }
     }
 
     container filter {
       description
         "This container includes information which characterises the filter at
         transceiver transmission for the given operational-mode.";
-
-      uses filter-attributes-top;
+      
+      container state {
+        config false;
+        description
+          "Filter's state attributes top container.";
+          
+        uses filter-attributes-top;
+      }
     }
   }
 
@@ -456,9 +525,9 @@ module openconfig-terminal-device-properties {
         "Indicates whether the transceiver's mode is a standard
         mode, an organizational mode or an explicit mode.";
     }
-    uses standard-mode-features-description;
+    uses standard-mode-features-description-top;
 
-    uses explicit-mode-features-description;
+    uses explicit-mode-features-description-top;
   }
 
   grouping operational-mode-top{
@@ -481,15 +550,16 @@ module openconfig-terminal-device-properties {
 
         leaf mode-id {
           type leafref {
-            path "../features/mode-id";
+            path "../state/mode-id";
           }
           description
             "Reference to mode-id";
         }
 
-        container features {
+        container state {
           description
-            "Features supported by the operational mode.";
+            "Static features or properties which characterize the
+            operational mode.";
 
           uses operational-mode-features-top;
         }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -1,0 +1,445 @@
+module openconfig-terminal-device-properties {
+
+  // Yang version can be "1" without mandatory fields.
+  // Yang version 1.1 allows mandatory fiels in an augment
+  // https://tools.ietf.org/html/rfc7950#section-7.17
+  // If the augmentation adds mandatory nodes (see Section 3) that
+  // represent configuration to a target node in another module, the
+  // augmentation MUST be made conditional with a "when" statement.
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://example.net/yang/openconfig-terminal-device-properties";
+  prefix "oc-opt-term-properties";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-transport-types { prefix oc-opt-types; }
+  import openconfig-terminal-device-property-types { prefix oc-opt-term-prop-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+      www.openconfig.net";
+
+  description
+      "Module to extend OC terminal device with information about
+      operational modes. It supports operational modes for 1 Optical
+      Channel, with a single OTSi. The operational mode incluides key
+      attributes such modulation format, symbol rate, nominal central
+      frequency (NFC) tunability constraits (grid, min/max NCF), FEC
+      gain,minimum and maximum output power of the transmitter or
+      minimum q-value at the receiver as well as the spectrum width of
+      the OTSi (OTSiMC). It also includes (optional) aspects such as
+      filter characterization, CD and DGD tolerance.";
+
+  oc-ext:openconfig-version "1.7.3";
+
+
+  // Revisions
+  revision "2021-06-21" {
+      description "Initial manifest fine to extend the information
+      related to the operational modes supported by a terminal device";
+      reference "0.1.0";
+  }
+
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig-properties";
+
+  // grouping statements
+
+  grouping standard-mode-features-description {
+    description
+      "Standard mode features description grouping. It is used if the
+      'mode-type' attribute is set to 'TRANSCEIVER_MODE_TYPE_STANDARD";
+
+    container G.698.2 {
+      leaf standard-mode {
+        type oc-opt-term-prop-types:standard-mode;
+        config false;
+        description
+          "G.698.2 (11/18) standard mode";
+      }
+      description
+        "ITU-T G.698.2 (11/18) standard mode that guarantees interoperability.
+        It must be an string with the following format:
+        B-DScW-ytz(v) where all these attributes are conformant
+        to the ITU-T G.698.2 (11/18) recomendation.";
+    }
+  }
+
+  grouping explicit-mode-features-description {
+    description
+      "Definition of propiertary or non-standard operational-modes, which can be
+      uniformly characterized by the set of attributes included in their
+      operational-mode-capabilities which defines the related signal physical
+      impairment related aspects such Rx and Tx associated attibutes and tolerances,
+      ; and its optical-channel-config-value-constrains, which defines what are the 
+      allowed values to be configured at the oc-component:optical-channel instance
+      configured to this mode.";
+
+    container explicit-mode {
+      container operational-mode-capabilities {
+        config false;
+        uses operational-mode-features-description;
+        description
+          "Set of attributes which charaterizes the operational-mode for optimal
+          optical-channel transmission and receiver functions. This attributes
+          are intending to describe all the relevant data used during the
+          network planning phase, to estimate the physical-impairment
+          tolerances which can be introduced by the DWDM optical path,
+          while assuring optimal transmission function.";
+      }
+      container optical-channel-config-value-constrains{
+        uses config-value-constrains-top;
+        description
+          "Set of constrains of the configuration attributes
+          of the optical-channel associated to the selected
+          operational-mode.";
+      }
+      description
+        "Explicit defition of the operational-mode. Typically this is used
+        for non-standard/propietary modes defined by the terminal-device
+        vendor and it is self described by the capabilities included in
+        the subtree underneath.";
+    }
+  }
+
+  grouping config-value-constrains-top {
+    description
+      "Configuration value constrains for optical channels
+      configured on the target operational mode.";
+
+    leaf min-central-frequency {
+      type oc-opt-types:frequency-type;
+      description
+        "The lowest configurable central frequency in MHz";
+    }
+
+    leaf max-central-frequency {
+      type oc-opt-types:frequency-type;
+      description
+        "The highest configurable central frequency in MHz";
+    }
+
+    leaf grid-type {
+      type oc-opt-term-prop-types:grid-type;
+      description
+        "Frequency  ITU-T G.694.1 (10/2020) grid specification attribute.";
+    }
+
+    leaf adjustment-granularity {
+      type oc-opt-term-prop-types:adjustment-granularity;
+      description
+        "Adjustment granularity in Gigahertz. As per  ITU-T G.694.1
+        (10/2020), it is used to calculate nominal central frequency of an
+        optical channel. It defines the minimun granularity supporting by the
+        optical channel's central frequency setting.";
+    }
+
+    leaf min-channel-spacing {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units GHz;
+      description
+       "Minimum recommended spectrum spacing between the central frequency of two
+        adjacent optical channels of the same mode. In case of two adjacent optical
+        channels with different operational-modes, it is up to the path computation
+        engine to determine the minimun distance between the central frequencies of
+        these two optical channels.";
+    }
+
+    leaf min-output-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Minimmun target output optical power level of the optical channel,
+        configurable according to the optical transceiver mode properties,
+        expressed in increments of 0.01 dBm (decibel-milliwats)";
+    }
+
+    leaf max-output-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Maximun arget output optical power level of the optical channel,
+        configurable according to the optical transceiver mode properties,
+        expressed in increments of 0.01 dBm (decibel-milliwats)";
+    }
+  }
+
+
+  grouping operational-mode-features-description {
+    leaf modulation-format {
+      type union {
+        type string;
+        type oc-opt-term-prop-types:modulation-format;
+      }
+      description
+        "Optical modulation format associated to the mode. The
+        modulation format associated to the optical signal ";
+    }
+
+    leaf bit-rate {
+      type oc-opt-term-prop-types:bit-rate;
+      description
+        "Rounded bit rate of the tributary signal delivered by the
+        optical channel associated to the specifc operational mode.
+        Exact bit rate will be refined by protocol selection at the
+        associated tributary logical channel.";
+    }
+
+    leaf baud-rate {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units Bd;
+      description
+        "Baud-rate or symbol rate.";
+    }
+
+    leaf optical-channel-spectrum-width {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units GHz;
+      description
+       "Spectrum width of the optical channel associated to this
+        operational mode, calculated as the baud-rate*(1+roll-off).";
+    }
+
+    container fec {
+      leaf fec-coding {
+        type union {
+          type string;
+          type oc-opt-term-prop-types:fec-coding;
+        }
+        description
+          "Forward error correction (FEC) coding schema used in the
+          tramission mode. Type union of string (for propietary codes)
+          and a set of standard codes encoded as identityrefs";
+      }
+
+      leaf coding-overhead {
+        type decimal64 {
+          fraction-digits 2;
+        }
+        description
+          "Coding overhead rate in %.";
+      }
+
+      leaf coding-gain {
+        type decimal64 {
+          fraction-digits 2;
+        }
+        default 0.00;
+        units dB;
+        description
+          "Net coding gain (NCG) in dB units at 10E-15 bit error rate.
+          It may vary depending on the modulation format used in the
+          associated transmission mode (operational-mode).";
+      }
+      leaf pre-fec-ber-threshold {
+        type decimal64 {
+          fraction-digits 18;
+        }
+        units bit-errors-per-second;
+        description
+          "Threshold on the PRE-FEC-BER, for which FEC code is able to
+          correct errors.";
+      }
+
+      description
+        "The Forward Error Coding (FEC) coding schema used,
+        including the name, overhead, pre-fec-ber threshold and gain
+        properties.";
+    }
+
+    //sensitivity specs.
+
+    leaf min-osnr {
+      type decimal64 {
+          fraction-digits 2;
+      }
+      units dB;
+      description
+        "Minimum OSNR measured over 0.1nm resolution bandwidth;
+        if received OSNR at minimum Rx-power is lower than min-osnr,
+        an increased level of bit-errors post-FEC needs to be expected.";
+    }
+
+    leaf min-input-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Minimun required input power in dBm of a optical channel
+        at the receiver (Rx) of the coherence transceiver.";
+    }
+
+    leaf max-input-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Maximun tolerated input power in dBm of a optical channel
+        at the receiver (Rx) of the coherence transceiver.";
+    }
+
+    leaf min-q-value {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "Minimum required Quality value (factor) in decibels (dB) of a optical
+        channel at the receiver side (RX) of the coherence transceiver.
+        This value corresponds to the pre-fec-ber-threshold value which if
+        exceeded, uncorrectable errors will start to be generated.";
+    }
+
+    leaf max-chromatic-dispersion {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps-nm;
+      description
+        "Maximum chromatic-dispersion, absolute value, supported by the
+        optical channel associated to the associated tranmission mode
+        (operational model), expressed in picoseconds / nanometer (ps/nm).";
+    }
+
+    leaf max-differential-group-delay {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps;
+      description
+        "Maximum differential-group-delay, absolute value, supported by the
+        optical channel associated to the associated tranmission mode
+        (operational model), expressed in picoseconds (ps).";
+    }
+
+    leaf max-polarization-dependent-loss {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "Maximum polarization-dependent-loss absolute value, supported by the
+        optical channel associated to the associated tranmission mode
+        (operational model), expressed in decibels (dB)";
+    }
+
+    list penalties {
+      key "parameter-and-unit up-to-boundary";
+      description
+        "Penalties includes contributions from different impairments including
+        cd, pmd, low RX Power, pdl,...
+        - For parameter values below lowest up-to-boundary value, the penalty is 0.
+        - For parameter values between lowest and highest up-to-boundary
+        values, penalty could be linerarly interpolated.
+        - For paramter values above highest up-to-boundary value, the penalty is the one
+        included within penalty-value attribute associated to the highest up-to-boundary";
+
+      leaf parameter-and-unit {
+        type oc-opt-term-prop-types:impairment-type;
+        description
+          "Impairment and unit leading to the penalty (i.e., cd-ps)";
+      }
+
+      leaf up-to-boundary {
+        type decimal64 {
+          fraction-digits 2;
+        }
+        description
+          "defines the upper (for positive values) and lower (for negative values)
+           limit for which the penalty value is valid.";
+      }
+
+      leaf penalty-value {
+        type decimal64 {
+          fraction-digits 2;
+        }
+        units dB;
+        description
+          "OSNR penalty associated to the given values, expressed in dB.";
+      }
+    }
+
+    container filter {
+      leaf roll-off {
+        description
+          "Decimal fraction between 0 and 1. Roll-off parameter (𝛽) of the TX pulse
+          shaping filter. This assumes a raised-cosine filter";
+        type decimal64 {
+          fraction-digits 2;
+        }
+      }
+    }
+  }
+
+  grouping operational-mode-features{
+    leaf mode-id {
+      type uint16;
+      description
+        "Two-octet encoding of the vendor-defined operational
+        mode";
+    }
+
+    leaf mode-type {
+      type identityref{
+          base oc-opt-term-prop-types:TRANSCEIVER_MODE_TYPE;
+      }
+      description
+        "Indicates whether the transceiver's mode is a standard
+        mode, an organizational mode or an explicit mode.";
+    }
+    uses standard-mode-features-description;
+
+    uses explicit-mode-features-description;
+  }
+
+  container operational-modes {
+    description
+      "Indicates the transceiver's list of supported operational
+       modes and its assoiated transmission features";
+
+    list mode-descriptor {
+      key "mode-id";
+      config false;
+      description
+        "List of operational modes supported by the platform.
+        The operational mode provides a platform-defined summary
+        of information such as symbol rate, modulation, pulse
+        shaping, etc.";
+
+      leaf mode-id {
+        type leafref {
+          path "../features/mode-id";
+        }
+        description
+          "Reference to mode-id";
+      }
+
+      container features {
+        description
+          "Features supported by the operational mode.";
+
+        uses operational-mode-features;
+      }
+    }
+  }
+}

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -25,13 +25,13 @@ module openconfig-terminal-device-properties {
       www.openconfig.net";
 
   description
-      "Module to extend OC terminal device with information about
-      operational modes. It supports operational modes for 1 Optical
-      Channel, with a single OTSi. The operational mode incluides key
+      "Module to extend OpenConfig terminal device's operational modes'
+      data. It supports operational modes for one Optical
+      Channel, with a single OTSi. The operational mode includes key
       attributes such modulation format, symbol rate, nominal central
-      frequency (NFC) tunability constraits (grid, min/max NCF), FEC
-      gain,minimum and maximum output power of the transmitter or
-      minimum q-value at the receiver as well as the spectrum width of
+      frequency (NFC) tunability constraints (grid, min/max NCF), FEC
+      gain, minimum and maximum output power of the transmitter or
+      minimum OSNR at the receiver as well as the spectrum width of
       the OTSi (OTSiMC). It also includes (optional) aspects such as
       filter characterization, CD and DGD tolerance.";
 
@@ -39,7 +39,7 @@ module openconfig-terminal-device-properties {
 
 
   // Revisions
-  revision "2021-06-21" {
+  revision "2022-04-19" {
       description "Initial manifest fine to extend the information
       related to the operational modes supported by a terminal device";
       reference "0.1.0";
@@ -68,30 +68,30 @@ module openconfig-terminal-device-properties {
         "ITU-T G.698.2 (11/18) standard mode that guarantees interoperability.
         It must be an string with the following format:
         B-DScW-ytz(v) where all these attributes are conformant
-        to the ITU-T G.698.2 (11/18) recomendation.";
+        to the ITU-T G.698.2 (11/18) recommendation.";
     }
   }
 
   grouping explicit-mode-features-description {
     description
-      "Definition of propiertary or non-standard operational-modes, which can be
+      "Definition of proprietary or non-standard operational-modes, which can be
       uniformly characterized by the set of attributes included in their
       operational-mode-capabilities which defines the related signal physical
-      impairment related aspects such Rx and Tx associated attibutes and tolerances,
+      impairment related aspects such Rx and Tx associated attributes and tolerances,
       ; and its optical-channel-config-value-constrains, which defines what are the
       allowed values to be configured at the oc-component:optical-channel instance
       configured to this mode.";
 
     container explicit-mode {
       description
-        "Explicit defition of the operational-mode. Typically this is used
-        for non-standard/propietary modes defined by the terminal-device
-        vendor and it is self described by the capabilities included in
+        "Explicit definition of the operational-mode. Typically this is used
+        for non-standard/proprietary modes defined by the terminal-device
+        vendor and it is self-described by the capabilities included in
         the subtree underneath.";
 
       container operational-mode-capabilities {
         description
-          "Set of attributes which charaterizes the operational-mode for optimal
+          "Set of attributes which characterizes the operational-mode for optimal
           optical-channel transmission and receiver functions. This attributes
           are intending to describe all the relevant data used during the
           network planning phase, to estimate the physical-impairment
@@ -139,7 +139,7 @@ module openconfig-terminal-device-properties {
       description
         "Adjustment granularity in Gigahertz. As per  ITU-T G.694.1
         (10/2020), it is used to calculate nominal central frequency of an
-        optical channel. It defines the minimun granularity supporting by the
+        optical channel. It defines the minimum granularity supporting by the
         optical channel's central frequency setting.";
     }
 
@@ -152,7 +152,7 @@ module openconfig-terminal-device-properties {
        "Minimum recommended spectrum spacing between the central frequency of two
         adjacent optical channels of the same mode. In case of two adjacent optical
         channels with different operational-modes, it is up to the path computation
-        engine to determine the minimun distance between the central frequencies of
+        engine to determine the minimum distance between the central frequencies of
         these two optical channels.";
     }
 
@@ -162,7 +162,7 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Minimmun target output optical power level of the optical channel,
+        "Minimum target output optical power level of the optical channel,
         configurable according to the optical transceiver mode properties,
         expressed in increments of 0.01 dBm (decibel-milliwats)";
     }
@@ -173,9 +173,9 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Maximun arget output optical power level of the optical channel,
+        "Maximum arget output optical power level of the optical channel,
         configurable according to the optical transceiver mode properties,
-        expressed in increments of 0.01 dBm (decibel-milliwats)";
+        expressed in increments of 0.01 dBm (decibel-milliwatts)";
     }
   }
 
@@ -212,7 +212,7 @@ module openconfig-terminal-device-properties {
   grouping fec-codes-attributes {
     description
       "FEC codes attributes grouping, including the set of attributes
-      which defines the FEC code employed on the tranmission represented
+      which defines the FEC code employed on the transmission represented
       by the operational-mode.";
 
     leaf fec-coding {
@@ -222,8 +222,8 @@ module openconfig-terminal-device-properties {
       }
       description
         "Forward error correction (FEC) coding schema used in the
-        tramission mode. Type union of string (for propietary codes)
-        and a set of standard codes encoded as identityrefs";
+        transmission mode. Type union of string (for proprietary codes)
+        and a set of standard codes encoded as identity references";
     }
 
     leaf coding-overhead {
@@ -258,8 +258,8 @@ module openconfig-terminal-device-properties {
 
   grouping filter-attributes-top {
     description
-      "This gruping includes the attributes which characterises the filter at
-      transceiver transmission for the given operational-mode.";
+      "This grouping includes the attributes which characterises the filter
+      at transceiver transmission for the given operational-mode.";
 
     leaf pulse-shaping-type {
       type union {
@@ -269,7 +269,7 @@ module openconfig-terminal-device-properties {
       description
        "Pulse/spectral shaping type such as Raised-cosine (RC),
          root-raised-cosine (RRC) and OFF. The attribute allows
-         other pulse-shapping types to be encoded as strings.";
+         other pulse-shaping types to be encoded as strings.";
     }
 
     leaf roll-off {
@@ -300,7 +300,7 @@ module openconfig-terminal-device-properties {
       type oc-opt-term-prop-types:bit-rate;
       description
         "Rounded bit rate of the tributary signal delivered by the
-        optical channel associated to the specifc operational mode.
+        optical channel associated to the specific operational mode.
         Exact bit rate will be refined by protocol selection at the
         associated tributary logical channel.";
     }
@@ -388,7 +388,7 @@ module openconfig-terminal-device-properties {
       units ps-nm;
       description
         "Maximum chromatic-dispersion, accumulated value, supported by the
-        optical channel associated to the associated tranmission mode
+        optical channel associated to the associated transmission mode
         (operational model), expressed in picoseconds / nanometer (ps/nm).";
     }
 
@@ -410,7 +410,7 @@ module openconfig-terminal-device-properties {
       units dB;
       description
         "Maximum polarization-dependent-loss accumulated value, supported by the
-        optical channel associated to the associated tranmission mode
+        optical channel associated to the associated transmission mode
         (operational model), expressed in decibels (dB)";
     }
 
@@ -421,8 +421,8 @@ module openconfig-terminal-device-properties {
         cd, pmd, low RX Power, pdl,...
         - For parameter values below lowest up-to-boundary value, the penalty is 0.
         - For parameter values between lowest and highest up-to-boundary
-        values, penalty could be linerarly interpolated.
-        - For paramter values above highest up-to-boundary value, the penalty is the one
+        values, penalty could be linearly interpolated.
+        - For parameter values above highest up-to-boundary value, the penalty is the one
         included within penalty-value attribute associated to the highest up-to-boundary";
 
       uses penalties-list-element-attributes;
@@ -469,7 +469,7 @@ module openconfig-terminal-device-properties {
       config false;
       description
         "Indicates the transceiver's list of supported operational
-         modes and its assoiated transmission features";
+         modes and its associated transmission features";
 
       list mode-descriptor {
         key "mode-id";

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -35,7 +35,7 @@ module openconfig-terminal-device-properties {
       the OTSi (OTSiMC). It also includes (optional) aspects such as
       filter characterization, CD and DGD tolerance.";
 
-  oc-ext:openconfig-version "1.7.3";
+  oc-ext:openconfig-version "0.1.0";
 
 
   // Revisions
@@ -61,7 +61,6 @@ module openconfig-terminal-device-properties {
     container G.698.2 {
       leaf standard-mode {
         type oc-opt-term-prop-types:standard-mode;
-        config false;
         description
           "G.698.2 (11/18) standard mode";
       }
@@ -85,7 +84,6 @@ module openconfig-terminal-device-properties {
 
     container explicit-mode {
       container operational-mode-capabilities {
-        config false;
         uses operational-mode-features-description;
         description
           "Set of attributes which charaterizes the operational-mode for optimal
@@ -411,12 +409,7 @@ module openconfig-terminal-device-properties {
 
     uses explicit-mode-features-description;
   }
-
-  container operational-modes {
-    description
-      "Indicates the transceiver's list of supported operational
-       modes and its assoiated transmission features";
-
+  grouping operational-mode-top{
     list mode-descriptor {
       key "mode-id";
       config false;
@@ -441,5 +434,12 @@ module openconfig-terminal-device-properties {
         uses operational-mode-features;
       }
     }
+  }
+
+  container operational-modes {
+    description
+      "Indicates the transceiver's list of supported operational
+       modes and its assoiated transmission features";
+    uses operational-mode-top;
   }
 }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -300,23 +300,25 @@ module openconfig-terminal-device-properties {
     container fec {
       description
         "The Forward Error Coding (FEC) coding schema used,
-        including the name, overhead, pre-fec-ber threshold and gain
-        properties.";
+        including the name, overhead, pre-fec-ber threshold and
+        gain properties.";
 
       uses fec-codes-attributes;
     }
 
     //sensitivity specs.
 
-    leaf min-osnr {
+    leaf min-rx-osnr {
       type decimal64 {
           fraction-digits 2;
       }
       units dB;
       description
-        "Minimum OSNR measured over 0.1nm resolution bandwidth;
-        if received OSNR at minimum Rx-power is lower than min-osnr,
-        an increased level of bit-errors post-FEC needs to be expected.";
+        "Minimum back-to-back OSNR measured over 0.1nm@193.7Thz or
+        12.5GHz noise resolution bandwidth at the min-input-power.
+        If received OSNR at min-input-power is lower than this value,
+        an increased level of bit-errors post-FEC needs to be 
+        expected.";
     }
 
     leaf min-input-power {
@@ -325,8 +327,10 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Minimun required input power in dBm of a optical channel
-        at the receiver (Rx) of the coherence transceiver.";
+        "Minimum value required input power in dBm of an optical channel
+        at the receiver (Rx) according to the given min-osnr value. If
+        the input-power is lower it is expected to introduce an OSNR
+        penalty.";
     }
 
     leaf max-input-power {
@@ -335,8 +339,9 @@ module openconfig-terminal-device-properties {
       }
       units dBm;
       description
-        "Maximun tolerated input power in dBm of a optical channel
-        at the receiver (Rx) of the coherence transceiver.";
+        "Maximum tolerated input power in dBm at the receiver (Rx) 
+        of the coherence transceiver, which if exceeded can cause an 
+        overload.";
     }
 
     leaf min-q-value {

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -267,7 +267,7 @@ module openconfig-terminal-device-properties {
         type oc-opt-term-prop-types:pulse-shaping-type;
       }
       description
-       "Pulse/spectral shaping type such as Raised-cosine (RC), 
+       "Pulse/spectral shaping type such as Raised-cosine (RC),
          root-raised-cosine (RRC) and OFF. The attribute allows
          other pulse-shapping types to be encoded as strings.";
     }

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -79,7 +79,7 @@ module openconfig-terminal-device-properties {
       uniformly characterized by the set of attributes included in their
       operational-mode-capabilities which defines the related signal physical
       impairment related aspects such Rx and Tx associated attibutes and tolerances,
-      ; and its optical-channel-config-value-constrains, which defines what are the 
+      ; and its optical-channel-config-value-constrains, which defines what are the
       allowed values to be configured at the oc-component:optical-channel instance
       configured to this mode.";
 

--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -238,8 +238,8 @@ module openconfig-terminal-device-properties {
       type decimal64 {
         fraction-digits 2;
       }
-      default 0.00;
       units dB;
+      default 0.00;
       description
         "Net coding gain (NCG) in dB units at 10E-15 bit error rate.
         It may vary depending on the modulation format used in the
@@ -253,6 +253,33 @@ module openconfig-terminal-device-properties {
       description
         "Threshold on the PRE-FEC-BER, for which FEC code is able to
         correct errors.";
+    }
+  }
+
+  grouping filter-attributes-top {
+    description
+      "This gruping includes the attributes which characterises the filter at
+      transceiver transmission for the given operational-mode.";
+
+    leaf pulse-shaping-type {
+      type union {
+        type string;
+        type oc-opt-term-prop-types:pulse-shaping-type;
+      }
+      description
+       "Pulse/spectral shaping type such as Raised-cosine (RC), 
+         root-raised-cosine (RRC) and OFF. The attribute allows
+         other pulse-shapping types to be encoded as strings.";
+    }
+
+    leaf roll-off {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      description
+        "Decimal fraction between 0 and 1. Roll-off parameter (𝛽) of the
+        TX pulse shaping filter. This assumes a raised-cosine filter";
+
     }
   }
 
@@ -308,13 +335,23 @@ module openconfig-terminal-device-properties {
 
     //sensitivity specs.
 
+    leaf min-tx-osnr {
+      type decimal64 {
+          fraction-digits 2;
+      }
+      units dB;
+      description
+        "Minimum in-band transmitter OSNR measured at 0.1nm@193.6Thz,
+        considering the maximum transceiver inserted noise. ";
+    }
+
     leaf min-rx-osnr {
       type decimal64 {
           fraction-digits 2;
       }
       units dB;
       description
-        "Minimum back-to-back OSNR measured over 0.1nm@193.7Thz or
+        "Minimum back-to-back OSNR measured over 0.1nm@193.6Thz or
         12.5GHz noise resolution bandwidth at the min-input-power.
         If received OSNR at min-input-power is lower than this value,
         an increased level of bit-errors post-FEC needs to be
@@ -344,25 +381,13 @@ module openconfig-terminal-device-properties {
         overload.";
     }
 
-    leaf min-q-value {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB;
-      description
-        "Minimum required Quality value (factor) in decibels (dB) of a optical
-        channel at the receiver side (RX) of the coherence transceiver.
-        This value corresponds to the pre-fec-ber-threshold value which if
-        exceeded, uncorrectable errors will start to be generated.";
-    }
-
     leaf max-chromatic-dispersion {
       type decimal64 {
         fraction-digits 2;
       }
       units ps-nm;
       description
-        "Maximum chromatic-dispersion, absolute value, supported by the
+        "Maximum chromatic-dispersion, accumulated value, supported by the
         optical channel associated to the associated tranmission mode
         (operational model), expressed in picoseconds / nanometer (ps/nm).";
     }
@@ -384,7 +409,7 @@ module openconfig-terminal-device-properties {
       }
       units dB;
       description
-        "Maximum polarization-dependent-loss absolute value, supported by the
+        "Maximum polarization-dependent-loss accumulated value, supported by the
         optical channel associated to the associated tranmission mode
         (operational model), expressed in decibels (dB)";
     }
@@ -408,14 +433,7 @@ module openconfig-terminal-device-properties {
         "This container includes information which characterises the filter at
         transceiver transmission for the given operational-mode.";
 
-      leaf roll-off {
-        description
-          "Decimal fraction between 0 and 1. Roll-off parameter (𝛽) of the TX pulse
-          shaping filter. This assumes a raised-cosine filter";
-        type decimal64 {
-          fraction-digits 2;
-        }
-      }
+      uses filter-attributes-top;
     }
   }
 

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -352,7 +352,7 @@ module openconfig-terminal-device-property-types {
     description
       "Dual-Carrier Dual-Polarization 32-Quadrature Amplitude Modulation
       (QAM) identity";
-  }  
+  }
 
   identity MODULATION_FORMAT_64QAM {
     base MODULATION_FORMAT;
@@ -372,7 +372,7 @@ module openconfig-terminal-device-property-types {
     description
       "Dual-Carrier Dual-Polarization 64-Quadrature Amplitude Modulation
       (QAM) identity";
-  }  
+  }
 
   identity MODULATION_FORMAT_PAM4 {
     base MODULATION_FORMAT;
@@ -385,7 +385,7 @@ module openconfig-terminal-device-property-types {
     description
       "8-level Pulse Amplitud Modulation (PAM)";
   }
-  
+
   identity MODULATION_FORMAT_PCS {
     base MODULATION_FORMAT;
     description

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -67,6 +67,14 @@ module openconfig-terminal-device-property-types {
       associated tributary logical channel.";
   }
 
+  typedef pulse-shaping-type {
+    type identityref {
+      base SHAPING_TYPE;
+    }
+    description
+      "Pulse/spectral shaping type associated to the mode.";
+  }
+
   typedef modulation-format {
     type identityref {
       base MODULATION_FORMAT;
@@ -109,6 +117,30 @@ module openconfig-terminal-device-property-types {
       "Definition of impairment type and unit used in penaty list";
   }
 
+  identity SHAPING_TYPE {
+    description
+      "Base identity for pulse-shaping-type, to help characterize the
+      filter type included in the transceiver which support the mode.";
+  }
+
+  identity RC {
+    base  SHAPING_TYPE;
+    description
+      "Raised-cosine filter shape.";
+  }
+
+  identity RRC {
+    base  SHAPING_TYPE;
+    description
+      "Root-raised-cosine filter shape.";
+  }
+
+  identity OFF {
+    base  SHAPING_TYPE;
+    description
+      "No filter.";
+  }
+
   identity IMPAIRMENT_TYPE {
     description
       "Base identity for impairment type and units, used in penaty list.";
@@ -124,6 +156,12 @@ module openconfig-terminal-device-property-types {
     base  IMPAIRMENT_TYPE;
     description
       "Polarization Mode Dispersion (PMD) in picoseconds units.";
+  }
+
+  identity PDL_DB {
+    base  IMPAIRMENT_TYPE;
+    description
+      "Polarization Dependent Loss (PDL) in decibels (dB) units.";
   }
 
   identity GRID_TYPE {

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -105,11 +105,13 @@ module openconfig-terminal-device-property-types {
     type identityref {
       base IMPAIRMENT_TYPE;
     }
+    description
+      "Definition of impairment type and unit used in penaty list";
   }
 
   identity IMPAIRMENT_TYPE {
     description
-      "Definition of impairment type and unit used in penaty list.";
+      "Base identity for impairment type and units, used in penaty list.";
   }
 
   identity CD_PS_NM {

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -26,7 +26,7 @@ module openconfig-terminal-device-property-types {
   description
       "Supplementary module to expose identity types for the
       openconfig-terminal-device-properties model. This model includes
-      definitions of the set of modulation format, fec codes and adjustment
+      definitions of the set of modulation format, FEC codes and adjustment
       granularity types use in the reffered model.";
 
   oc-ext:openconfig-version "0.1.0";
@@ -426,10 +426,10 @@ module openconfig-terminal-device-property-types {
       "8-level Pulse Amplitud Modulation (PAM)";
   }
 
-  identity MODULATION_FORMAT_PCS {
+  identity MODULATION_FORMAT_PROPRIETARY {
     base MODULATION_FORMAT;
     description
-      "Probabilistic Constellation Shaping.";
+      "Proprietary modulation format.";
   }
 
   identity TRANSCEIVER_MODE_TYPE{
@@ -454,6 +454,4 @@ module openconfig-terminal-device-property-types {
       operational mode features follows the model subtree explicit
       features description.";
   }
-
-
 }

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -29,7 +29,7 @@ module openconfig-terminal-device-property-types {
       definitions of the set of modulation format, fec codes and adjustment
       granularity types use in the reffered model.";
 
-  oc-ext:openconfig-version "1.7.3";
+  oc-ext:openconfig-version "0.1.0";
 
 
   // Revisions

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -1,0 +1,419 @@
+module openconfig-terminal-device-property-types {
+
+  // Yang version can be "1" without mandatory fields.
+  // Yang version 1.1 allows mandatory fiels in an augment
+  // https://tools.ietf.org/html/rfc7950#section-7.17
+  // If the augmentation adds mandatory nodes (see Section 3) that
+  // represent configuration to a target node in another module, the
+  // augmentation MUST be made conditional with a "when" statement.
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://example.net/yang/openconfig-terminal-device-property-types";
+  prefix "oc-opt-term-prop-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-transport-types { prefix oc-opt-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+      www.openconfig.net";
+
+  description
+      "Supplementary module to expose identity types for the
+      openconfig-terminal-device-properties model. This model includes
+      definitions of the set of modulation format, fec codes and adjustment
+      granularity types use in the reffered model.";
+
+  oc-ext:openconfig-version "1.7.3";
+
+
+  // Revisions
+  revision "2022-03-08" {
+      description "Initial version to provide the initial set of identities
+      used in the openconfig-terminal-device-properties model.";
+      reference "0.1.0";
+  }
+
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig-properties";
+
+
+  typedef standard-mode {
+    type string;
+    description
+      "ITU-T G.698.2 standard mode that guarantees interoperability.
+      It must be an string with the following format:
+      B-DScW-ytz(v) where all these attributes are conformant
+      to the ITU-T recomendation";
+      reference "ITU-T G.698.2 (11/2018)";
+  }
+
+  typedef bit-rate {
+    type identityref {
+      base oc-opt-types:TRIBUTARY_RATE_CLASS_TYPE;
+    }
+    description
+      "Rounded bit rate of the tributary signal delivered by the
+      optical channel associated to the specifc operational mode.
+      Exact bit rate will be refined by protocol selection at the
+      associated tributary logical channel.";
+  }
+
+  typedef modulation-format {
+    type identityref {
+      base MODULATION_FORMAT;
+    }
+    description
+      "Optical modulation format associated to the mode";
+  }
+
+  typedef fec-coding {
+    type identityref {
+      base FEC;
+    }
+    description
+      "FEC Type identityref, e.g., FEC_G";
+  }
+
+  typedef grid-type {
+    type identityref {
+      base GRID_TYPE;
+    }
+    description
+      "Type for frequency ITU-T grid specification attributes.";
+  }
+
+  typedef adjustment-granularity {
+    type identityref {
+      base ADJUSTMENT_GRANULARITY;
+    }
+    description
+      "Type definition for the possible adjustment granularity attributes.
+      As per ITU-T G.694.1 (10/2020), it is used to calculate nominal
+      central frequency.";
+  }
+
+  typedef impairment-type {
+    type identityref {
+      base IMPAIRMENT_TYPE;
+    }
+  }
+
+  identity IMPAIRMENT_TYPE {
+    description
+      "Definition of impairment type and unit used in penaty list.";
+  }
+
+  identity CD_PS_NM {
+    base  IMPAIRMENT_TYPE;
+    description
+      "Chromatic Dispersion (CD) in picoseconds per nanometer units.";
+  }
+
+  identity PMD_PS {
+    base  IMPAIRMENT_TYPE;
+    description
+      "Polarization Mode Dispersion (PMD) in picoseconds units.";
+  }
+
+  identity GRID_TYPE {
+    description
+      "Base identity for Grid Type definitions according to ITU-T
+      ITU-T G.694.1 (10/2020) standard which defines the possible
+      configurable values of the optical channel component's
+      central frequency attribute.";
+  }
+
+  identity DWDM {
+    base  GRID_TYPE;
+    description
+      "Fixed frequency grid in C & L bands as specified
+      in  ITU-T G.694.1 (10/2020)";
+  }
+
+  identity CWDM {
+    base  GRID_TYPE;
+    description
+      "Fixed frequency grid as specified in  ITU-T G.694.1 (10/2020).";
+  }
+
+  identity FLEX {
+    base  GRID_TYPE;
+    description
+      "Flexible frequency grid as specified in  ITU-T G.694.1 (10/2020).";
+  }
+
+  identity GRIDLESS {
+    base  GRID_TYPE;
+    description
+      "No grid";
+  }
+
+  identity UNSPECIFIED {
+    base  GRID_TYPE;
+    description
+      "Unspecified/proprietary frequency grid";
+  }
+
+  identity ADJUSTMENT_GRANULARITY {
+    description
+      "Base identity for the adjustment granularity or nominal central
+      frequency granularity, according to  ITU-T G.694.1 (10/2020) standard,
+      defined as the minimun spectrum separation between the central
+      frequencies of two contiguous optical channels";
+  }
+
+  identity G_100GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 100 gigahertz.";
+  }
+
+  identity G_50GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 50 gigahertz.";
+  }
+
+  identity G_25GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 25 gigahertz.";
+  }
+
+  identity G_12_5GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 12.5 gigahertz.";
+  }
+
+  identity G_6_25GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 6.25 gigahertz.";
+  }
+
+  identity G_3_125GHZ {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value of 3.125 gigahertz.";
+  }
+
+  identity UNCONSTRAINED {
+      base  ADJUSTMENT_GRANULARITY;
+      description
+        "Adjustment granularity value unconstrained, i.e.,
+        no minimun spacing between channels is defined.";
+  }
+
+
+  identity FEC {
+    description
+      "Forward Error Correction base identity.";
+  }
+
+  identity FEC_HD {
+    base FEC;
+    description
+      "Hard-Decision (HD) Staircase FEC, defined in
+      ITU-T G.709.2 (07/18)";
+  }
+
+  identity FEC_G {
+    base FEC;
+    description
+      "Generic FEC, Reed Solomon (255,239) coding schema,
+      defined in ITU-T G.975 (10/2000).";
+  }
+  identity FEC_E {
+    base FEC;
+    description
+      "Enhanced FEC (EFEC) from G.975.1 Clause I.4.";
+  }
+  identity FEC_O {
+    base FEC;
+    description
+      "OpenROADM 200G Open FEC (oFEC) soft-decision coding
+      schema.";
+  }
+
+  identity FEC_C {
+    base FEC;
+    description
+      "OIF 400G concatenated FEC (cFEC) with soft-decision inner
+       Hamming code and hard-decision outer Staircase code";
+  }
+
+  identity FEC_OTHER {
+    base FEC;
+    description
+      "Placeholder identity to refer to any other propiertary or
+      non-propiertary FEC coding schema non-defined in this model
+      yet.";
+  }
+
+  identity MODULATION_FORMAT {
+    description
+      "Base identity for identiying the optical modulation
+      format associated to the operational mode.";
+  }
+
+  identity MODULATION_FORMAT_BPSK {
+    base MODULATION_FORMAT;
+    description
+      "Binary phase-shift keying (BPSK) modulation format
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DPSK {
+    base MODULATION_FORMAT;
+    description
+      "Differential phase-shift keying (DPSK) modulation format
+      identity";
+  }
+
+  identity MODULATION_FORMAT_QPSK {
+    base MODULATION_FORMAT;
+    description
+      "Quadrature phase-shift keying (QPSK) modulation format
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DP_QPSK {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Polarization Quadrature Phase-Shift Keying (QPSK)
+      modulation format identity";
+  }
+
+  identity MODULATION_FORMAT_8QAM {
+    base MODULATION_FORMAT;
+    description
+      "8-Quadrature Amplitude Modulation (QAM) identity";
+  }
+
+  identity MODULATION_FORMAT_DP_8QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Polarization 8-Quadrature Amplitude Modulation (QAM)
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DC_DP_8QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Carrier Dual-Polarization 8-Quadrature Amplitude
+      Modulation identity";
+  }
+
+  identity MODULATION_FORMAT_16QAM {
+    base MODULATION_FORMAT;
+    description
+      "16-Quadrature Amplitude Modulation (QAM) identity";
+  }
+
+  identity MODULATION_FORMAT_DP_16QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Polarization 16-Quadrature Amplitude Modulation (QAM)
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DC_DP_16QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Carrier Dual-Polarization 16-Quadrature Amplitude Modulation
+      (QAM) identity";
+  }
+
+  identity MODULATION_FORMAT_32QAM {
+    base MODULATION_FORMAT;
+    description
+      "32-Quadrature Amplitude Modulation (QAM) identity";
+  }
+
+  identity MODULATION_FORMAT_DP_32QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Polarization 32-Quadrature Amplitude Modulation (QAM)
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DC_DP_32QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Carrier Dual-Polarization 32-Quadrature Amplitude Modulation
+      (QAM) identity";
+  }  
+
+  identity MODULATION_FORMAT_64QAM {
+    base MODULATION_FORMAT;
+    description
+      "64-Quadrature Amplitude Modulation (QAM) identity";
+  }
+
+  identity MODULATION_FORMAT_DP_64QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Polarization 64-Quadrature Amplitude Modulation (QAM)
+      identity";
+  }
+
+  identity MODULATION_FORMAT_DC_DP_64QAM {
+    base MODULATION_FORMAT;
+    description
+      "Dual-Carrier Dual-Polarization 64-Quadrature Amplitude Modulation
+      (QAM) identity";
+  }  
+
+  identity MODULATION_FORMAT_PAM4 {
+    base MODULATION_FORMAT;
+    description
+      "4-level Pulse Amplitud Modulation (PAM)";
+  }
+
+  identity MODULATION_FORMAT_PAM8 {
+    base MODULATION_FORMAT;
+    description
+      "8-level Pulse Amplitud Modulation (PAM)";
+  }
+  
+  identity MODULATION_FORMAT_PCS {
+    base MODULATION_FORMAT;
+    description
+      "Probabilistic Constellation Shaping.";
+  }
+
+  identity TRANSCEIVER_MODE_TYPE{
+    description
+      "Base identity for identiying the transceiver's mode category:
+      Standard or Explicit. This differentiates on the way operational
+      mode's features are expose by the transceiver device.";
+  }
+
+  identity TRANSCEIVER_MODE_TYPE_STANDARD{
+    base TRANSCEIVER_MODE_TYPE;
+    description
+      "Operational model type Standard, according to ITU-T G.698.2,
+      indicates the mode is interoperable with other transceiver-modules
+      supporting the same Standard mode.";
+  }
+
+  identity TRANSCEIVER_MODE_TYPE_EXPLICIT{
+    base TRANSCEIVER_MODE_TYPE;
+    description
+      "Operational model type Explicit, indicating the description of the
+      operational mode features follows the model subtree explicit
+      features description.";
+  }
+
+
+}


### PR DESCRIPTION
This PR intends to model openconfig terminal device's coherent transmission operational models properties/features, which can enhance current black/opaque visibility of operational-mode's Tx and Rx characteristics which are relevant for network planning and configuration processes.

openconfig-terminal-device-properties.yang provides the list of operational modes supported within the terminal device's which is exposing this manifest file.
 Each operational mode descriptor is defined for single OTSi scope from now. It allows to two types of modes: standard ITU-T g.698.2 defined application identifiers; and explicitly defined modes, characterized by the set of attributes included within the "explicit-mode" container.

Each explicit mode descriptor contains two target set of properties:
 - optical-channel-config-value-constrains, which characterises operational ranges for config values of the optical-channel component associated to the target mode, such central-frequency-range, target-output-power-range.
- operational-mode-capabilities, which characterises the transmission model signal for planning purposes such modulation format, symbol rate, FEC gain, min/max rx input power, min-osnr, pre-fec-ber-threshold, minimum q-value and CD/PMD dispersion tolerances and OSNR penalties, which characterises the maximum physical impairments introduced by the line system which are tolerable for an optical transmission function. This information is typically provided by the transceiver/optical terminal product's datasheet.

This initial commit brings to the public repository the current status of the private pull request at: https://github.com/openconfig/models/pull/998