### PR TITLE
Replacement of BGP decimal64 types

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description
@@ -131,9 +137,7 @@ submodule openconfig-bgp-common {
       peer";
 
     leaf connect-retry {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       default 30;
       description
         "Time interval in seconds between attempts to establish a
@@ -141,9 +145,7 @@ submodule openconfig-bgp-common {
     }
 
     leaf hold-time {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       default 90;
       description
         "Time interval in seconds that a BGP session will be
@@ -155,9 +157,7 @@ submodule openconfig-bgp-common {
     }
 
     leaf keepalive-interval {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       default 30;
       description
         "Time interval in seconds between transmission of keepalive
@@ -166,9 +166,7 @@ submodule openconfig-bgp-common {
     }
 
     leaf minimum-advertisement-interval {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       default 30;
       description
         "Minimum time which must elapse between subsequent UPDATE
@@ -476,9 +474,7 @@ submodule openconfig-bgp-common {
     }
 
     leaf stale-routes-time {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       description
         "An upper-bound on the time thate stale routes will be
         retained by a router after a session is restarted. If an

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description
@@ -450,9 +456,7 @@ submodule openconfig-bgp-neighbor {
       with the BGP session";
 
     leaf negotiated-hold-time {
-      type decimal64 {
-        fraction-digits 2;
-      }
+      type uint16;
       description
         "The negotiated hold-time for the BGP session";
     }

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -60,7 +60,13 @@ module openconfig-bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "9.0.0";
+
+  revision "2022-03-19" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
 
   revision "2021-12-01" {
     description


### PR DESCRIPTION
* (M) release/models/bgp/openconfig-bgp.yang
* (M) release/models/bgp/openconfig-bgp-common-structure.yang
* (M) release/models/bgp/openconfig-bgp-common.yang
* (M) release/models/bgp/openconfig-bgp-global.yang
* (M) release/models/bgp/openconfig-bgp-neighbor.yang
* (M) release/models/bgp/openconfig-bgp-peer-group.yang
* (M) release/models/bgp/openconfig-bgp-common-multiprotocol.yang
  - Deprecate and migrate decimal64 types for various BGP timers

### Summary

Since the initial versions of the BGP models, various timer types were declared
as 2 fraction-digit `decimal64` types however it has been noted that no known
shipping implementations support decimal/float types for these node values if
configurable whatsoever.  In addition, the `decimal64` type is a signed type
and negative values are not permitted for these timers.

This has resulted in implementations to either:

* Deviate the leaf as `not-supported`
* Deviate the leaf to change the type
* Support the leaf as-is but implement translation logic to drop the digits and
  thus precision as well as enforce backend validation at their discretion

This addresses the long-standing issue previously raised at:
https://github.com/openconfig/public/issues/348

Each leaf in this change set is either currently not supported by an
implementation or mismatched and noted.  The replaced datatypes chosen are all
of type `uint16` corresponding to the valid ranges per implementation which is
likely to correspond directly to the underlying type.  Note that since this is
a type change, this is backwards incompatible and thus a major revision is
incremented.

### `connect-retry`

References:

* Arista EOS: https://github.com/aristanetworks/yang/blob/master/EOS-4.27.2F/release/openconfig/models/bgp/arista-bgp-deviations.yang#L206-L216
* Cisco IOS-XR: https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/751/cisco-xr-openconfig-network-instance-deviations.yang#L1378

### `hold-time`

References:

* Juniper JUNOS: https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/statement/hold-time-edit-protocols-bgp.html
* Arista EOS: https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1118565
* Cisco IOS-XR: https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r3-9/routing/command/reference/rr39crs1book_chapter1.html#wp959794130

### `keepalive-interval`

References:

* Arista EOS: https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1118565
* Cisco IOS-XR: https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r3-9/routing/command/reference/rr39crs1book_chapter1.html#wp959794130

### `minimum-advertisement-interval`

References:

* Juniper JUNOS: https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/statement/out-delay-edit-protocols-bgp.html
* Cisco IOS-XR: https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/command/reference/rr40xr12kbook_chapter1.html#wp2027236550
* Arista EOS: https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1123712

### `negotiated-hold-time`

Same references as `hold-time`

### `stale-routes-time`

References:

* Juniper JUNOS: https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/statement/stale-routes-time-edit-protocols-bgp.html
* Cisco IOS-XR: https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r3-9/routing/command/reference/rr39crs1book_chapter1.html#wp1302250876
* Arista EOS: https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1116676
