### PR TITLE
Add convergence tracking stats to ATE flow model

### DIFF
--- a/release/models/ate/openconfig-ate-flow.yang
+++ b/release/models/ate/openconfig-ate-flow.yang
@@ -219,6 +219,20 @@ module openconfig-ate-flow {
         "The rate, measured in bits per second, at which the flow is being
         received.";
     }
+
+    leaf first-packet-latency {
+      type oc-types:timeticks64;
+      description
+        "The time from when the flow was started to when the first packet was
+        received.";
+    }
+
+    leaf convergence-time {
+      type oc-types:timeticks64;
+      description
+        "The time from when the first packet was received to when traffic
+        loss dropped below a minimal threshold value.";
+    }
   }
 
   grouping flow-counters-state {

--- a/release/models/ate/openconfig-ate-flow.yang
+++ b/release/models/ate/openconfig-ate-flow.yang
@@ -24,7 +24,13 @@ module openconfig-ate-flow {
     stream of packets whose definition is outside of the context of this
     module.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision 2022-04-29 {
+    description
+      "Add protocol convergence tracking statistics.";
+    reference "0.4.0";
+  }
 
   revision 2022-02-16 {
     description


### PR DESCRIPTION
Adds leaves to expose statistics related to protocol convergence testing (eg. the time taken for BGP routes to be installed and used for forwarding.)