### PR TITLE
Switchover ready

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -19,7 +19,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.17.0";
+  oc-ext:openconfig-version "0.18.0";
+
+  revision "2022-07-11" {
+    description
+      "Add switchover ready";
+    reference "0.18.0";
+  }
 
   revision "2022-06-10" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.17.0";
+  oc-ext:openconfig-version "0.18.0";
+
+  revision "2022-07-11" {
+    description
+      "Add switchover ready";
+    reference "0.18.0";
+  }
 
   revision "2022-06-10" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -515,7 +515,7 @@ module openconfig-platform {
       type boolean;
       description
         "For components that have redundant roles, this reports a value
-        of that indicates if the secondary component is ready to
+        that indicates if the secondary component is ready to
         failover in the case of component failure.";
     }
   }

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -515,12 +515,12 @@ module openconfig-platform {
       type boolean;
       description
         "For components that have redundant roles, this reports a value
-        that indicates if the secondary component is ready to
-        failover in the case of component failure.
+        that indicates if the component is ready to support failover.
 
-        The components with a redundant-role of primary should reflect
-        the overall system's switchover status. For example, two
-        supervisors in a device should both report the same value.";
+        The components with a redundant-role should reflect the overall 
+        system's switchover status.  For example, two supervisors in a 
+        device, one as primary and the other as secondary, should both 
+        report the same value.";
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -517,9 +517,9 @@ module openconfig-platform {
         "For components that have redundant roles, this reports a value
         that indicates if the component is ready to support failover.
 
-        The components with a redundant-role should reflect the overall 
-        system's switchover status.  For example, two supervisors in a 
-        device, one as primary and the other as secondary, should both 
+        The components with a redundant-role should reflect the overall
+        system's switchover status.  For example, two supervisors in a
+        device, one as primary and the other as secondary, should both
         report the same value.";
     }
   }

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -516,7 +516,11 @@ module openconfig-platform {
       description
         "For components that have redundant roles, this reports a value
         that indicates if the secondary component is ready to
-        failover in the case of component failure.";
+        failover in the case of component failure.
+
+        The components with a redundant-role of primary should reflect
+        the overall system's switchover status. For example, two
+        supervisors in a device should both report the same value.";
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -504,6 +504,14 @@ module openconfig-platform {
         value is the timestamp in nanoseconds relative to the Unix Epoch
         (Jan 1, 1970 00:00:00 UTC).";
     }
+
+    leaf switchover-ready {
+      type boolean;
+      description
+        "For components that have redundant roles, this reports a value
+        of that indicates if the secondary component is ready to
+        failover in the case of component failure.";
+    }
   }
 
   grouping platform-component-temp-alarm-state {


### PR DESCRIPTION
* (M) release/models/platform/openconfig-platform.yang
  - Add boolean switchover-ready leaf

Add an indication for when redundant components are ready to failover.

Relevant pyang output:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--ro state
           +--ro switchover-ready?   boolean
```

References:
* Arista `show redundancy status`
  * https://www.arista.com/en/um-eos/eos-supervisor-redundancy
* Juniper `show system switchover`
  * https://www.juniper.net/documentation/us/en/software/junos/high-availability/topics/ref/command/show-system-switchover.html
* Cisco `show redundancy states`
  * https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/16-9/command_reference/b_169_9400_cr/high_availability_commands.html#reference_t1d_ppp_dgb