### PR TITLE
[WiFi] Split phy-rate into rx/tx pay-rate leaves

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,13 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.1";
-
-  revision "2022-09-13" {
-    description
-      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
-    reference "1.1.1";
-  }
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description
@@ -1356,16 +1350,10 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf rx-phy-rate {
+      leaf phy-rate {
         type uint16;
         description
-          "Last used PHY rate received from connected client.";
-      }
-
-      leaf tx-phy-rate {
-        type uint16;
-        description
-          "Last used PHY rate transmitted to connected client.";
+          "Last used PHY rate of connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,12 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.2.0";
 
-  revision "2022-09-13" {
+  revision "2023-01-17" {
     description
-      "Splits client phy-rate leaf into rx/tx phy-rate leaves.";
-    reference "2.0.0";
+      "Splits client phy-rate leaf into rx/tx phy-rate leaves.  Marks phy-rate
+      as deprecated.";
+    reference "1.2.0";
   }
 
   revision "2022-03-24" {
@@ -1354,6 +1355,13 @@ module openconfig-wifi-mac {
         type uint8;
         description
           "Number of Spatial Streams supported by the client.";
+      }
+
+      leaf phy-rate {
+        type uint16;
+        status deprecated;
+        description
+          "Last used PHY rate of connected client.";
       }
 
       leaf rx-phy-rate {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.1.1";
+
+  revision "2022-09-13" {
+    description
+      "Splits client phy-rate leaf into rx/tx phy-rate leaves.";
+    reference "1.1.1";
+  }
 
   revision "2022-03-24" {
     description
@@ -1350,10 +1356,16 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf phy-rate {
+      leaf rx-phy-rate {
         type uint16;
         description
-          "Last used PHY rate of connected client.";
+          "Last used PHY rate received from connected client.";
+      }
+
+      leaf tx-phy-rate {
+        type uint16;
+        description
+          "Last used PHY rate transmitted to connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.1.1";
+
+  revision "2022-09-13" {
+    description
+      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
+    reference "1.1.1";
+  }
 
   revision "2022-03-24" {
     description
@@ -1350,10 +1356,16 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf phy-rate {
+      leaf rx-phy-rate {
         type uint16;
         description
-          "Last used PHY rate of connected client.";
+          "Last used PHY rate received from connected client.";
+      }
+
+      leaf tx-phy-rate {
+        type uint16;
+        description
+          "Last used PHY rate transmitted to connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,12 +26,12 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.1";
+  oc-ext:openconfig-version "2.0.0";
 
   revision "2022-09-13" {
     description
       "Splits client phy-rate leaf into rx/tx phy-rate leaves.";
-    reference "1.1.1";
+    reference "2.0.0";
   }
 
   revision "2022-03-24" {


### PR DESCRIPTION
Source: https://github.com/openconfig/public/blob/c28f23731fe0d7b5816746bccef1efa25075b36a/release/models/wifi/openconfig-wifi-mac.yang#L1292

"Last used PHY rate of connected client."

Prescribed intent: Last used PHY rate based on frames received by the AP from client.

Vendor interpretations
Arista
TBD: Unimplemented, asking for clarification on which value to use

Aruba
“The rate used by the AP to transmit the most recent 802.11 data frame to the specific client at the last sample time.”

Problem(s)
Model does not specify how the PHY rate is formed, from frames received or transmitted by the AP to/from a client.  When asked to support this leaf, Arista asked for clarification but assumed received phy-rate would be the right value to use, which would have been different from Aruba’s implementation.  

User Case
Identify AVG phy rates in one, or both, directions used by clients. This will help with identifying link health; ie whether a client is typically utilizing low MCS rates, while other clients in the area are high, given the same SNR.

Solution
Both are important for debug purposes of downlink vs uplink issues, the leaf should be split into both receive and transmit phy-rate.
