### PR TITLE
Add support for SFP28 and SFP56 form factor identities

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
+
+  revision "2022-09-26" {
+    description
+      "Add SFP28 and SFP56 form factor identities.";
+    reference "0.16.0";
+  }
 
   revision "2021-07-29" {
     description
@@ -827,6 +833,20 @@ module openconfig-transport-types {
     description
       "Enhanced small form-factor pluggable transceiver supporting
       up to 16 Gb/s signals, including 10 GbE and OTU2";
+  }
+
+  identity SFP28 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      25 Gb/s signal";
+  }
+
+  identity SFP56 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      50 Gb/s signal";
   }
 
   identity XFP {


### PR DESCRIPTION
SFP28 and SFP56 transceiver form factor identities are missing from
OpenConfig.

The successor of #562, which I had to close because I based the PR on the master branch.