### PR TITLE
Fix CI push: Use models-ci image for ygot step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -218,7 +218,7 @@ steps:
   - 'GOPATH=/go'
   waitFor: ['go path creation']
   id: 'goyang-ygot prep'
-- name: 'golang'
+- name: 'gcr.io/$PROJECT_ID/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/goyang-ygot/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']


### PR DESCRIPTION
This is to fix the push step where the gcloud CLI is required. I was experimenting with the image and forgot to change it back.