### PR TITLE
Implement acceptable interface identifier range for P4RT

### DIFF
--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -72,7 +72,18 @@ module openconfig-p4rt {
 
         Note that this identifier is used only when a numeric reference
         to the interface is required, it does not replace the unique
-        name assigned to the interface.";
+        name assigned to the interface.
+
+        Ranges:
+
+        0x00000000: Unspecified/Invalid
+        0x00000001: Minimum Port Value
+        0xFFFFFEFF: Maximum Port Value
+
+        Reserved:   0xFFFFFFF0 - 0xFFFFFFFF
+        0xFFFFFFFA: Recirculate
+        0xFFFFFFFD: CPU
+        ";
       reference
         "P4 Runtime Specification v1.3.0
         https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-translation-of-port-numbers";

--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -23,10 +23,17 @@ module openconfig-p4rt {
     the P4RT service, or allow it to be used alongside other OpenConfig
     data models.
 
-    The P4RT protocol specification is linkde from https://p4.org/specs/
+    The P4RT protocol specification is linked from https://p4.org/specs/
     under the P4Runtime heading.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision 2022-06-08 {
+    description
+      "Add valid range for interface identifier and update node
+      descriptions per P4 Runtime Specification.";
+    reference "0.3.0";
+  }
 
   revision 2021-07-20 {
     description
@@ -52,17 +59,23 @@ module openconfig-p4rt {
       are running the P4RT service.";
 
     leaf id {
-      type uint32;
+      type uint32 {
+        range 1..4294967039;
+      }
       description
-        "The numeric identifier used by the controller to address the interface.
-        This ID is assigned by an external-to-the-device entity (e.g., an SDN
-        management system) to establish an externally deterministic numeric
-        reference for the interface. The programming entity must ensure that
-        the ID is unique within the required context.
+        "The numeric identifier (SDN Port) used by the controller to
+        address the interface. This ID is assigned by an
+        external-to-the-device entity (e.g., an SDN management system)
+        to establish an externally deterministic numeric reference for
+        the interface. The programming entity must ensure that the ID is
+        unique within the required context.
 
-        Note that this identifier is used only when a numeric reference to the
-        interface is required, it does not replace the unique name assigned to
-        the interface.";
+        Note that this identifier is used only when a numeric reference
+        to the interface is required, it does not replace the unique
+        name assigned to the interface.";
+      reference
+        "P4 Runtime Specification v1.3.0
+        https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-translation-of-port-numbers";
     }
   }
 
@@ -88,16 +101,20 @@ module openconfig-p4rt {
     leaf node-id {
       type uint64;
       description
-        "The numeric ID used by the controller to address the integrated circuit,
-        which may be referred to as a 'device', 'node' or 'target' by the P4RT
-        specification.
+        "The numeric ID (device_id) used by the controller to address
+        the integrated circuit, which may be referred to as a 'device',
+        'node' or 'target' by the P4RT specification.
 
-        Each switching ASIC (i.e., node) is addressed by the external entity
-        based on its numeric identifier.
+        Each switching ASIC (i.e., node) is addressed by the external
+        entity based on its numeric identifier.
 
-        The node ID is specified in addition to the string identifier assigned to
-        the integrated circuit within the /components/component list.";
+        The node ID is specified in addition to the string identifier
+        assigned to the integrated circuit within the
+        /components/component list.";
     }
+    reference
+      "P4 Runtime Specification v1.3.0
+      https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-write-rpc";
   }
 
   augment "/oc-platform:components/oc-platform:component/" +


### PR DESCRIPTION
* (M) release/models/p4rt/openconfig-p4rt.yang
  - Add range statement to interface identifier in conformance to P4RT
    specification v1.3.0
  - Description cleanup to map OpenConfig terminology to P4RT
    specification terminology

Per https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-translation-of-port-numbers, the 'SDN Port' is the equivalent attribute to the OpenConfig P4RT interface 'id'.  This change limits the acceptable uint32 range for configurable values per specification.
