### PR TITLE
Clarify next-hop ip-address description

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description
@@ -289,7 +295,9 @@ submodule openconfig-aft-common {
     leaf ip-address {
       type oc-inet:ip-address;
       description
-        "The IP address of the next-hop system.";
+        "The IP address of the next-hop system. This leaf represents the
+        ip-address of the flattened next-hop representation in case of
+        recursion or indirection at the next-hop-group level";
     }
 
     leaf mac-address {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.2.1";
+
+  revision "2022-08-17" {
+    description
+      "Clarify next-hop ip-address description.";
+    reference "2.2.1";
+  }
 
   revision "2022-06-16" {
     description


### PR DESCRIPTION
This change is because of a recent regression found in hierarchical route installation test.

As per the latest expectation, for recursive next-hop-groups, AFT should return the flattened next-hop instead of the direct next-hop. 