### PR TITLE
MAC-VRF and L2 fdb/l2rib mac-table and mac-ip-table lists corrections

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -5,12 +5,12 @@ submodule openconfig-network-instance-l2 {
   }
 
   // import some basic types
-  import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-interfaces { prefix "oc-if"; }
-  import ietf-yang-types { prefix "yang"; }
-  import ietf-inet-types { prefix "inet"; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-inet-types { prefix oc-inet; }
   import openconfig-evpn-types { prefix oc-evpn-types; }
-  import openconfig-evpn { prefix "oc-evpn"; }
+  import openconfig-evpn { prefix oc-evpn; }
 
   // meta
   organization "OpenConfig working group";
@@ -24,7 +24,15 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.3.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-08-10" {
+    description
+      "Add VLAN as key to mac-table and mac-ip-table under fdb/l2rib and allow
+      fdb hierarchy for MAC_VRF network-instance type. Correct yang/inet types
+      to use OpenConfig types.";
+    reference "2.0.0";
+  }
 
   revision "2022-07-04" {
     description
@@ -313,7 +321,7 @@ submodule openconfig-network-instance-l2 {
       "Configuration data for MAC table entries";
 
     leaf mac-address {
-      type yang:mac-address;
+      type oc-yang:mac-address;
       description
         "MAC address for the dynamic or static MAC table
         entry";
@@ -453,14 +461,25 @@ submodule openconfig-network-instance-l2 {
             "Enclosing container for list of MAC address entries";
 
           list entry {
-            key "mac-address";
+            key "mac-address vlan";
             description "List of learned MAC addresses";
 
             leaf mac-address {
               type leafref {
                 path "../state/mac-address";
               }
-              description "Leafref of MAC address object";
+              description
+                "Reference to the MAC address associated with the
+                mac-table entry.";
+            }
+
+            leaf vlan {
+              type leafref {
+                path "../state/vlan";
+              }
+              description
+                "Reference to the VLAN ID associated with the mac-table
+                entry.";
             }
 
             container state {
@@ -508,21 +527,34 @@ submodule openconfig-network-instance-l2 {
             "Enclosing container for list of MAC-IP address entries";
 
           list entry {
-            key "mac-address host-ip";
+            key "mac-address host-ip vlan";
             description "List of learned MAC-IP addresses";
 
             leaf mac-address {
               type leafref {
                 path "../state/mac-address";
               }
-              description "Leafref of MAC-IP address object";
+              description
+                "Reference to the MAC address associated with the
+                mac-ip-table entry.";
             }
 
             leaf host-ip {
               type leafref {
                 path "../state/host-ip";
               }
-              description "IP address of the Customer Edge device";
+              description
+                "Reference to the IP address of the Customer Edge Device
+                associated with the mac-ip-table entry.";
+            }
+
+            leaf vlan {
+              type leafref {
+                path "../state/vlan";
+              }
+              description
+                "Reference to the VLAN ID associated with the mac-ip-table
+                entry.";
             }
 
             container state {
@@ -571,7 +603,7 @@ submodule openconfig-network-instance-l2 {
     uses l2ni-l2rib-common-state;
 
     leaf host-ip {
-      type inet:ip-address;
+      type oc-inet:ip-address;
       description
         "Host IP address of the CE device for the L2RIB MAC-IP entry";
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
@@ -593,7 +625,7 @@ submodule openconfig-network-instance-l2 {
     description "L2RIB Common Property Operational State Data Grouping";
 
     leaf mac-address {
-        type yang:mac-address;
+        type oc-yang:mac-address;
         description "MAC address of the L2RIB MAC or MAC-IP entry";
     }
     leaf vlan {
@@ -700,7 +732,7 @@ submodule openconfig-network-instance-l2 {
             description "A unique entry for the next-hop.";
           }
           leaf peer-ip {
-            type inet:ip-address;
+            type oc-inet:ip-address;
             description "Next hop peer address";
           }
           leaf label {

--- a/release/models/network-instance/openconfig-network-instance-types.yang
+++ b/release/models/network-instance/openconfig-network-instance-types.yang
@@ -19,7 +19,13 @@ module openconfig-network-instance-types {
   description
     "Types associated with a network instance";
 
-  oc-ext:openconfig-version "0.9.3";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2022-08-10" {
+    description
+      "Add MAC_VRF network-instance type.";
+    reference "0.10.0";
+  }
 
   revision "2021-07-14" {
     description
@@ -173,6 +179,12 @@ module openconfig-network-instance-types {
     base NETWORK_INSTANCE_TYPE;
     description
       "A private Layer 2 and Layer 3 forwarding instance";
+  }
+
+  identity MAC_VRF {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A MAC-VRF forwarding instance";
   }
 
   identity ENDPOINT_TYPE {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,15 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.3.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-08-10" {
+    description
+       "Add VLAN as key to mac-table and mac-ip-table under fdb/l2rib and allow
+       fdb hierarchy for MAC_VRF network-instance type. Correct yang/inet types
+       to use OpenConfig types.";
+    reference "2.0.0";
+  }
 
   revision "2022-07-04" {
     description
@@ -295,6 +303,7 @@ module openconfig-network-instance {
             when "./config/type = 'oc-ni-types:L2VSI'
                   or ./config/type = 'oc-ni-types:L2P2P'
                   or ./config/type = 'oc-ni-types:L2L3'
+                  or ./config/type = 'oc-ni-types:MAC_VRF'
                   or ./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
                   description
                     "Layer 2 configuration parameters included when


### PR DESCRIPTION
* (M) release/models/network-instance/openconfig-network-instance.yang
* (M) release/models/network-instance/openconfig-network-instance-types.yang
    - Add support for MAC_VRF network-instance type
    - Permit fdb hierarchy for the MAC_VRF instance type
* (M) release/models/network-instance/openconfig-network-instance-l2.yang
    - Refactor L2 fdb/l2rib mac-table and mac-ip-table lists to have vlan in their key
    - Correct types imports to use OpenConfig types vs. IETF types

Per previous PR https://github.com/openconfig/public/pull/527 and the comments in https://github.com/openconfig/public/pull/527#pullrequestreview-891658236, there was an initial proposal to have vlan as part of  the key list for l2rib's mac-ip-table and mac-table entries. However it was reverted per the comments listed above prior to merge.

First, it is generally not the intention that a VLAN maps to a network-instance 1:1 in all cases as suggested in the comments and carried in the network-instance name.  Per RFC7432, there can be 'VLAN-Based Service Interfaces' (Section 6.1) and 'VLAN-Aware Bundle Service Interfaces' (Section 6.3).  In order to support both, the model structure actually does need to encompass a VLAN as key in addition to a mac-address and host-ip into the mac-ip-table list as well as in addition to mac-address in mac-table list much like how the fdb/mac-table is constructed.  Leaving this omitted is a shortfall of the model and the model cannot represent > 1 VLAN per network-instance.

In addition, a new network-instance type of `MAC_VRF` has been introduced to distinguish between other L2 instance types that already map to existing L2 instance types among implementations.

References:

* https://datatracker.ietf.org/doc/html/rfc7432#section-6.1
* https://datatracker.ietf.org/doc/html/rfc7432#section-6.3