### PR TITLE
Adding control over sending of IS-IS CSNP packets on P2P interfaces

### DIFF
--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -261,6 +261,13 @@ module openconfig-isis {
       description
         "Controls the padding type for IS-IS Hello PDUs on a global level.";
     }
+
+    leaf enable-csnp-on-p2p-links {
+      description
+        "Enable/disable the transmission of periodic CSNP PDUs on point-to-point interfaces. When this is set to false, CSNP PDUs will only be sent on a P2P interface when the adjacency is initialized. This setting has no effect on broadcast interfaces.";
+      type boolean;
+      default true;
+    }
   }
 
   grouping admin-config {


### PR DESCRIPTION
Adding a single new leaf to control (optionally disable) the periodic transmission of CSNP PDUs on point-to-point interfaces