### PR TITLE
Add DSCP marking for egress sFlow packets.

### DIFF
--- a/release/models/sampling/openconfig-sampling-sflow.yang
+++ b/release/models/sampling/openconfig-sampling-sflow.yang
@@ -13,6 +13,7 @@ module openconfig-sampling-sflow {
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-network-instance { prefix oc-netinst; }
+  import openconfig-packet-match-types { prefix oc-pkt-match-t; }
 
 
   // meta
@@ -29,7 +30,13 @@ module openconfig-sampling-sflow {
     RFC 3176 - InMon Corporation's sFlow: A Method for
     Monitoring Traffic in Switched and Routed Networks";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2022-06-14" {
+    description
+      "Add support for specifying a DSCP for egress sFlow packets.";
+    reference "0.2.0";
+  }
 
   revision "2020-06-26" {
     description
@@ -227,6 +234,13 @@ module openconfig-sampling-sflow {
       description
         "Sets the source IP address for sFlow datagrams sent to
         sFlow collectors.";
+    }
+
+    leaf dscp {
+      type oc-inet:dscp;
+      description
+        "The DSCP value that should be used for sFlow packets sent to the
+        collector.";
     }
 
     leaf sampling-rate {


### PR DESCRIPTION
```
* (M) release/models/sampling/openconfig-sampling-sflow.yang
   - Add a DSCP leaf that specifies the egress marking to be used
     for sFlow packets.
```

Supported by numerous vendors per the documentation below:
 * Arista: `sflow qos dscp` [doc](https://www.arista.com/jp/um-eos/eos-user-security?searchword=eos%20section%2028%202%20ipv4%20routing)
 * Cisco: `flow exporter map ... \n dscp` [doc](https://www.cisco.com/c/dam/en/us/td/docs/iosxr/ncs5xx/netflow/63x/b-netflow-cg-63x-ncs5xx.html)
 * Nokia: `sgt-qos sflow <dscp-val>` [doc](https://documentation.nokia.com/cgi-bin/dbaccessfilename.cgi/3HE15825AAAATQZZA01_V1_7450%20ESS%207750%20SR%207950%20XRS%20and%20VSR%20Quality%20of%20Service%20Guide%2020.2.R1.pdf)
 * Juniper: `set sflow collector <addr> dscp <dscp-val>` [doc](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/collector-edit-protocols-sflow-ex-series.html)
