### PR TITLE
Revert IETF type module usage in BGP RIB modules

### DIFF
--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -24,7 +24,13 @@ submodule openconfig-rib-bgp-attributes {
     attributes for use in BGP RIB tables.";
 
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.8.1";
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
 
   revision "2021-06-21" {
     description

--- a/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-shared-attributes {
     "This submodule contains structural data definitions for
     attribute sets shared across routes.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.8.1";
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
 
   revision "2021-06-21" {
     description

--- a/release/models/rib/openconfig-rib-bgp-table-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-table-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-table-attributes {
     "This submodule contains common data definitions for data
     related to a RIB entry, or RIB table.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.8.1";
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
 
   revision "2021-06-21" {
     description

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -7,9 +7,9 @@ submodule openconfig-rib-bgp-tables {
 
   // import some basic types
   import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-yang-types { prefix oc-yang; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-policy-types { prefix oc-pol-types; }
-  import ietf-yang-types { prefix yang; }
 
   import openconfig-network-instance-types { prefix oc-ni-types; }
   import openconfig-evpn-types { prefix oc-evpn-types; }
@@ -30,7 +30,13 @@ submodule openconfig-rib-bgp-tables {
     "This submodule contains structural data definitions for
     BGP routing tables.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.8.1";
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
 
   revision "2021-06-21" {
     description
@@ -778,7 +784,7 @@ submodule openconfig-rib-bgp-tables {
           }
 
           leaf mac-address {
-            type yang:mac-address;
+            type oc-yang:mac-address;
             description
               "The MAC address that is learned on a PE from a CE that is
               connected to it or learned from other PEs";

--- a/release/models/rib/openconfig-rib-bgp.yang
+++ b/release/models/rib/openconfig-rib-bgp.yang
@@ -67,7 +67,13 @@ module openconfig-rib-bgp {
     eligible for sending (advertising) to the neighbor after output
     policy rules have been applied.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.8.1";
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
 
   revision "2021-06-21" {
     description


### PR DESCRIPTION
  * (M) release/models/rib/openconfig-rib-bgp-attributes.yang
  * (M) release/models/rib/openconfig-rib-bgp-shared-attributes.yang
  * (M) release/models/rib/openconfig-rib-bgp-table-attributes.yang
  * (M) release/models/rib/openconfig-rib-bgp-tables.yang
  * (M) release/models/rib/openconfig-rib-bgp.yang
    - Revert IETF types in favor of oc-types

Revert introduction of `ietf-yang-types` dependency brought in by commit 3a5269e4e52d5ca42cd4240111cf224e23e8e381 in favor of `oc-yang-types`
