### PR TITLE
Adjust enum variant values for consistency

### DIFF
--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -19,7 +19,14 @@ module openconfig-mpls-types {
   description
     "General types for MPLS / TE data model";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.4.1";
+
+  revision "2022-07-20" {
+    description
+      "Assign missing enum variant values where values are already
+      allocated";
+    reference "3.4.1";
+  }
 
   revision "2021-12-01" {
     description
@@ -459,6 +466,7 @@ module openconfig-mpls-types {
             labels RFC 6790";
         }
         enum NO_LABEL {
+          value -1;
           description
             "This value is utilised to indicate that the packet that
             is forwarded by the local system does not have an MPLS

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,14 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-07-20" {
+    description
+      "Remove enum variant values when the enumeration does not
+      require";
+    reference "0.5.1";
+  }
 
   revision "2021-08-28" {
     description

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,14 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-07-20" {
+    description
+      "Remove enum variant values when the enumeration does not
+      require";
+    reference "0.5.1";
+  }
 
   revision "2021-08-28" {
     description
@@ -208,12 +215,10 @@ submodule openconfig-qos-interfaces {
     leaf type {
       type enumeration {
         enum IPV4 {
-          value 4;
           description
             "Classifier matches IPv4 Unicast packets.";
         }
         enum IPV6 {
-          value 6;
           description
             "Classifier matches IPv6 Unicast packets.";
         }

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,14 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-07-20" {
+    description
+      "Remove enum variant values when the enumeration does not
+      require";
+    reference "0.5.1";
+  }
 
   revision "2021-08-28" {
     description

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,14 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-07-20" {
+    description
+      "Remove enum variant values when the enumeration does not
+      require";
+    reference "0.5.1";
+  }
 
   revision "2021-08-28" {
     description


### PR DESCRIPTION
  * (M) release/models/mpls/openconfig-mpls-types.yang
  * (M) release/models/qos/openconfig-qos.yang
  * (M) release/models/qos/openconfig-qos-elements.yang
  * (M) release/models/qos/openconfig-qos-mem-mgmt.yang
  * (M) release/models/qos/openconfig-qos-interfaces.yang
    - Remove enum variant values where there is only partial definition
      within the enumeration and there is no need for underlying mapping
      for functionality
    - Add any missing variant values where applicable.  If it falls
      outside of a protocol defined range, use negative integers to
      reflect (e.g. -1)

Most enum variant value declarations carry some meaning to an underlying specification and do not need to be defined in many cases.  Per RFC6020, Section 9.6.4.2, if values are not specified, they will be automatically assigned.  This PR removes any partial declarations that do not need to be there while adding any partial declarations that should.  In the event that a variant value is defined that falls outside of a specification (e.g. for the ANY/ALL/NONE, catchall case), then a negative value is assigned as the values are within the range -2147483648 - 2147483647.
