### PR TITLE
Add File Synchronization for redundancy

### DIFF
--- a/release/models/system/.spec.yml
+++ b/release/models/system/.spec.yml
@@ -12,6 +12,7 @@
     - yang/system/openconfig-alarms.yang
     - yang/system/openconfig-messages.yang
     - yang/system/openconfig-license.yang
+    - yang/system/openconfig-system-redundancy.yang
   build:
     - yang/system/openconfig-system.yang
   run-ci: true

--- a/release/models/system/openconfig-system-redundancy.yang
+++ b/release/models/system/openconfig-system-redundancy.yang
@@ -58,17 +58,17 @@ module openconfig-system-redundancy {
 
     leaf status {
       type enumeration {
-        enum unsynchronized {
+        enum UNSYNCHRONIZED {
           description
             "The file is being synchronized or the synchronization has yet to be started.";
         }
 
-        enum synchronized {
+        enum SYNCHRONIZED {
           description
             "The file was successfully synchronization.";
         }
 
-        enum failed {
+        enum FAILED {
           description
             "The file synchronization has failed.";
         }

--- a/release/models/system/openconfig-system-redundancy.yang
+++ b/release/models/system/openconfig-system-redundancy.yang
@@ -1,0 +1,156 @@
+module openconfig-system-redundancy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/system/redundancy";
+
+  prefix "oc-sys-red";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines the configuration and operational state data
+    related to redundant systems, such as two supervisors in a device.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-07-20" {
+    description
+      "Initial revision with file sync";
+    reference "0.1.0";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping redundancy-file-sync-config {
+    description
+      "Configuration grouping for file synchronization.";
+
+    leaf path {
+      type string;
+      description
+        "The system file path of the file to be synched to another
+        redundant system.";
+    }
+  }
+
+  grouping redundancy-file-sync-state {
+    description
+      "Operational grouping for file synchronization.";
+
+    leaf status {
+      type enumeration {
+        enum unsynchronized {
+          description
+            "The file is being synchronized or the synchronization has yet to be started.";
+        }
+
+        enum synchronized {
+          description
+            "The file was successfully synchronization.";
+        }
+
+        enum failed {
+          description
+            "The file synchronization has failed.";
+        }
+      }
+      default unsynchronized;
+      description
+        "The enum reports the synchronization status of the file.";
+    }
+
+    leaf last-sync-time {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "This reports the time of the last successful synchronization of the file.
+        The value is the timestamp in nanoseconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+
+  grouping redundancy-file-sync-top {
+    description
+      "Top-level grouping for file synchronization between multiple supervisors.";
+
+    container file-sync {
+      description
+        "Top-level container for file synchronization.";
+
+      container files {
+        description
+          "This contains the list of files to synchronize between
+          multiple systems.";
+
+        list file {
+          key "path";
+          description
+            "List of files in the system to sync.";
+
+          leaf path {
+            type leafref {
+              path "../config/path";
+            }
+            description
+              "Reference to the path of the file.";
+          }
+
+          container config {
+            description
+              "Configuration data for each file to be synced.";
+
+              uses redundancy-file-sync-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state data of each file synced.";
+
+              uses redundancy-file-sync-config;
+              uses redundancy-file-sync-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping system-redundancy-top {
+    description
+      "Top-level grouping for redundancy.";
+
+    container redundancy {
+      description
+        "Top-level container for system level redundancy features.";
+
+      uses redundancy-file-sync-top;
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/release/models/system/openconfig-system-redundancy.yang
+++ b/release/models/system/openconfig-system-redundancy.yang
@@ -73,7 +73,7 @@ module openconfig-system-redundancy {
             "The file synchronization has failed.";
         }
       }
-      default unsynchronized;
+      default UNSYNCHRONIZED;
       description
         "The enum reports the synchronization status of the file.";
     }

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -15,6 +15,7 @@ module openconfig-system {
   import openconfig-aaa { prefix oc-aaa; }
   import openconfig-system-logging { prefix oc-log; }
   import openconfig-system-terminal { prefix oc-sys-term; }
+  import openconfig-system-redundancy { prefix oc-sys-red; }
   import openconfig-procmon { prefix oc-proc; }
   import openconfig-platform { prefix oc-platform; }
   import openconfig-alarms { prefix oc-alarms; }
@@ -46,7 +47,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.13.1";
+  oc-ext:openconfig-version "0.14.0";
+
+  revision "2022-07-20" {
+    description
+      "Adding system redundancy models.";
+    reference "0.14.0";
+  }
 
   revision "2022-07-12" {
     description
@@ -1165,6 +1172,7 @@ module openconfig-system {
       uses oc-alarms:alarms-top;
       uses oc-messages:messages-top;
       uses oc-license:license-top;
+      uses oc-sys-red:system-redundancy-top;
     }
   }
 


### PR DESCRIPTION
* (A) release/models/system/openconfig-system-redundancy.yang
  * Add OpenConfig model for file synchronization
* (M) release/models/system/openconfig-system.yang

This proposal introduces a set of models which represent files that synchronize between two controller cards or supervisors.  Synced files can be specified as arbitrary files from within the system.

pyang output:
```
module: openconfig-system                                                      
  +--rw system
     +--rw redundancy
        +--rw file-sync
           +--rw files
              +--rw file* [path]
                 +--rw path      -> ../config/path
                 +--rw config
                 |  +--rw path?   string
                 +--ro state
                    +--ro path?             string
                    +--ro status?           enumeration
                    +--ro last-sync-time?   oc-types:timeticks64
```

Reference:
- Arista
  - `show redundancy file-replication`
    - https://www.arista.com/en/um-eos/eos-switch-booting-commands#xx1122125
  - `file-replication` configuration example
```
redundancy
   file replication
      path flash:/random-file
      path flash:/another-file
```
- Cisco `rsync`
  - https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-management/73x/b-system-management-cg-8k-73x/m-synch-file-systems.html?dtid=osscdc000283#Cisco_Concept.dita_2134690f-1fa9-44a9-8ccb-b62836abaeff
- Juniper `commit synchronize`
  - https://www.juniper.net/documentation/us/en/software/junos/cli/topics/topic-map/synchronising-routing-engines.html