### PR TITLE
Correct BFD diagnostic codes per RFC5880/6428

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,13 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.2.4";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2022-07-18" {
+    description
+      "Correct diagnostic codes per RFC5880/6428";
+    reference "0.3.0";
+  }
 
   revision "2022-06-28" {
     description
@@ -138,21 +144,26 @@ module openconfig-bfd {
           "The BFD echo function failed - echo packets have not been
           received for the required period of time.";
       }
-      enum FORWARDING_RESET {
+      enum NEIGHBOR_SESSION_DOWN {
         value 3;
+        description
+          "The neighbor has signaled the session down.";
+      }
+      enum FORWARDING_RESET {
+        value 4;
         description
           "The forwarding plane in the local system was reset - such
           that the remote system cannot rely on the forwarding state of
           the device specifying this error code.";
       }
       enum PATH_DOWN {
-        value 4;
+        value 5;
         description
           "Signalling outside of BFD specified that the path underlying
           this session has failed.";
       }
       enum CONCATENATED_PATH_DOWN {
-        value 5;
+        value 6;
         description
           "When a BFD session runs over a series of path segments, this
           error code indicates that a subsequent path segment (i.e.,
@@ -160,26 +171,34 @@ module openconfig-bfd {
           of the session) has failed.";
       }
       enum ADMIN_DOWN {
-        value 6;
+        value 7;
         description
           "The BFD session has been administratively disabled by the
           peer.";
       }
       enum REVERSE_CONCATENATED_PATH_DOWN {
-        value 7;
+        value 8;
         description
           "In the case that a BFD session is running over a series of
           path segments, this error code indicates that a path segment
           on the reverse path (i.e., in the transmit direction from the
           destination to the source of the session) has failed.";
       }
+      enum MIS_CONNECTIVITY_DEFECT {
+        value 9;
+        description
+          "Mis-connectivity defect.";
+        reference
+          "RFC6428 - Proactive Connectivity Verification, Continuity
+          Check, and Remote Defect Indication for the MPLS Transport
+          Profile, Section 5";
+      }
     }
     description
       "Diagnostic codes defined by BFD. These typically indicate the
       reason for a change of session state.";
     reference
-      "RFC5880 - Bidirectional Forwarding Detection, Section
-      4.1";
+      "RFC5880 - Bidirectional Forwarding Detection, Section 4.1";
   }
 
 


### PR DESCRIPTION
  * (M) release/models/bfd/openconfig-bfd.yang
    - Add missing codes and adjust value mappings according to RFC

Previously, the enum variants for BFD diagnostic codes missed value (3) per
RFC5880.  This PR addresses the missing diagnostic code, correcting the
subsequent variant values and adding the reserved value (9) per RFC6428.
