### PR TITLE
Add fib-ready flag to AFT IPv(4/6) state

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -379,11 +379,9 @@ submodule openconfig-aft-common {
 
   }
 
-  grouping aft-common-ip-state {
+  grouping aft-common-ip-aft-state {
     description
-      "Common parameters across IP address families";
-
-    uses aft-common-install-protocol;
+      "Common parameters across AFT IP address families";
 
     leaf fib-ready {
       type boolean;
@@ -405,6 +403,13 @@ submodule openconfig-aft-common {
         A device would set this leaf or flag to indicate to the
         client that AFT data/view is consistent.";
     }
+  }
+
+  grouping aft-common-ip-state {
+    description
+      "Common parameters across IP address families";
+
+    uses aft-common-install-protocol;
 
     leaf decapsulate-header {
       type oc-aftt:encapsulation-header-type;

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description
@@ -378,6 +384,27 @@ submodule openconfig-aft-common {
       "Common parameters across IP address families";
 
     uses aft-common-install-protocol;
+
+    leaf fib-ready {
+      type boolean;
+      default false;
+      description
+        "AFT streaming over gNMI is an eventually consistent system.
+        When the device updates an entry it is usually expected to
+        stream an update to the client within a vert short amount
+        of time (few milliseconds). So, Telemetry collector or a
+        controller that parse the AFT doesn't have a consistent
+        snapshot, or overall versioned copy of AFT with the device
+        at any point of time.
+
+        In certain failure modes like device boot up, gNMI daemon
+        failure and device/routing engine stateful switchover
+        Telemetry collector or a controller need a flag to
+        determine whether it is in consistent with the device or
+        not such that it can a corrective action when needed.
+        A device would set this leaf or flag to indicate to the
+        client that AFT data/view is consistent.";
+    }
 
     leaf decapsulate-header {
       type oc-aftt:encapsulation-header-type;

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ethernet {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv4 {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv6 {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -25,7 +25,7 @@ submodule openconfig-aft-mpls {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -32,7 +32,7 @@ submodule openconfig-aft-pf {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -44,7 +44,7 @@ module openconfig-aft {
 
   revision "2022-05-03" {
     description
-      "Add fib-ready to AFT IPv(4/6) entry state";
+      "Add fib-ready to AFT IPv(4/6) state";
     reference "0.11.0";
   }
 

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -40,7 +40,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-03" {
+    description
+      "Add fib-ready to AFT IPv(4/6) entry state";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -166,6 +166,14 @@ module openconfig-aft {
           for installation into the FIB of the device exporting the
           data structure.";
 
+        container state {
+          config false;
+          description
+          "Operational state parameters for the IPv4 unicast AFT.";
+
+          uses aft-common-ip-aft-state;
+        }
+
         uses aft-ipv4-unicast-structural;
       }
 
@@ -175,11 +183,20 @@ module openconfig-aft {
           within this table are uniquely keyed on the IPv6 unicast
           destination prefix which is matched by ingress packets.
 
-          The data set represented by the IPv6 Unicast AFTis the set
-          of entries within the IPv6 RIB that ";
+          The data set represented by the IPv6 Unicast AFT is the set
+          of entries within the IPv6 RIB that that have been selected
+          for installation into the FIB of the device exporting the
+          data structure.";
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the IPv6 unicast AFT.";
+
+          uses aft-common-ip-aft-state;
+        }
 
         uses aft-ipv6-unicast-structural;
-
       }
 
       container policy-forwarding {


### PR DESCRIPTION
AFT streaming over gNMI is an eventually consistent system.
When the device updates an entry it is usually expected to
stream an update to the client within a vert short amount
of time (few milliseconds). So, Telemetry collector or a
controller that parse the AFT doesn't have a consistent
snapshot, or overall versioned copy of AFT with the device
at any point of time.

In certain failure modes like device boot up, gNMI daemon
failure and device/routing engine stateful switchover
Telemetry collector or a controller need a flag to
determine whether it is in consistent with the device or
not such that it can a corrective action when needed.
A device would set this leaf or flag to indicate to the
client that AFT data/view is consistent.

$ pyang -p release/models -f tree --tree-path=/network-instances/network-instance/afts/ipv4-unicast release/models/network-instance/openconfig-network-instance.yang
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--ro afts
           +--ro ipv4-unicast
              +--ro state
              |  +--ro fib-ready?   boolean
              +--ro ipv4-entry* [prefix]
                 +--ro prefix    -> ../state/prefix
                 +--ro state
                    +--ro prefix?                            oc-inet:ipv4-prefix
                    +--ro packets-forwarded?                 oc-yang:counter64
                    +--ro octets-forwarded?                  oc-yang:counter64
                    +--ro next-hop-group?                    -> /network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
                    +--ro next-hop-group-network-instance?   -> /network-instances/network-instance/config/name
                    +--ro entry-metadata?                    binary
                    +--ro origin-protocol?                   identityref
                    +--ro decapsulate-header?                oc-aftt:encapsulation-header-type

$ pyang -p release/models -f tree --tree-path=/network-instances/network-instance/afts/ipv6-unicast release/models/network-instance/openconfig-network-instance.yang
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--ro afts
           +--ro ipv6-unicast
              +--ro state
              |  +--ro fib-ready?   boolean
              +--ro ipv6-entry* [prefix]
                 +--ro prefix    -> ../state/prefix
                 +--ro state
                    +--ro prefix?                            oc-inet:ipv6-prefix
                    +--ro packets-forwarded?                 oc-yang:counter64
                    +--ro octets-forwarded?                  oc-yang:counter64
                    +--ro next-hop-group?                    -> /network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
                    +--ro next-hop-group-network-instance?   -> /network-instances/network-instance/config/name
                    +--ro entry-metadata?                    binary
                    +--ro origin-protocol?                   identityref
                    +--ro decapsulate-header?                oc-aftt:encapsulation-header-type