### PR TITLE
Add resouce utilization to components

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -1,0 +1,152 @@
+submodule openconfig-platform-common {
+
+  yang-version "1";
+
+  belongs-to openconfig-platform {
+    prefix "oc-platform";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This modules contains common groupings that are used in multiple
+    components within the platform module.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-04-15" {
+    description
+      "Initial revision with platform utilization.";
+    reference "0.1.0";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping platform-utilization-top {
+    description
+      "Top level of utilization.";
+
+    container utilization {
+      description
+        "Utilization of the component.";
+
+      container resources {
+        description
+          "Enclosing container for the resources in this component.";
+
+        list resource {
+          key "name";
+          description
+            "List of resources, keyed by resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container config {
+            description
+              "Configuration data for each resource.";
+
+            uses platform-utilization-resource-config;
+          }
+
+          container state {
+            description
+              "Operational state data for each resource.";
+
+            uses platform-utilization-resource-config;
+            uses platform-utilization-resource-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping platform-utilization-resource-config {
+    description
+      "Configuration data for utilization resource.";
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the component.";
+    }
+  }
+
+  grouping platform-utilization-resource-state {
+    description
+      "Operational state data for utilization resource.";
+
+    leaf used {
+      type uint64;
+      description
+        "Number of entries currently in use for the resource.";
+    }
+
+    leaf used-percent {
+      type oc-types:percentage;
+      description
+        "Percent utilization of the resource";
+    }
+
+    leaf committed {
+      type uint64;
+      description
+        "Number of entries currently reserved for this resource. This is only
+        relevant to tables which allocate a block of resource for a given
+        feature.";
+    }
+
+    leaf free {
+      type uint64;
+      description
+        "Number of entries available to use.";
+    }
+
+    leaf max-limit {
+      type uint64;
+      description
+        "Maximum number of entries available for the resource. The value
+        is the theoretical maximum resource utilization possible.";
+    }
+
+    leaf high-watermark {
+      type uint64;
+      description
+        "A watermark of highest number of entries used for this resource.";
+    }
+
+    leaf last-high-watermark {
+      type oc-types:timeticks64;
+      description
+        "The time when the high-watermark was last updated";
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/release/models/platform/openconfig-platform-linecard.yang
+++ b/release/models/platform/openconfig-platform-linecard.yang
@@ -23,7 +23,13 @@ module openconfig-platform-linecard {
     "This module defines data related to LINECARD components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "0.1.2";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2022-04-15" {
+    description
+      "Add utilization to linecard";
+    reference "0.2.0";
+  }
 
   revision "2020-05-10" {
     description
@@ -108,6 +114,7 @@ module openconfig-platform-linecard {
         uses linecard-config;
         uses linecard-state;
       }
+      uses oc-platform:platform-utilization-top;
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -13,6 +13,7 @@ module openconfig-platform {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-types { prefix oc-types; }
 
+  include openconfig-platform-common;
 
   // meta
   organization "OpenConfig working group";
@@ -64,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
+
+  revision "2022-04-15" {
+    description
+      "Add utilization to integrated-circuit and chassis";
+    reference "0.16.0";
+  }
 
   revision "2022-02-02" {
     description
@@ -835,6 +842,8 @@ module openconfig-platform {
         description
           "Operational state data for chassis components";
       }
+
+      uses platform-utilization-top;
     }
 
 // TODO(aashaikh): linecard container is already defined in
@@ -989,6 +998,8 @@ module openconfig-platform {
         description
           "Operational state data for chip components";
       }
+
+      uses platform-utilization-top;
     }
 
     container backplane {


### PR DESCRIPTION
* (A) release/models/platform/openconfig-platform-common.yang
  - Add platform-utilization models
* (M) release/models/platform/openconfig-platform.yang
  - Add platform-utilization into chassis and integrated circuit
* (M) release/models/platform/openconfig-platform-linecard.yang
  - Add platform-utilization into linecard

This proposal is trying to model the utilization of hardware without adding further specific leaves within pipeline-counters.

The goals of this proposal is the same as #602, defining a vendor and architecture agnostic way to represent memory usage or hardware table entries. Unlike #602, this avoids defining specific a specific leaf within the pipeline counter which may not be an accurate representative of the current usage especially when each vendor has different complex implementation and approaches that usually cannot be represented by just one leaf.

On a separate note, the utilization container could be a better place to put the thresholds (#506) configuration and alarms. `utilization` already associates with a specific component and `resource` can break down further into separate features/tables.

`pyang` output of `/components/component/integrated-circuit/utilization`:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--rw utilization
              +--rw resources
                 +--rw resource* [name]
                    +--rw name      -> ../config/name
                    +--rw config
                    |  +--rw name?   string
                    +--rw state
                       +--rw name?                  string
                       +--rw used?                  uint64
                       +--rw used-percent?          oc-types:percentage
                       +--rw committed?             uint64
                       +--rw free?                  uint64
                       +--rw max-limit?             uint64
                       +--rw high-watermark?        uint64
                       +--rw last-high-watermark?   oc-types:timeticks64
```