### PR TITLE
Clean up unused imports

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -10,7 +10,6 @@ module openconfig-if-ethernet {
   // import some basic types
   import openconfig-interfaces { prefix oc-if; }
   import iana-if-type { prefix ianaift; }
-  import openconfig-platform-types { prefix oc-platform-types; }
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-extensions { prefix oc-ext; }
 
@@ -25,7 +24,13 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.12.1";
+  oc-ext:openconfig-version "2.12.2";
+
+  revision "2022-04-20" {
+    description
+      "Remove unused import";
+    reference "2.12.2";
+  }
 
   revision "2021-07-20" {
     description

--- a/release/models/platform/openconfig-platform-integrated-circuit.yang
+++ b/release/models/platform/openconfig-platform-integrated-circuit.yang
@@ -7,7 +7,6 @@ module openconfig-platform-integrated-circuit {
 
   import openconfig-platform { prefix oc-platform; }
   import openconfig-extensions { prefix oc-ext; }
-  import openconfig-types { prefix oc-types; }
 
   organization "OpenConfig working group";
   contact
@@ -20,7 +19,13 @@ module openconfig-platform-integrated-circuit {
     These components are generically forwarding NPUs or ASICs within
     the system for which configuration or state is applicable.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2022-04-20" {
+    description
+      "Remove unused import";
+    reference "0.3.1";
+  }
 
   revision "2021-08-09" {
     description


### PR DESCRIPTION
  * (M) release/models/interfaces/openconfig-if-ethernet.yang
  * (M) release/models/platform/openconfig-platform-integrated-circuit.yang
    - Remove unused imports

As the title suggests, patch versions incremented for non-affecting schema change removal of unused imports
