### PR TITLE
Add update-generation container in bgp global

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description
@@ -370,6 +376,19 @@ submodule openconfig-bgp-global {
     }
   }
 
+  grouping bgp-global-update-generation-config {
+    description
+      "Configuration options relating to update message generation
+      for the BGP router";
+
+    leaf wait-fib-install {
+      type boolean;
+      default "false";
+      description
+        "Advertisement will be postponed until route is programmed
+        in the FIB";
+    }
+  }
   // Structural groupings
   grouping bgp-global-base {
     description
@@ -452,6 +471,21 @@ submodule openconfig-bgp-global {
     }
 
     uses bgp-global-dynamic-neighbors;
-  }
 
+    container update-generation {
+      description
+        "Parameters relating the update message generation for BGP";
+      container config {
+        description
+          "Configuration parameter relating to update message generation";
+        uses bgp-global-update-generation-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with update message generation";
+        uses bgp-global-update-generation-config;
+      }
+    }
+ }
 }

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -67,7 +67,7 @@ module openconfig-bgp {
       "Added update generation support.";
     reference "9.2.0";
   }
- 
+
   revision "2022-05-21" {
     description
       "Added extended-next-hop-encoding leaf.";

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -60,8 +60,14 @@ module openconfig-bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
 
+  revision "2022-08-30" {
+    description
+      "Added update generation support.";
+    reference "9.2.0";
+  }
+ 
   revision "2022-05-21" {
     description
       "Added extended-next-hop-encoding leaf.";


### PR DESCRIPTION
Added a new container update-generation to configure update
generation message parameters under bgp global. update-generation
conatiner have one leaf wait-fib-install of boolean type and
default value as false. wait-fib-install is used to postpone the
route advertisment untill installed in FIB.