### PR TITLE
CLEI-code - second attempt

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.19.0";
+  oc-ext:openconfig-version "0.20.0";
+
+  revision "2022-08-31" {
+    description
+      "Add new state data for component CLEI code.";
+    reference "0.20.0";
+  }
 
   revision "2022-07-28" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.19.0";
+  oc-ext:openconfig-version "0.20.0";
+
+  revision "2022-08-31" {
+    description
+      "Add new state data for component CLEI code.";
+    reference "0.20.0";
+  }
 
   revision "2022-07-28" {
     description
@@ -430,6 +436,14 @@ module openconfig-platform {
         "System-assigned part number for the component.  This should
         be present in particular if the component is also an FRU
         (field replaceable unit)";
+    }
+
+    leaf clei-code {
+      type string;
+      description
+        "Common Language Equipment Identifier (CLEI) code of the
+        component.  This should be present in particular if the
+        component is also an FRU (field replaceable unit)";
     }
 
     leaf removable {


### PR DESCRIPTION
This is a carryover of https://github.com/openconfig/public/pull/628 which was left outstanding too long. There are no changes from that other than it is using an up to date branch that isn't causing issues :)


Most (if not all) optical platforms support CLEI codes. A couple references:
Cisco: https://www.cisco.com/c/en/us/support/docs/optical-networking/ons-15454-sonet-multiservice-provisioning-platform-mspp/46247-15454-cleicodes.html
Nokia: https://documentation.nokia.com/html/365-372-324R10.0/index.html?i=365-372-324R10.0-qzx79

