### PR TITLE
Adding control over sending of IS-IS CSNP packets on P2P interfaces. …

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2022-09-19" {
+    description
+      "Added control for disabling periodic CSNPs on P2P interfaces.";
+    reference "1.0.1";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2022-09-19" {
+    description
+      "Added control for disabling periodic CSNPs on P2P interfaces.";
+    reference "1.0.1";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -261,6 +261,13 @@ module openconfig-isis {
       description
         "Controls the padding type for IS-IS Hello PDUs on a global level.";
     }
+
+    leaf enable-csnp-on-p2p-links {
+      description
+        "Enable/disable the transmission of periodic CSNP PDUs on point-to-point interfaces. When this is set to false, CSNP PDUs will only be sent on a P2P interface when the adjacency is initialized. This setting has no effect on broadcast interfaces.";
+      type boolean;
+      default true;
+    }
   }
 
   grouping admin-config {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2022-09-19" {
+    description
+      "Added control for disabling periodic CSNPs on P2P interfaces.";
+    reference "1.0.1";
+  }
 
   revision "2022-05-10" {
     description


### PR DESCRIPTION
Change Scope
Strictly speaking it is not necessary to send periodic CSNP PDUs on point-to-point interfaces (i.e. after the adjacency has been established). Some implementations support a configuration option to disable these periodic transmissions, to save resources. This change introduces a new leaf to support this configuration option.

Platform Implementations
To be provided