### PR TITLE
Add state-synced container under afts container

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -25,7 +25,7 @@ submodule openconfig-aft-common {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -22,7 +22,7 @@ submodule openconfig-aft-ethernet {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ethernet {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-fib-ready.yang
+++ b/release/models/aft/openconfig-aft-fib-ready.yang
@@ -29,12 +29,19 @@ submodule openconfig-aft-fib-ready {
       "Structural grouping defining the schema for the FIB ready signals
       of various abstract forwarding table.";
 
-    leaf ip-unicast {
-      type boolean;
-      default false;
+    container state {
+      config false;
       description
-        "FIB ready signal indicating consistent device snapshot of
-        IPv4 & IPv6 unicast AFTs.";
+        "Operational state parameters relating to the FIB
+        ready signals of various AFTs.";
+
+      leaf ip-unicast {
+        type boolean;
+        default false;
+        description
+          "FIB ready signal indicating consistent device snapshot of
+          IPv4 & IPv6 unicast AFTs.";
+      }
     }
   }
 }

--- a/release/models/aft/openconfig-aft-fib-ready.yang
+++ b/release/models/aft/openconfig-aft-fib-ready.yang
@@ -1,0 +1,40 @@
+submodule openconfig-aft-fib-ready {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the FIB
+    ready signals corresponding to various abstract forwarding tables.";
+
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
+
+  grouping aft-fib-ready-structural {
+    description
+      "Structural grouping defining the schema for the FIB ready signals
+      of various abstract forwarding table.";
+
+    leaf ip-unicast {
+      type boolean;
+      default false;
+      description
+        "FIB ready signal indicating consistent device snapshot of
+        IPv4 & IPv6 unicast AFTs.";
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv4 {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -22,7 +22,7 @@ submodule openconfig-aft-ipv4 {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -24,7 +24,7 @@ submodule openconfig-aft-ipv6 {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -22,7 +22,7 @@ submodule openconfig-aft-ipv6 {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "1.1.0";

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -23,7 +23,7 @@ submodule openconfig-aft-mpls {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -25,7 +25,7 @@ submodule openconfig-aft-mpls {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -32,7 +32,7 @@ submodule openconfig-aft-pf {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -30,7 +30,7 @@ submodule openconfig-aft-pf {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -40,7 +40,7 @@ submodule openconfig-aft-state-synced {
         default false;
         description
           "State synced signal indicating consistent device snapshot of
-          IPv4 unicast AFT entries. Before setting this flag to True
+          IPv4 unicast AFT entries. Before setting this flag to true
           next-hop-groups and next-hops AFT entries, associated with
           ipv4-unicast AFT entries, are expected to be consistent with
           device snapshot.";

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -18,7 +18,7 @@ submodule openconfig-aft-state-synced {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -52,7 +52,7 @@ submodule openconfig-aft-state-synced {
         description
           "State synced signal indicating consistent device snapshot of
           IPv6 unicast AFT entries. Before setting this flag to true
-          next-hop-groups & next-hops AFT entries, associated with
+          next-hop-groups and next-hops AFT entries, associated with
           ipv6-unicast AFT entries, are expected to be consistent with
           device snapshot.";
       }

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -41,7 +41,7 @@ submodule openconfig-aft-state-synced {
         description
           "State synced signal indicating consistent device snapshot of
           IPv4 unicast AFT entries. Before setting this flag to True
-          next-hop-groups & next-hops AFT entries, associated with
+          next-hop-groups and next-hops AFT entries, associated with
           ipv4-unicast AFT entries, are expected to be consistent with
           device snapshot.";
       }

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -1,4 +1,4 @@
-submodule openconfig-aft-fib-ready {
+submodule openconfig-aft-state-synced {
   belongs-to "openconfig-aft" {
     prefix "oc-aft";
   }
@@ -13,33 +13,33 @@ submodule openconfig-aft-fib-ready {
     www.openconfig.net";
 
   description
-    "Submodule containing definitions of groupings for the FIB
-    ready signals corresponding to various abstract forwarding tables.";
+    "Submodule containing definitions of groupings for the state
+    synced signals corresponding to various abstract forwarding tables.";
 
   oc-ext:openconfig-version "1.1.0";
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 
-  grouping aft-fib-ready-structural {
+  grouping aft-state-synced-structural {
     description
-      "Structural grouping defining the schema for the FIB ready signals
+      "Structural grouping defining the schema for the state synced signals
       of various abstract forwarding table.";
 
     container state {
       config false;
       description
-        "Operational state parameters relating to the FIB
-        ready signals of various AFTs.";
+        "Operational state parameters relating to the state
+        synced signals of various AFTs.";
 
       leaf ip-unicast {
         type boolean;
         default false;
         description
-          "FIB ready signal indicating consistent device snapshot of
+          "State synced signal indicating consistent device snapshot of
           IPv4 & IPv6 unicast AFTs.";
       }
     }

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -35,12 +35,26 @@ submodule openconfig-aft-state-synced {
         "Operational state parameters relating to the state
         synced signals of various AFTs.";
 
-      leaf ip-unicast {
+      leaf ipv4-unicast {
         type boolean;
         default false;
         description
           "State synced signal indicating consistent device snapshot of
-          IPv4 & IPv6 unicast AFTs.";
+          IPv4 unicast AFT entries. Before setting this flag to True
+          next-hop-groups & next-hops AFT entries, associated with
+          ipv4-unicast AFT entries, are expected to be consistent with
+          device snapshot.";
+      }
+
+      leaf ipv6-unicast {
+        type boolean;
+        default false;
+        description
+          "State synced signal indicating consistent device snapshot of
+          IPv6 unicast AFT entries. Before setting this flag to True
+          next-hop-groups & next-hops AFT entries, associated with
+          ipv6-unicast AFT entries, are expected to be consistent with
+          device snapshot.";
       }
     }
   }

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -51,7 +51,7 @@ submodule openconfig-aft-state-synced {
         default false;
         description
           "State synced signal indicating consistent device snapshot of
-          IPv6 unicast AFT entries. Before setting this flag to True
+          IPv6 unicast AFT entries. Before setting this flag to true
           next-hop-groups & next-hops AFT entries, associated with
           ipv6-unicast AFT entries, are expected to be consistent with
           device snapshot.";

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -253,7 +253,7 @@ module openconfig-aft {
 
           In certain failure modes like device boot up, gNMI daemon
           failure and device/routing engine stateful switchover
-          Telemetry collector or a controller need a flag to
+          a telemetry collector or a controller need a flag to
           determine whether it is in consistent with the device or
           not such that it can a corrective action when needed.
           A device would set this leaf or flag to indicate to the

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -256,7 +256,7 @@ module openconfig-aft {
           a telemetry collector or a controller need a flag to
           determine whether it is in consistent with the device or
           not such that it can a corrective action when needed.
-          A device would set this leaf or flag to indicate to the
+          A device sets this leaf or flag to indicate to the
           client that AFT data/view is consistent.";
 
         uses aft-state-synced-structural;

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -246,7 +246,7 @@ module openconfig-aft {
           "In some cases AFT streaming (e.g., over gNMI) is an eventually consistent system.
           When the device updates an entry it is usually expected to
           stream an update to the client within a vert short amount
-          of time (few milliseconds). So, Telemetry collector or a
+          of time (few milliseconds). Given this is the casee, a telemetry collector or a
           controller that parse the AFT doesn't have a consistent
           snapshot, or overall versioned copy of AFT with the device
           at any point of time.

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -249,7 +249,7 @@ module openconfig-aft {
           of time (few milliseconds). Given this is the casee, a telemetry collector or a
           controller that parse the AFT doesn't have a consistent
           snapshot, or overall versioned copy of AFT with the device
-          at any point of time.
+          at any specific point of time.
 
           In certain failure modes like device boot up, gNMI daemon
           failure and device/routing engine stateful switchover

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -20,6 +20,8 @@ module openconfig-aft {
   include openconfig-aft-ethernet;
   // Include the common cross-AFT entities.
   include openconfig-aft-common;
+  // Include the FIB ready submodule.
+  include openconfig-aft-fib-ready;
 
   organization
     "OpenConfig working group";
@@ -40,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2022-05-12" {
+    description
+      "Add fib-ready container under afts.";
+    reference "0.11.0";
+  }
 
   revision "2022-01-26" {
     description
@@ -170,10 +178,11 @@ module openconfig-aft {
           destination prefix which is matched by ingress packets.
 
           The data set represented by the IPv6 Unicast AFTis the set
-          of entries within the IPv6 RIB that ";
+          of entries within the IPv6 unicast RIB that have been
+          selected for installation into the FIB of the device
+          exporting the data structure.";
 
         uses aft-ipv6-unicast-structural;
-
       }
 
       container policy-forwarding {
@@ -212,6 +221,27 @@ module openconfig-aft {
         uses aft-ethernet-structural;
       }
 
+      container fib-ready {
+        description
+          "AFT streaming over gNMI is an eventually consistent system.
+          When the device updates an entry it is usually expected to
+          stream an update to the client within a vert short amount
+          of time (few milliseconds). So, Telemetry collector or a
+          controller that parse the AFT doesn't have a consistent
+          snapshot, or overall versioned copy of AFT with the device
+          at any point of time.
+
+          In certain failure modes like device boot up, gNMI daemon
+          failure and device/routing engine stateful switchover
+          Telemetry collector or a controller need a flag to
+          determine whether it is in consistent with the device or
+          not such that it can a corrective action when needed.
+          A device would set this leaf or flag to indicate to the
+          client that AFT data/view is consistent.";
+
+        uses aft-fib-ready-structural;
+      }
+          
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -20,8 +20,8 @@ module openconfig-aft {
   include openconfig-aft-ethernet;
   // Include the common cross-AFT entities.
   include openconfig-aft-common;
-  // Include the FIB ready submodule.
-  include openconfig-aft-fib-ready;
+  // Include the state synced submodule.
+  include openconfig-aft-state-synced;
 
   organization
     "OpenConfig working group";
@@ -46,7 +46,7 @@ module openconfig-aft {
 
   revision "2022-05-12" {
     description
-      "Add fib-ready container under afts.";
+      "Add state-synced container under afts.";
     reference "1.1.0";
   }
 
@@ -227,7 +227,7 @@ module openconfig-aft {
         uses aft-ethernet-structural;
       }
 
-      container fib-ready {
+      container state-synced {
         description
           "AFT streaming over gNMI is an eventually consistent system.
           When the device updates an entry it is usually expected to
@@ -245,7 +245,7 @@ module openconfig-aft {
           A device would set this leaf or flag to indicate to the
           client that AFT data/view is consistent.";
 
-        uses aft-fib-ready-structural;
+        uses aft-state-synced-structural;
       }
 
       uses aft-next-hop-groups-structural;

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -247,7 +247,7 @@ module openconfig-aft {
 
         uses aft-fib-ready-structural;
       }
-          
+
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -44,7 +44,7 @@ module openconfig-aft {
 
   oc-ext:openconfig-version "2.1.0";
 
-  revision "2022-05-12" {
+  revision "2022-06-09" {
     description
       "Add state-synced container under afts.";
     reference "2.1.0";

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -243,7 +243,7 @@ module openconfig-aft {
 
       container state-synced {
         description
-          "AFT streaming over gNMI is an eventually consistent system.
+          "In some cases AFT streaming (e.g., over gNMI) is an eventually consistent system.
           When the device updates an entry it is usually expected to
           stream an update to the client within a vert short amount
           of time (few milliseconds). So, Telemetry collector or a


### PR DESCRIPTION
AFT streaming over gNMI is an eventually consistent system.
When the device updates an entry it is usually expected to
stream an update to the client within a vert short amount
of time (few milliseconds). So, Telemetry collector or a
controller that parse the AFT doesn't have a consistent
snapshot, or overall versioned copy of AFT with the device
at any point of time.

In certain failure modes like device boot up, gNMI daemon
failure and device/routing engine stateful switchover
Telemetry collector or a controller need a flag to
determine whether it is in consistent with the device or
not such that it can a corrective action when needed.
A device would set this leaf or flag to indicate to the
client that AFT data/view is consistent.

Following Tree shows new container `state-synced` & newly added elements under it:
```  
+--rw network-instances
     +--rw network-instance* [name]
        +--ro afts
           +--ro ipv4-unicast
           +--ro ipv6-unicast
           +--ro state-synced
           |  +--ro state
           |     +--ro ipv4-unicast?   boolean
           |     +--ro ipv6-unicast?   boolean
```