### PR TITLE
Add next-hop-group/next-hop-group-network-instance to network-instance's spec files

### DIFF
--- a/release/models/network-instance/.spec.yml
+++ b/release/models/network-instance/.spec.yml
@@ -4,11 +4,12 @@
     - yang/network-instance/openconfig-network-instance.yang
     - yang/network-instance/openconfig-evpn-types.yang
     - yang/network-instance/openconfig-evpn.yang
+    - yang/aft/openconfig-aft-network-instance.yang
   build:
     - yang/network-instance/openconfig-network-instance.yang
+    - yang/aft/openconfig-aft-network-instance.yang
   run-ci: true
 - name: openconfig-network-instance-bgp-rib-augment
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/rib/openconfig-rib-bgp-ext.yang
-    - yang/aft/openconfig-aft-network-instance.yang

--- a/release/models/network-instance/.spec.yml
+++ b/release/models/network-instance/.spec.yml
@@ -11,3 +11,4 @@
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/rib/openconfig-rib-bgp-ext.yang
+    - yang/aft/openconfig-aft-network-instance.yang


### PR DESCRIPTION
Currently they don't show up in the [documentation](https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-network-instance.html), but they should be there.