### PR TITLE
Prefix qualification for AFT absolute paths

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -10,6 +10,7 @@ submodule openconfig-aft-common {
   import openconfig-mpls-types { prefix "oc-mplst"; }
   import openconfig-policy-types { prefix "oc-pol-types"; }
   import openconfig-aft-types { prefix "oc-aftt"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   organization
     "OpenConfig working group";
@@ -22,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description
@@ -186,8 +193,9 @@ submodule openconfig-aft-common {
     // made to it.
     leaf next-hop-group {
       type leafref {
-        path "/network-instances/network-instance/afts/" +
-              "next-hop-groups/next-hop-group/state/id";
+        path "/oc-ni:network-instances/oc-ni:network-instance/" +
+             "oc-ni:afts/oc-ni:next-hop-groups/oc-ni:next-hop-group/" +
+             "oc-ni:state/oc-ni:id";
       }
       description
         "A reference to the next-hop-group that is in use for the entry
@@ -196,9 +204,7 @@ submodule openconfig-aft-common {
     }
 
     leaf next-hop-group-network-instance {
-      type leafref {
-        path "/network-instances/network-instance/config/name";
-      }
+      type oc-ni:network-instance-ref;
       description
         "The network instance to look up the next-hop-group in.  If
          unspecified, the next hop group is in the local network

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-03-29" {
+    description
+      "Fix leafref qualification for absolute paths";
+    reference "0.10.0";
+  }
 
   revision "2021-12-09" {
     description


### PR DESCRIPTION
  * (M) release/models/aft/openconfig-aft-common.yang
  * (M) release/models/aft/openconfig-aft-ethernet.yang
  * (M) release/models/aft/openconfig-aft-ipv4.yang
  * (M) release/models/aft/openconfig-aft-ipv6.yang
  * (M) release/models/aft/openconfig-aft-mpls.yang
  * (M) release/models/aft/openconfig-aft-pf.yang
  * (M) release/models/aft/openconfig-aft.yang
    - Add prefixes to next-hop-group leafref
    - Use common typedef for next-hop-group-network-instance

Similar issues to:
* https://github.com/openconfig/public/pull/598
* https://github.com/openconfig/public/pull/557

Absolute paths to alternate schema locations must be qualified
