### PR TITLE
Prefix qualification for AFT network-instance absolute paths

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -22,7 +22,15 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description
@@ -178,33 +186,6 @@ submodule openconfig-aft-common {
       description
         "The number of octets which have matched, and been forwarded,
          based on the AFT entry";
-    }
-
-    // This leafref needs to refer to any network-instance on the system
-    // hence must be absolute. This change means that this module cannot
-    // be used outside of the network instance model without changes being
-    // made to it.
-    leaf next-hop-group {
-      type leafref {
-        path "/network-instances/network-instance/afts/" +
-              "next-hop-groups/next-hop-group/state/id";
-      }
-      description
-        "A reference to the next-hop-group that is in use for the entry
-        within the AFT. Traffic is distributed across the set of next-hops
-        within the next-hop group according to the weight.";
-    }
-
-    leaf next-hop-group-network-instance {
-      type leafref {
-        path "/network-instances/network-instance/config/name";
-      }
-      description
-        "The network instance to look up the next-hop-group in.  If
-         unspecified, the next hop group is in the local network
-         instance.  The referenced network-instance must be an existing
-         network instance on the device and have corresponding entries
-         in the /network-instances/network-instance list.";
     }
 
     leaf entry-metadata {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,15 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft-network-instance.yang
+++ b/release/models/aft/openconfig-aft-network-instance.yang
@@ -19,7 +19,15 @@ module openconfig-aft-network-instance {
      when building the OpenConfig network instance model to
      add per-NI AFTs.";
 
-  oc-ext:openconfig-version "0.2.3";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "0.3.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -44,17 +52,6 @@ module openconfig-aft-network-instance {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
-          "oc-ni:afts/oc-ni:next-hops/oc-ni:next-hop/oc-ni:state" {
-
-    description
-      "Add leaves that require referencing of a network instance to the
-      operational state parameters of a next-hop within the AFT for IPv4
-      unicast.";
-
-    uses aft-nexthop-ni-state;
-  }
-
   grouping aft-nexthop-ni-state {
     description
       "Operational state parameters relating to a next-hop which reference a
@@ -67,24 +64,6 @@ module openconfig-aft-network-instance {
          When this leaf is unspecified, the next-hop is resolved within
          the local instance.";
     }
-  }
-
-  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
-          "oc-ni:afts/oc-ni:ipv4-unicast/oc-ni:ipv4-entry/oc-ni:state" {
-    description
-      "Add leaves that require referencing of a network instance to the
-      operational state parameters of an entry within the IPv4 unicast AFT.";
-
-    uses aft-entry-ni-state;
-  }
-
-  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
-          "oc-ni:afts/oc-ni:ipv6-unicast/oc-ni:ipv6-entry/oc-ni:state" {
-    description
-      "Add leaves that require referencing of a network instance to the
-      operational state parameters of an entry within the IPv6 unicast AFT.";
-
-    uses aft-entry-ni-state;
   }
 
   grouping aft-entry-ni-state {
@@ -105,5 +84,93 @@ module openconfig-aft-network-instance {
         in the DEFAULT_INSTANCE, then this value would reflect the
         DEFAULT_INSTANCE as the origin-network-instance.";
     }
+  }
+
+  grouping aft-entry-nexthop-group-state {
+    description
+      "Operational state nexthop group parameters relating to an AFT entry
+      which reference a network instance.";
+
+    leaf next-hop-group {
+      type leafref {
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/" +
+             "oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:state/oc-ni:id";
+      }
+      description
+        "A reference to the next-hop-group that is in use for the entry within
+        the AFT. Traffic is distributed across the set of next-hops within the
+        next-hop group according to the weight. This node needs to refer to any
+        network-instance on the system hence must be absolute.";
+    }
+
+    leaf next-hop-group-network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance to look up the next-hop-group in. If unspecified,
+        the next hop group is in the local network instance. The referenced
+        network-instance must be an existing network instance on the device and
+        have corresponding entries in the /network-instances/network-instance
+        list.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:next-hops/oc-ni:next-hop/oc-ni:state" {
+
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of a next-hop within the AFT for IPv4
+      unicast.";
+
+    uses aft-nexthop-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv4-unicast/oc-ni:ipv4-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv4 unicast AFT.";
+
+    uses aft-entry-nexthop-group-state;
+    uses aft-entry-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv6-unicast/oc-ni:ipv6-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv6 unicast AFT.";
+
+    uses aft-entry-nexthop-group-state;
+    uses aft-entry-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:policy-forwarding/oc-ni:policy-forwarding-entry/" +
+          "oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the Policy Forwarding
+      AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:mpls/oc-ni:label-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the MPLS AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ethernet/oc-ni:mac-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the Ethernet AFT.";
+
+    uses aft-entry-nexthop-group-state;
   }
 }

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,15 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,15 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "1.0.0";
+  }
 
   revision "2021-12-09" {
     description


### PR DESCRIPTION
* (M) release/models/aft/openconfig-aft-common.yang
* (M) release/models/aft/openconfig-aft-ethernet.yang
* (M) release/models/aft/openconfig-aft-ipv4.yang
* (M) release/models/aft/openconfig-aft-ipv6.yang
* (M) release/models/aft/openconfig-aft-mpls.yang
* (M) release/models/aft/openconfig-aft-pf.yang
* (M) release/models/aft/openconfig-aft.yang
* (M) release/models/aft/openconfig-aft-network-instance.yang
  - Relocate network-instance specific next-hop-group leafs to the AFT
    network-instance model
  - Fix prefixing for network-instance specific leafrefs

Adjustment to previous https://github.com/openconfig/public/pull/610

And addressing similar issues as found in:
* https://github.com/openconfig/public/pull/598
* https://github.com/openconfig/public/pull/557

This involves relocating next-hop-group leafs that have absolute paths to
network-instances to the AFT network-instance model to prevent circular
dependencies and segment network-instance specifics to its own module.
