### PR TITLE
Update WiFi models to support 6 GHz operation.

### DIFF
--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -104,7 +104,7 @@ module openconfig-ap-manager {
             "Standard Power 6 GHz Access Point that can operate outdoors.";
         }
       }
-      default "INDOOR-AP";
+      default "INDOOR_AP";
       description
         "The type of 6 GHz AP deployment.";
       }

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -27,6 +27,12 @@ module openconfig-ap-manager {
 
   oc-ext:openconfig-version "1.0.0";
 
+  revision "2023-03-24" {
+    description
+      "Update model to support operation in 6 GHz frequency.";
+    reference "1.1.0";
+  }
+
   revision "2021-08-02" {
     description
       "Update model version as it is in production.";
@@ -86,6 +92,22 @@ module openconfig-ap-manager {
         "Country code where the AP operates in ISO 3166-1 alpha-2
         format.";
     }
+
+    leaf deployment-type-6ghz {
+      type enumeration {
+        enum INDOOR-AP {
+          description
+            "Indoor 6 GHz Access Point.";
+        }
+        enum STANDARD-AP {
+          description
+            "Standard Power 6 GHz Access Point that can operate outdoors.";
+        }
+      }
+      default "INDOOR-AP";
+      description
+        "The type of 6 GHz AP deployment.";
+      }
   }
 
   grouping controller-aps-system-state {
@@ -165,6 +187,9 @@ module openconfig-ap-manager {
       }
       enum AF {
         description "Powered using 802.3af.";
+      }
+      enum BT {
+        description "Powered using 802.3bt.";
       }
       enum PLUG {
         description "Powered using local source, not PoE.";

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -25,7 +25,7 @@ module openconfig-ap-manager {
     "This module defines the top level configuration and state data for a
     system which manages Access Points.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2023-03-24" {
     description
@@ -95,11 +95,11 @@ module openconfig-ap-manager {
 
     leaf deployment-type-6ghz {
       type enumeration {
-        enum INDOOR-AP {
+        enum INDOOR_AP {
           description
             "Indoor 6 GHz Access Point.";
         }
-        enum STANDARD-AP {
+        enum STANDARD_AP {
           description
             "Standard Power 6 GHz Access Point that can operate outdoors.";
         }

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -188,8 +188,11 @@ module openconfig-ap-manager {
       enum AF {
         description "Powered using 802.3af.";
       }
-      enum BT {
-        description "Powered using 802.3bt.";
+      enum BT_TYPE3 {
+        description "Powered using 802.3bt Type 3.";
+      }
+      enum BT_TYPE4 {
+        description "Powered using 802.3bt Type 4.";
       }
       enum PLUG {
         description "Powered using local source, not PoE.";

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -92,22 +92,6 @@ module openconfig-ap-manager {
         "Country code where the AP operates in ISO 3166-1 alpha-2
         format.";
     }
-
-    leaf deployment-type-6ghz {
-      type enumeration {
-        enum INDOOR_AP {
-          description
-            "Indoor 6 GHz Access Point.";
-        }
-        enum STANDARD_AP {
-          description
-            "Standard Power 6 GHz Access Point that can operate outdoors.";
-        }
-      }
-      default "INDOOR_AP";
-      description
-        "The type of 6 GHz AP deployment.";
-      }
   }
 
   grouping controller-aps-system-state {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -123,7 +123,7 @@ module openconfig-wifi-mac {
       default "oc-wifi-types:FREQ_2_5_GHZ";
       description
         "Operating frequency of this SSID. When none specified, the
-        default is dual-band.";
+        default is dual-band 2.4 and 5 GHz.";
     }
 
     leaf-list basic-data-rates-2g {
@@ -239,7 +239,13 @@ module openconfig-wifi-mac {
         }
         enum WPA3_ENTERPRISE {
           description
-            "WPA3-Enterprise with 802.1X authentication.";
+            "WPA3-Enterprise with 802.1X SHA-256 authentication key
+             management.";
+        }
+        enum WPA3_ENTERPRISE_192_BIT {
+          description
+            "WPA3-Enterprise with 802.1X SHA-384 authentication key
+             management.";
         }
       }
       description
@@ -255,12 +261,22 @@ module openconfig-wifi-mac {
       }
       description
         "The passphrase used on this WPA2-Personal SSID.";
-     }
+    }
+
+    leaf wpa3-psk {
+      when "../opmode = 'WPA3_SAE'";
+      type string {
+        length "8..63";
+      }
+      description
+        "The passphrase used on this WPA3-SAE SSID.";
+    }
 
     leaf server-group {
       when "../opmode = 'WPA2_ENTERPRISE' or
       ../opmode = 'WPA2_PERSONAL' or
       ../opmode = 'WPA3_ENTERPRISE' or
+      ../opmode = 'WPA3_ENTERPRISE_192_BIT' or
       ../opmode = 'WPA3_SAE'";
       type string;
         description
@@ -332,6 +348,7 @@ module openconfig-wifi-mac {
 
     leaf mfp {
       when "../opmode = 'WPA3_ENTERPRISE' or ../opmode =
+      'WPA3_ENTERPRISE_192_BIT' or ../opmode =
       'WPA3_SAE' or ../opmode = 'ENHANCED_OPEN'";
       type boolean;
       mandatory true;
@@ -1373,8 +1390,7 @@ module openconfig-wifi-mac {
       leaf frequency {
         type uint8;
         description
-          "Frequency the client is utilizing. Typically, 2.4 or
-          5[GHz].";
+          "Frequency the client is utilizing. Typically, 2.4, 5 or 6 [GHz].";
       }
     }
   }

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -28,6 +28,12 @@ module openconfig-wifi-mac {
 
   oc-ext:openconfig-version "1.0.0";
 
+  revision "2022-03-24" {
+    description
+      "Update model to support operation in 6 GHz frequency.";
+    reference "1.1.0";
+  }
+
   revision "2021-08-02" {
     description
       "Update tx/rx MCS rates, add AX as client connection mode.";
@@ -151,6 +157,21 @@ module openconfig-wifi-mac {
       description
         "5GHz Supported data-rates for the SSID.";
     }
+    leaf-list basic-data-rates-6g {
+      type identityref {
+        base oc-wifi-types:DATA_RATE;
+      }
+      description
+        "6GHz Basic data-rates for the SSID.";
+    }
+
+    leaf-list supported-data-rates-6g {
+      type identityref {
+        base oc-wifi-types:DATA_RATE;
+      }
+      description
+        "6GHz Supported data-rates for the SSID.";
+    }
     // MCS rates explicitly absent, as they are typically not pruned.
 
     leaf broadcast-filter {
@@ -208,8 +229,19 @@ module openconfig-wifi-mac {
           description
             "WPA2-Enterprise with 802.1X authentication.";
         }
+        enum ENHANCED-OPEN {
+          description
+            "Open authentication with Opportunistic Wireless Encryption.";
+        }
+        enum WPA3_SAE {
+          description
+            "WPA3-SAE using Simultaneous Authentication of Equals (SAE).";
+        }
+        enum WPA3_ENTERPRISE {
+          description
+            "WPA3-Enterprise with 802.1X authentication.";
+        }
       }
-      default "OPEN";
       description
         "The type of Layer2 authentication in use.";
     }
@@ -226,14 +258,17 @@ module openconfig-wifi-mac {
      }
 
     leaf server-group {
-      when "../opmode = 'WPA2_ENTERPRISE' or ../opmode =
-      'WPA2_PERSONAL'";
+      when "../opmode = 'WPA2_ENTERPRISE' or
+      ../opmode = 'WPA2_PERSONAL' or
+      ../opmode = 'WPA3_ENTERPRISE' or
+      ../opmode = 'WPA3_SAE'";
       type string;
         description
           "Specifies the RADIUS server-group to be used,
           as defined in the openconfig-aaa.yang model.
 
-          Including WPA2_PERSONAL as it can be accompained by MAB.";
+          Including WPA2_PERSONAL and WPA3_SAE as they can be accompanied by
+          MAB.";
     }
 
     leaf dva {
@@ -293,6 +328,15 @@ module openconfig-wifi-mac {
       type boolean;
       description
         "Enable/disable Opportunistic Key Caching.";
+    }
+
+    leaf mfp {
+      when "../opmode = 'WPA3_ENTERPRISE' or ../opmode =
+      'WPA3_SAE' or ../opmode = 'ENHANCED_OPEN'";
+      type boolean;
+      mandatory true;
+      description
+        "Management Frame Protection is required for WPA3 and OWE.";
     }
   }
 

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description
@@ -229,7 +229,7 @@ module openconfig-wifi-mac {
           description
             "WPA2-Enterprise with 802.1X authentication.";
         }
-        enum ENHANCED-OPEN {
+        enum ENHANCED_OPEN {
           description
             "Open authentication with Opportunistic Wireless Encryption.";
         }

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -290,13 +290,6 @@ module openconfig-wifi-phy {
         restrictions.";
     }
 
-    leaf-list supported-channels-6ghz {
-      type oc-wifi-types:channels-type-6ghz;
-      description
-        "6 GHz channels allowed by a combination of regulatory and AP
-         certification restrictions.";
-    }
-
     leaf channel-change-reason {
       type identityref {
         base oc-wifi-types:CHANGE_REASON_TYPE;

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -434,6 +434,24 @@ module openconfig-wifi-phy {
           description
             "Any flavor of WEP encryption.";
         }
+        enum ENHANCED_OPEN {
+          description
+            "Open authentication with Opportunistic Wireless Encryption.";
+        }
+        enum WPA3_SAE {
+          description
+            "WPA3-SAE using Simultaneous Authentication of Equals (SAE).";
+        }
+        enum WPA3_ENTERPRISE {
+          description
+            "WPA3-Enterprise with 802.1X SHA-256 authentication key
+             management.";
+        }
+        enum WPA3_ENTERPRISE_192_BIT {
+          description
+            "WPA3-Enterprise with 802.1X SHA-384 authentication key
+             management.";
+        }
       }
       description
         "Operating mode of the BSS.";

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -25,7 +25,7 @@ module openconfig-wifi-phy {
   description
     "Model for managing PHY layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -27,6 +27,12 @@ module openconfig-wifi-phy {
 
   oc-ext:openconfig-version "1.0.0";
 
+  revision "2022-03-24" {
+    description
+      "Update model to support operation in 6 GHz frequency.";
+    reference "1.1.0";
+  }
+
   revision "2021-08-02" {
     description
       "Add BSS color to radio config and neighbor table.";
@@ -122,7 +128,7 @@ module openconfig-wifi-phy {
 
     leaf channel {
       type uint8 {
-        range "1..165";
+        range "1..233";
         }
       description
         "Operating channel of this radio. If using channel-bonding
@@ -282,6 +288,13 @@ module openconfig-wifi-phy {
       description
         "Channels allowed by a combination of regulatory and AP certification
         restrictions.";
+    }
+
+    leaf-list supported-channels-6ghz {
+      type oc-wifi-types:channels-type-6ghz;
+      description
+        "6 GHz channels allowed by a combination of regulatory and AP
+         certification restrictions.";
     }
 
     leaf channel-change-reason {

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -247,11 +247,7 @@ module openconfig-wifi-types {
     base OPERATING_FREQUENCY;
     description
       "The Radio or SSID will be dual-band; operating in
-      both 2.4 & 5GHz frequencies.
-
-      Dual-band Radio typically refers to a Monitor-mode radio, hopping
-      between frequencies, dwelling for a configurable amount of time on
-      each frequency.";
+      both 2.4 & 5GHz frequencies.";
   }
 
   identity FREQ_6GHZ {
@@ -262,17 +258,13 @@ module openconfig-wifi-types {
   identity FREQ_5_6_GHZ {
     base OPERATING_FREQUENCY;
     description "The Radio or SSID will be dual-band; operating in both 5 &
-    6GHz frequencies. Dual-band Radio typically refers to a Monitor-mode
-    radio, hopping between frequencies, dwelling for a configurable amount of
-    time on each frequency.";
+    6GHz frequencies.";
   }
 
   identity FREQ_2_5_6_GHZ {
     base OPERATING_FREQUENCY;
     description "The Radio or SSID will be tri-band; operating in 2.4, 5 and
-    6GHz frequencies. Tri-band Radio typically refers to a Monitor-mode radio,
-    hopping between frequencies, dwelling for a configurable amount of time on
-    each frequency.";
+    6GHz frequencies.";
   }
 
   identity CLIENT_CAPABILITIES {

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -22,7 +22,7 @@ module openconfig-wifi-types {
     that are used in the openconfig-wifi modules. It can be
     imported by any module to make use of these types.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -57,22 +57,12 @@ module openconfig-wifi-types {
   //typdef statements
   typedef channels-type {
     type uint8 {
-      range "1..14 | 36 | 40 | 44| 48 | 52 | 56 | 60 | 64 | 100 | 104 | 108 | 112 | 116 | 120 | 124 | 128 | 132 | 136 | 140 | 144 | 149 | 153 | 157 | 161 | 165";
+      range "1..14 | 17 | 21 | 25 | 29 | 33 | 36 | 37 | 40 | 41 | 44 | 45 | 48 | 49 | 52 | 53 | 56 | 57 | 60 | 61 | 64 | 65 | 69 | 73 | 77 | 81 | 85 | 89 | 93 | 97 | 100 | 101 | 104 | 105 | 108 | 109 | 112 | 113 | 116 | 117 | 120 | 121 | 124 | 125 | 128 | 129 | 132 | 133 | 136 | 137 | 140 | 141 | 144 | 145 | 149 | 153 | 157 | 161 | 165 | 169 | 173 | 177 | 181 | 185 | 189 | 193 | 197 | 201 | 205 | 209 | 213 | 217 | 221 | 225 | 229 | 233";
     }
     description
       "Type to specify all the WiFi channels available for use. This is
       a superset of what may be allowed by any one particular regulatory
       domain.";
-  }
-
-  typedef channels-type-6ghz {
-    type uint8 {
-      range "1 | 5 | 9 | 13 | 17 | 21 | 25 | 29 | 33 | 37 | 41 | 45 | 49 | 53 | 57 | 61 | 65 | 69 | 73 | 77 | 81 | 85 | 89 | 93 | 97 | 101 | 105 | 109 | 113 | 117 | 121 | 125 | 129 | 133 | 137 | 141 | 145 | 149 | 153 | 157 | 161 | 165 | 169 | 173 | 177 | 181 | 185 | 189 | 193 | 197 | 201 | 205 | 209 | 213 | 217 | 221 | 225 | 229 | 233";
-    }
-    description
-      "Type to specify all the 6 GHz channels available for use. This is a
-       superset of what may be allowed by any one particular regulatory
-       domain.";
   }
 
   // identity statements

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -259,7 +259,7 @@ module openconfig-wifi-types {
     description "The Radio or SSID will operate at 6GHz only.";
   }
 
-  identity FREQ_5_6GHZ {
+  identity FREQ_5_6_GHZ {
     base OPERATING_FREQUENCY;
     description "The Radio or SSID will be dual-band; operating in both 5 &
     6GHz frequencies. Dual-band Radio typically refers to a Monitor-mode
@@ -267,7 +267,7 @@ module openconfig-wifi-types {
     time on each frequency.";
   }
 
-  identity FREQ_2_5_6GHZ {
+  identity FREQ_2_5_6_GHZ {
     base OPERATING_FREQUENCY;
     description "The Radio or SSID will be tri-band; operating in 2.4, 5 and
     6GHz frequencies. Tri-band Radio typically refers to a Monitor-mode radio,

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -24,6 +24,12 @@ module openconfig-wifi-types {
 
   oc-ext:openconfig-version "1.0.0";
 
+  revision "2022-03-24" {
+    description
+      "Update model to support operation in 6 GHz frequency.";
+    reference "1.1.0";
+  }
+
   revision "2021-08-02" {
     description
       "Add OFDMA in client capabilities.";
@@ -57,6 +63,16 @@ module openconfig-wifi-types {
       "Type to specify all the WiFi channels available for use. This is
       a superset of what may be allowed by any one particular regulatory
       domain.";
+  }
+
+  typedef channels-type-6ghz {
+    type uint8 {
+      range "1 | 5 | 9 | 13 | 17 | 21 | 25 | 29 | 33 | 37 | 41 | 45 | 49 | 53 | 57 | 61 | 65 | 69 | 73 | 77 | 81 | 85 | 89 | 93 | 97 | 101 | 105 | 109 | 113 | 117 | 121 | 125 | 129 | 133 | 137 | 141 | 145 | 149 | 153 | 157 | 161 | 165 | 169 | 173 | 177 | 181 | 185 | 189 | 193 | 197 | 201 | 205 | 209 | 213 | 217 | 221 | 225 | 229 | 233";
+    }
+    description
+      "Type to specify all the 6 GHz channels available for use. This is a
+       superset of what may be allowed by any one particular regulatory
+       domain.";
   }
 
   // identity statements
@@ -248,6 +264,27 @@ module openconfig-wifi-types {
       each frequency.";
   }
 
+  identity FREQ_6GHZ {
+    base OPERATING_FREQUENCY;
+    description "The Radio or SSID will operate at 6GHz only.";
+  }
+
+  identity FREQ_5_6GHZ {
+    base OPERATING_FREQUENCY;
+    description "The Radio or SSID will be dual-band; operating in both 5 &
+    6GHz frequencies. Dual-band Radio typically refers to a Monitor-mode
+    radio, hopping between frequencies, dwelling for a configurable amount of
+    time on each frequency.";
+  }
+
+  identity FREQ_2_5_6GHZ {
+    base OPERATING_FREQUENCY;
+    description "The Radio or SSID will be tri-band; operating in 2.4, 5 and
+    6GHz frequencies. Tri-band Radio typically refers to a Monitor-mode radio,
+    hopping between frequencies, dwelling for a configurable amount of time on
+    each frequency.";
+  }
+
   identity CLIENT_CAPABILITIES {
     description
       "Client capabilities, as reported by Assoc. Req. or
@@ -282,6 +319,11 @@ module openconfig-wifi-types {
       "Whether this STA supports 802.11v BSS Transition. Note, must
       be enabled on BSS for this to be accurate; unless Probe Req.
       are observied in addition to Assoc. Req.";
+  }
+
+  identity MFP {
+    base CLIENT_CAPABILITIES;
+    description "Whether this STA can use Management Frame Protection.";
   }
 
   identity CHANGE_REASON_TYPE {


### PR DESCRIPTION
    * (M) release/models/wifi/openconfig-ap-manager.yang
      - Added deployment types and power sources.
    * (M) release/models/wifi/openconfig-wifi-mac.yang
      - Added ssid basic/supported data rates, opmode
      - Changed server-group requirements for new opmodes
      - Added mfp support
    * (M) release/models/wifi/openconfig-wifi-phy.yang
      - Added new channels and neighbor-list-state opmodes.
    * (M) release/models/wifi/openconfig-wifi-types
      - Added new channels, operating frequencies and operating capabilities.