### PR TITLE
Add utilization leaves for memory blocks in pipeline-counters model

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.3.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-03-16" {
+    description
+      "Add percent utilization leaves for lookup, nexthop, and ACL memories.";
+    reference "0.3.0";
+  }
 
   revision "2022-01-19" {
     description
@@ -504,6 +510,12 @@ module openconfig-platform-pipeline-counters {
         "The amount of memory used in the lookup subsystem.";
     }
 
+    leaf lookup-memory-utilization {
+      type oc-types:percentage;
+      description
+        "Percent utilization of overall lookup memory.";
+    }
+
     leaf nexthop-memory {
       type uint64;
       units bytes;
@@ -516,6 +528,12 @@ module openconfig-platform-pipeline-counters {
       units bytes;
       description
         "The amount of nexthops memory used in the lookup subsystem.";
+    }
+
+    leaf nexthop-memory-utilization {
+      type oc-types:percentage;
+      description
+        "Percent utilization of overall nexthop memory.";
     }
 
     leaf acl-memory-total-entries {
@@ -548,6 +566,12 @@ module openconfig-platform-pipeline-counters {
         The number of used bytes must include the bytes
         that are 'allocated but free' if the memory reaping algorithm makes
         these bytes practically unusable";
+    }
+
+    leaf acl-memory-utilization {
+      type oc-types:percentage;
+      description
+        "Percent utilization of overall firewall or ACL memory.";
     }
 
     leaf fragment-total-pkts {


### PR DESCRIPTION
(M) release/models/platform/openconfig-pipeline-counters.yang
   -Add leaf for each memory attribute to indicate utilization

This proposal seeks to add three new leaves to the OpenConfig pipeline-counters model to represent ASIC memory utilization as relative values.

The primary motivation behind this proposal is that these leaves provide a more vendor and architecture agnostic measurement of memory utilization, and offload the often complex logic of deriving an accurate utilization of memory to the implementor (vendor). Lookup, nexthop, and ACL memories vary greatly across vendors and implementations. Each can be implemented on a variety (and combination) of memory types (e.g., TCAM, SRAM, various types of DRAM) and using a wide variety of search approaches and data structures. For instance, Juniper's express family of ASICs uses several different memories, search algos, and data structures just for ACL/filter programming which makes representing usage in entries or bytes difficult and ultimately low signal.

Several vendor implementations today yield relative values - EOS does so for both ACL and lookup memory (usage/util metrics):
https://eos.arista.com/introduction-to-managing-eos-devices-platform-specific-monitoring-and-troubleshooting/

IOS-XR also vends relative utilization values per lookup table (page 126):
https://www.ciscolive.com/c/dam/r/ciscolive/us/docs/2018/pdf/BRKARC-3000.pdf