### PR TITLE
Define default behavior for user creation when no role is defined

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,14 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2022-07-29" {
+    description
+      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
+      user role is not specified during user creation.";
+      reference "0.6.0";
+  }
 
   revision "2020-07-30" {
     description

--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -30,8 +30,7 @@ submodule openconfig-aaa-radius {
 
   revision "2022-07-29" {
     description
-      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
-      user role is not specified during user creation.";
+      "Update user role to be mandatory."
       reference "0.6.0";
   }
 

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,14 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2022-07-29" {
+    description
+      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
+      user role is not specified during user creation.";
+      reference "0.6.0";
+  }
 
   revision "2020-07-30" {
     description

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -29,8 +29,7 @@ submodule openconfig-aaa-tacacs {
 
   revision "2022-07-29" {
     description
-      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
-      user role is not specified during user creation.";
+      "Update user role to be mandatory."
       reference "0.6.0";
   }
 

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -71,8 +71,7 @@ module openconfig-aaa-types {
   identity SYSTEM_DEFINED_ROLES {
     description
       "Base identity for system_defined roles that can be assigned
-      to users.  Default of SYSTEM_ROLE_READ_ONLY is used if role
-      is not specified during user creation.";
+      to users.";
   }
 
   identity SYSTEM_ROLE_ADMIN {

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -22,7 +22,14 @@ module openconfig-aaa-types {
     "This module defines shared types for data related to AAA
     (authentication, authorization, accounting).";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2022-07-29" {
+    description
+      "Add two new SYSTEM_DEFINED_ROLES: SYSTEM_ROLE_OPERATOR
+      and SYSTEM_ROLE_READ_ONLY.";
+    reference "0.5.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -71,7 +78,8 @@ module openconfig-aaa-types {
   identity SYSTEM_DEFINED_ROLES {
     description
       "Base identity for system_defined roles that can be assigned
-      to users.";
+      to users.  Default of SYSTEM_ROLE_READ_ONLY is used if role
+      is not specified during user creation.";
   }
 
   identity SYSTEM_ROLE_ADMIN {
@@ -80,6 +88,22 @@ module openconfig-aaa-types {
       "Built-in role that allows the equivalent of superuser
       permission for all configuration and operational commands
       on the device.";
+  }
+
+  identity SYSTEM_ROLE_OPERATOR {
+    base SYSTEM_DEFINED_ROLES;
+    description
+      "Built-in role that allows the equivalent of network-operator
+      permission for all read-only and operational commands
+      on the device.";
+  }
+
+  identity SYSTEM_ROLE_READ_ONLY {
+    base SYSTEM_DEFINED_ROLES;
+    description
+      "Built-in role that allows for the execution of read-only
+      commands on the device.  Lacks permissions to operational
+      or configuration commands.";
   }
 
   identity AAA_ACCOUNTING_EVENT_TYPE {

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -24,13 +24,6 @@ module openconfig-aaa-types {
 
   oc-ext:openconfig-version "0.5.0";
 
-  revision "2022-07-29" {
-    description
-      "Add two new SYSTEM_DEFINED_ROLES: SYSTEM_ROLE_OPERATOR
-      and SYSTEM_ROLE_READ_ONLY.";
-    reference "0.5.0";
-  }
-
   revision "2018-11-21" {
     description
       "Add OpenConfig module metadata extensions.";
@@ -88,22 +81,6 @@ module openconfig-aaa-types {
       "Built-in role that allows the equivalent of superuser
       permission for all configuration and operational commands
       on the device.";
-  }
-
-  identity SYSTEM_ROLE_OPERATOR {
-    base SYSTEM_DEFINED_ROLES;
-    description
-      "Built-in role that allows for the access to state paths.
-      Lacks permissions to operational (gNOI) and lacks
-      write access to config paths.";
-  }
-
-  identity SYSTEM_ROLE_READ_ONLY {
-    base SYSTEM_DEFINED_ROLES;
-    description
-      "Built-in role that allows for the execution of read-only
-      commands on the device.  Lacks permissions to operational
-      or configuration commands.";
   }
 
   identity AAA_ACCOUNTING_EVENT_TYPE {

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -22,7 +22,7 @@ module openconfig-aaa-types {
     "This module defines shared types for data related to AAA
     (authentication, authorization, accounting).";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.4.1";
 
   revision "2018-11-21" {
     description

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -26,11 +26,7 @@ module openconfig-aaa-types {
 
   revision "2022-07-29" {
     description
-<<<<<<< HEAD
       "Add two new SYSTEM_DEFINED_ROLES: SYSTEM_ROLE_OPERATOR
-=======
-      "Add two new SYSTEM_DEFINED_ROLES: SYSTEM_ROLE_OPERATOR 
->>>>>>> 6982bee099e20a6c6a68de59257aa1dd020a6246
       and SYSTEM_ROLE_READ_ONLY.";
     reference "0.5.0";
   }
@@ -97,9 +93,9 @@ module openconfig-aaa-types {
   identity SYSTEM_ROLE_OPERATOR {
     base SYSTEM_DEFINED_ROLES;
     description
-      "Built-in role that allows the equivalent of network-operator
-      permission for all read-only and operational commands
-      on the device.";
+      "Built-in role that allows for the access to state paths.  
+      Lacks permissions to operational (gNOI) and lacks
+      write access to config paths.";
   }
 
   identity SYSTEM_ROLE_READ_ONLY {

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -93,7 +93,7 @@ module openconfig-aaa-types {
   identity SYSTEM_ROLE_OPERATOR {
     base SYSTEM_DEFINED_ROLES;
     description
-      "Built-in role that allows for the access to state paths.  
+      "Built-in role that allows for the access to state paths.
       Lacks permissions to operational (gNOI) and lacks
       write access to config paths.";
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -403,7 +403,6 @@ module openconfig-aaa {
         }
       }
       mandatory true;
-      default oc-aaa-types:SYSTEM_ROLE_READ_ONLY;
       description
         "Role assigned to the user.  The role must be supplied
         as a role defined by the SYSTEM_DEFINED_ROLES

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -32,7 +32,14 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2022-07-29" {
+    description
+      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
+      user role is not specified during user creation.";
+      reference "0.6.0";
+  }
 
   revision "2020-07-30" {
     description
@@ -396,10 +403,12 @@ module openconfig-aaa {
           base oc-aaa-types:SYSTEM_DEFINED_ROLES;
         }
       }
+      default oc-aaa-types:SYSTEM_ROLE_READ_ONLY;
       description
-        "Role assigned to the user.  The role may be supplied
-        as a string or a role defined by the SYSTEM_DEFINED_ROLES
-        identity.";
+        "Role assigned to the user.  The role must be supplied
+        as a role defined by the SYSTEM_DEFINED_ROLES
+        identity or a string.  If no role is supplied,
+        a default of SYSTEM_ROLE_READ_ONLY must be used.";
     }
   }
 

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -36,7 +36,7 @@ module openconfig-aaa {
 
   revision "2022-07-29" {
     description
-      "Specify a default role of SYSTEM_ROLE_READ_ONLY if 
+      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
       user role is not specified during user creation.";
       reference "0.6.0";
   }
@@ -407,7 +407,7 @@ module openconfig-aaa {
       description
         "Role assigned to the user.  The role must be supplied
         as a role defined by the SYSTEM_DEFINED_ROLES
-        identity or a string.  If no role is supplied, 
+        identity or a string.  If no role is supplied,
         a default of SYSTEM_ROLE_READ_ONLY must be used.";
     }
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -407,11 +407,7 @@ module openconfig-aaa {
       description
         "Role assigned to the user.  The role must be supplied
         as a role defined by the SYSTEM_DEFINED_ROLES
-<<<<<<< HEAD
-        identity or a string.  If no role is supplied,
-=======
         identity or a string.  If no role is supplied, 
->>>>>>> 6982bee099e20a6c6a68de59257aa1dd020a6246
         a default of SYSTEM_ROLE_READ_ONLY must be used.";
     }
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -36,11 +36,7 @@ module openconfig-aaa {
 
   revision "2022-07-29" {
     description
-<<<<<<< HEAD
-      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
-=======
       "Specify a default role of SYSTEM_ROLE_READ_ONLY if 
->>>>>>> 6982bee099e20a6c6a68de59257aa1dd020a6246
       user role is not specified during user creation.";
       reference "0.6.0";
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -36,8 +36,7 @@ module openconfig-aaa {
 
   revision "2022-07-29" {
     description
-      "Specify a default role of SYSTEM_ROLE_READ_ONLY if
-      user role is not specified during user creation.";
+      "Update user role to be mandatory."
       reference "0.6.0";
   }
 
@@ -403,12 +402,12 @@ module openconfig-aaa {
           base oc-aaa-types:SYSTEM_DEFINED_ROLES;
         }
       }
+      mandatory true;
       default oc-aaa-types:SYSTEM_ROLE_READ_ONLY;
       description
         "Role assigned to the user.  The role must be supplied
         as a role defined by the SYSTEM_DEFINED_ROLES
-        identity or a string.  If no role is supplied,
-        a default of SYSTEM_ROLE_READ_ONLY must be used.";
+        identity or a string.";
     }
   }
 


### PR DESCRIPTION
* (M) release/models/system/system-aaa.yang
* (M) release/models/system/system-aaa-radius.yang
* (M) release/models/system/system-aaa-tacacs.yang

 - Update role to be mandatory attribute of user configuration

This is to address the undefined behavior when a system user is created but no role is specified.  

1. Junos/EVO require a role and do not allow a user to be created without one.
2. EOS allows the creation of a user without specifying a role.  The default role is 'network-operator',
with a privilege level of 1. (https://www.arista.com/en/um-eos/eos-user-security#xx1347271)
3. Can't find documentation for IOS-XR, but NX-OS behaves in a similiar manner to EOS and assigns a 
default role of network-operator to a user if a role isn't provided at time of creation (role of 'operator').

###Arista EOS###
eos-oc1#show run | in username test
eos-oc1(config)#username test nopassword 
eos-oc1#show run | in  username test
username test nopassword
eos-oc1#show users accounts 
user: admin
       role: network-admin
       privilege level: 15
user: test
       role: network-operator
       privilege level: 1

###Cisco NX-OS###
D-SW1# show run | in "username test"
D-SW1# conf t
Enter configuration commands, one per line.  End with CNTL/Z.
D-SW1(config)# username test
warning: password for user:test not set. S/he may not be able to login
D-SW1(config)# exit
D-SW1# show run | in "username test"
username test password 5 !  role network-operator
D-SW1# show user-account test
user:test
        this user account has no expiry date
        roles:network-operator 
 