### PR TITLE
Introduce LINECARD_MODULE identity for hardware component type

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -308,9 +308,10 @@ module openconfig-platform-types {
   identity LINECARD_MODULE {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
-      "A modular adapter, typically inserted into a linecard
-      component that serves the purpose of housing physical ports
-      or services";
+      "A modular adapter, inserted into a linecard component that serves
+      the purpose of housing physical ports or services.  A component of
+      this type MUST be a subcomponent (child) of a component of type
+      'LINECARD'.";
   }
 
   identity CONTROLLER_CARD {

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.5.0";
+
+  revision "2022-03-30" {
+    description
+      "Add identity for MODULE hardware component";
+    reference "1.5.0";
+  }
 
   revision "2022-03-27" {
     description
@@ -297,6 +303,14 @@ module openconfig-platform-types {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
       "Linecard component, typically inserted into a chassis slot";
+  }
+
+  identity MODULE {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "A modular adapter, typically inserted into a linecard
+      component that serves the purpose of housing physical ports
+      or services";
   }
 
   identity CONTROLLER_CARD {

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -24,9 +24,9 @@ module openconfig-platform-types {
 
   oc-ext:openconfig-version "1.5.0";
 
-  revision "2022-03-30" {
+  revision "2022-04-22" {
     description
-      "Add identity for MODULE hardware component";
+      "Add identity for LINECARD_MODULE hardware component";
     reference "1.5.0";
   }
 
@@ -305,7 +305,7 @@ module openconfig-platform-types {
       "Linecard component, typically inserted into a chassis slot";
   }
 
-  identity MODULE {
+  identity LINECARD_MODULE {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
       "A modular adapter, typically inserted into a linecard


### PR DESCRIPTION
* (M) release/models/platform/openconfig-platform-types.yang
  - Add LINECARD_MODULE identity as valid hardware component type

This proposal adds the `LINECARD_MODULE ` hardware component type to represent modular
interface and services modules generally used as a child of `LINECARD` and
parent of `PORT` or `ASIC`

References:
* https://www.cisco.com/c/en/us/products/interfaces-modules/index.html
* https://infocenter.nokia.com/public/7750SR140R4/index.jsp?topic=%2Fcom.sr.interface%2Fhtml%2Finterfaces.html
* https://www.juniper.net/documentation/en_US/release-independent/junos/topics/concept/pic-overview-nog.html
