### PR TITLE
Add counter collection into pipeline counters

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,14 +65,20 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.3.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-04-13" {
+    description
+      "Add generic pipeline counters per block";
+    reference "0.3.0";
+  }
 
   revision "2022-01-19" {
     description
       "Fixed typo for aggregate field.";
-    reference "0.2.1";
+    reference "0.3.0";
   }
 
   revision "2021-10-16" {
@@ -116,6 +122,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-counters-packet-interface-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container lookup-block {
@@ -130,6 +138,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-counters-packet-lookup-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container queueing-block {
@@ -144,6 +154,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-counters-packet-queueing-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container fabric-block {
@@ -158,6 +170,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-counters-packet-fabric-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container host-interface-block {
@@ -172,6 +186,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-counters-packet-host-interface-block-state;
           }
+
+          uses pipeline-counters-common;
         }
       }
 
@@ -193,6 +209,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-drop-packet-interface-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container lookup-block {
@@ -206,6 +224,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-drop-packet-lookup-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container queueing-block {
@@ -220,6 +240,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-drop-packet-queueing-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container fabric-block {
@@ -233,6 +255,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-drop-packet-fabric-block-state;
           }
+
+          uses pipeline-counters-common;
         }
 
         container host-interface-block {
@@ -247,6 +271,8 @@ module openconfig-platform-pipeline-counters {
 
             uses pipeline-drop-packet-host-interface-block-state;
           }
+
+          uses pipeline-counters-common;
         }
       }
 
@@ -392,6 +418,49 @@ module openconfig-platform-pipeline-counters {
               uses pipeline-errors-packet-host-interface-block-state;
             }
           }
+        }
+      }
+    }
+  }
+
+  grouping pipeline-counter {
+    leaf name {
+      type string;
+      description
+        "Name of the counter in the NPU.";
+    }
+    leaf count {
+      type oc-yang:counter64;
+      description
+        "Total counts of this type.";
+    }
+  }
+
+  grouping pipeline-counters-common {
+    description
+      "A common set of packet counters that apply to multiple sections.";
+    container counters {
+      description
+        "The container for a common set of packet counters.";
+
+      list counter {
+        key "name";
+        description
+          "An individual counter within the NPU sub-block. Each counter is
+        uniquely identified by the name of the counter.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the name of the counter being described.";
+        }
+
+        container state {
+          description
+            "Counter corresponding to the NPU sub-block of the IC";
+          uses pipeline-counter;
         }
       }
     }

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -424,6 +424,8 @@ module openconfig-platform-pipeline-counters {
   }
 
   grouping pipeline-counter {
+    description
+      "A common set of counters that apply to multiple NPU blocks.";
     leaf name {
       type string;
       description
@@ -447,7 +449,7 @@ module openconfig-platform-pipeline-counters {
         key "name";
         description
           "An individual counter within the NPU sub-block. Each counter is
-        uniquely identified by the name of the counter.";
+          uniquely identified by the name of the counter.";
 
         leaf name {
           type leafref {
@@ -459,7 +461,7 @@ module openconfig-platform-pipeline-counters {
 
         container state {
           description
-            "Counter corresponding to the NPU sub-block of the IC";
+            "Counter corresponding to the NPU sub-block of the IC.";
           uses pipeline-counter;
         }
       }


### PR DESCRIPTION
(M) release/models/platform/openconfig-pipeline-counters.yang
- Add list of counters keyed by name for each block of packet and drop containers

This proposal is to add a collection of counters into the pipeline-counter module for each IC subsystem block.

The motivation of this proposal is to provide flexibility in publishing platform specific counters that do not fit into existing counters defined within `pipeline-counters`. Every vendor may have multiple platforms with different and unique implementations. Providing a place to put counters that do not fit currently defined leafs will allow for more information and better real time analysis of the devices.

Example of one block:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--ro oc-ppc:pipeline-counters
              +--ro oc-ppc:packet
                 +--ro oc-ppc:interface-block
                    +--ro oc-ppc:counters
                       +--ro oc-ppc:counter* [name]
                          +--ro oc-ppc:name     -> ../state/name
                          +--ro oc-ppc:state
                             +--ro oc-ppc:name?    string
                             +--ro oc-ppc:count?   oc-yang:counter64
```