### PR TITLE
Update AAA model to make user role a mandatory attribute

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,13 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
 
   revision "2020-07-30" {
     description

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,13 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
 
   revision "2020-07-30" {
     description

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -32,7 +32,13 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
 
   revision "2020-07-30" {
     description
@@ -396,10 +402,11 @@ module openconfig-aaa {
           base oc-aaa-types:SYSTEM_DEFINED_ROLES;
         }
       }
+      mandatory true;
       description
-        "Role assigned to the user.  The role may be supplied
-        as a string or a role defined by the SYSTEM_DEFINED_ROLES
-        identity.";
+        "Role assigned to the user.  The role must be supplied
+        as a role defined by the SYSTEM_DEFINED_ROLES
+        identity or a string that matches a user defined role.";
     }
   }
 


### PR DESCRIPTION
    * (M) release/models/system/system-aaa.yang
    * (M) release/models/system/system-aaa-radius.yang
    * (M) release/models/system/system-aaa-tacacs.yang

     - Update role to be mandatory attribute of user configuration

    This is to address the undefined behavior when a system user is created but no role is specified.  Implementations vary in their behavior here - proposal is to make role a mandatory attribute.