### PR TITLE
Add update-generation container in bgp global

### DIFF
--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description
@@ -370,6 +376,20 @@ submodule openconfig-bgp-global {
     }
   }
 
+  grouping bgp-global-update-generation-config {
+    description
+      "Configuration options relating to update message generation
+      for the BGP router";
+
+    leaf wait-fib-install {
+      type boolean;
+      default "false";
+      description
+        "Advertisement will be postponed until route is programmed
+        in the FIB";
+    }
+  }
+
   // Structural groupings
   grouping bgp-global-base {
     description
@@ -452,6 +472,20 @@ submodule openconfig-bgp-global {
     }
 
     uses bgp-global-dynamic-neighbors;
-  }
 
+    container update-generation {
+       description
+         "Parameters relating the update message generation for BGP";
+       container config {
+         description
+           "Configuration parameter relating to update message generation";
+         uses bgp-global-update-generation-config;
+       }
+       container state {
+         config false;
+         description
+           "State information associated with update message generation";
+         uses bgp-global-update-generation-config;
+       }
+    }
 }

--- a/release/models/platform/.spec.yml
+++ b/release/models/platform/.spec.yml
@@ -11,8 +11,10 @@
     - yang/platform/openconfig-platform-cpu.yang
     - yang/platform/openconfig-platform-ext.yang
     - yang/platform/openconfig-platform-software.yang
+    - yang/platform/openconfig-platform-fabric.yang
     - yang/platform/openconfig-platform-pipeline-counters.yang
     - yang/platform/openconfig-platform-integrated-circuit.yang
+    - yang/platform/openconfig-platform-controller-card.yang
   build:
     - yang/platform/openconfig-platform.yang
     - yang/platform/openconfig-platform-common.yang
@@ -24,6 +26,8 @@
     - yang/platform/openconfig-platform-ext.yang
     - yang/platform/openconfig-platform-cpu.yang
     - yang/platform/openconfig-platform-software.yang
+    - yang/platform/openconfig-platform-fabric.yang
     - yang/platform/openconfig-platform-pipeline-counters.yang
     - yang/platform/openconfig-platform-integrated-circuit.yang
+    - yang/platform/openconfig-platform-controller-card.yang
   run-ci: true

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -6,6 +6,7 @@ submodule openconfig-platform-common {
     prefix "oc-platform";
   }
 
+  import openconfig-platform-types { prefix oc-platform-types; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-types { prefix oc-types; }
 
@@ -19,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.18.0";
+  oc-ext:openconfig-version "0.19.0";
+
+  revision "2022-07-28" {
+    description
+      "Add grouping for component power management";
+    reference "0.19.0";
+  }
 
   revision "2022-07-11" {
     description
@@ -146,6 +153,18 @@ submodule openconfig-platform-common {
       type oc-types:timeticks64;
       description
         "The time when the high-watermark was last updated";
+    }
+  }
+
+  grouping component-power-management {
+    description
+      "Common grouping for managing component power";
+
+    leaf power-admin-state {
+      type oc-platform-types:component-power-type;
+      default POWER_ENABLED;
+      description
+        "Enable or disable power to the component";
     }
   }
 

--- a/release/models/platform/openconfig-platform-controller-card.yang
+++ b/release/models/platform/openconfig-platform-controller-card.yang
@@ -1,0 +1,81 @@
+module openconfig-platform-controller-card {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/controller-card";
+
+  prefix "oc-ctrl-card";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to CONTROLLER_CARD components in
+    the openconfig-platform model";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-07-28" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping controller-card-config {
+    description
+      "Configuration data for controller card components";
+
+    uses oc-platform:component-power-management;
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:controller-card/oc-platform:config" {
+    description
+      "Adding controller card data to physical inventory. This subtree
+      is only valid when the type of the component is CONTROLLER_CARD.";
+
+    uses controller-card-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:controller-card/oc-platform:state" {
+    description
+      "Adding controller card data to physical inventory. This subtree
+      is only valid when the type of the component is CONTROLLER_CARD.";
+
+    uses controller-card-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/release/models/platform/openconfig-platform-fabric.yang
+++ b/release/models/platform/openconfig-platform-fabric.yang
@@ -1,0 +1,81 @@
+module openconfig-platform-fabric {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/fabric";
+
+  prefix "oc-fabric";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to FABRIC components in
+    the openconfig-platform model";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-07-28" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping fabric-config {
+    description
+      "Configuration data for fabric components";
+
+    uses oc-platform:component-power-management;
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:fabric/oc-platform:config" {
+    description
+      "Adding fabric data to physical inventory. This subtree
+      is only valid when the type of the component is FABRIC.";
+
+    uses fabric-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:fabric/oc-platform:state" {
+    description
+      "Adding fabric data to physical inventory. This subtree
+      is only valid when the type of the component is FABRIC.";
+
+    uses fabric-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/release/models/platform/openconfig-platform-linecard.yang
+++ b/release/models/platform/openconfig-platform-linecard.yang
@@ -8,7 +8,6 @@ module openconfig-platform-linecard {
   prefix "oc-linecard";
 
   import openconfig-platform { prefix oc-platform; }
-  import openconfig-platform-types { prefix oc-platform-types; }
   import openconfig-extensions { prefix oc-ext; }
 
 
@@ -23,7 +22,14 @@ module openconfig-platform-linecard {
     "This module defines data related to LINECARD components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-28" {
+    description
+      "Remove leaf power-admin-state and use a common definition
+      instead.";
+    reference "1.0.0";
+  }
 
   revision "2022-04-21" {
     description
@@ -69,12 +75,7 @@ module openconfig-platform-linecard {
     description
       "Configuration data for linecard components";
 
-    leaf power-admin-state {
-      type oc-platform-types:component-power-type;
-      default POWER_ENABLED;
-      description
-        "Enable or disable power to the linecard";
-    }
+    uses oc-platform:component-power-management;
   }
 
   grouping linecard-state {

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.5.0";
+
+  revision "2022-07-28" {
+    description
+      "Add grouping for component power management";
+    reference "1.5.0";
+  }
 
   revision "2022-03-27" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.18.0";
+  oc-ext:openconfig-version "0.19.0";
+
+  revision "2022-07-28" {
+    description
+      "Add container for controller card component";
+    reference "0.19.0";
+  }
 
   revision "2022-07-11" {
     description
@@ -1062,6 +1068,25 @@ module openconfig-platform {
         config false;
         description
           "Operational state data for software module components";
+      }
+    }
+
+    container controller-card {
+      description
+        "Data for controller card components, i.e., for components
+        with type=CONTROLLER_CARD";
+
+      container config {
+        description
+          "Configuration data for controller card components. Note that disabling
+          power to the primary supervisor should be rejected, and the operator is
+          required to perform a switchover first.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for controller card components";
       }
     }
   }


### PR DESCRIPTION
Added a new container update-generation to configure update
generation message parameters under bgp global. update-generation
conatiner have one leaf wait-fib-install of boolean type and
default value as false. wait-fib-install is used to postpone the
route advertisment untill installed in FIB.