### PR TITLE
[WiFi] Update channel utilization leafs

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,13 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.1";
-
-  revision "2022-09-13" {
-    description
-      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
-    reference "1.1.1";
-  }
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description
@@ -1356,16 +1350,10 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf rx-phy-rate {
+      leaf phy-rate {
         type uint16;
         description
-          "Last used PHY rate received from connected client.";
-      }
-
-      leaf tx-phy-rate {
-        type uint16;
-        description
-          "Last used PHY rate transmitted to connected client.";
+          "Last used PHY rate of connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.1.1";
+
+  revision "2022-09-13" {
+    description
+      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
+    reference "1.1.1";
+  }
 
   revision "2022-03-24" {
     description
@@ -1350,10 +1356,16 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf phy-rate {
+      leaf rx-phy-rate {
         type uint16;
         description
-          "Last used PHY rate of connected client.";
+          "Last used PHY rate received from connected client.";
+      }
+
+      leaf tx-phy-rate {
+        type uint16;
+        description
+          "Last used PHY rate transmitted to connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -25,7 +25,13 @@ module openconfig-wifi-phy {
   description
     "Model for managing PHY layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2022-09-16" {
+    description
+      "Adds obss-rx and clarifies language on rx-dot11-channel-utilization.";
+    reference "1.2.0";
+  }
 
   revision "2022-03-24" {
     description
@@ -306,13 +312,14 @@ module openconfig-wifi-phy {
         Radio. The total channel utilization should include all time
         periods the AP spent actively receiving and transmitting
         802.11 frames, and also include all time spent with clear
-        channel assessment (CCA) in a busy state";
+        channel assessment (CCA) in a busy state.";
     }
 
     leaf rx-dot11-channel-utilization {
       type oc-types:percentage;
       description
-        "Received channel-utilization due to 802.11 frames";
+        "Received channel-utilization due to any 802.11 frames, destined to this
+        radio or otherwise.";
     }
 
     leaf rx-noise-channel-utilization {
@@ -325,6 +332,13 @@ module openconfig-wifi-phy {
       type oc-types:percentage;
       description
         "Transmit channel-utilization percentage.";
+    }
+
+    leaf obss-rx {
+      type oc-types:percentage;
+      description
+        "Received channel utilization due to 802.11 frames NOT destined to a
+        BSS on this AP ('Overlapping BSS')";
     }
   }
 


### PR DESCRIPTION
<b id="docs-internal-guid-e35055f4-7fff-6dc7-f251-c5cc1494a559" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; font-weight: normal;"><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Source: </span><a href="https://github.com/openconfig/public/blob/c28f23731fe0d7b5816746bccef1efa25075b36a/release/models/wifi/openconfig-wifi-phy.yang#L306" style="text-decoration: none;"><span style="font-size: 11pt; font-family: Arial; color: rgb(17, 85, 204); background-color: rgb(255, 255, 255); font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: underline; text-decoration-skip-ink: none; vertical-align: baseline; white-space: pre-wrap;">https://github.com/openconfig/public/blob/c28f23731fe0d7b5816746bccef1efa25075b36a/release/models/wifi/openconfig-wifi-phy.yang#L306</span></a></p><br><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">“Received channel-utilization due to 802.11 frames”.  </span></p><br><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Prescribed intent: Percent of time AP spent processing .11 frames received. or overheard, destined to this AP or otherwise.</span></p><br><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 700; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Vendor interpretations</span></p><div dir="ltr" align="left" style="margin-left: 0pt;">

Arista | .11 frames destined to AP
-- | --
Aruba | “the percentage of time AP spent during the last beacon interval processing 802.11 frames that the AP received or overheard, whether destined for this AP or not.”

</div></b>

<b id="docs-internal-guid-604b3ed8-7fff-b7d0-e411-dd446f364a16" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; font-weight: normal;"><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 700; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Problem(s)</span></p><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Because Arista does not account for .11 frames not destined to it (OBSS RX), and Aruba does; it creates the following inconsistency: </span></p><br><div dir="ltr" align="left" style="margin-left: 0pt;">

Arista | (rx-dot11… + tx-dot11…+ rx-noise…) < total-channel-utilization
-- | --
Aruba | (rx-dot11… + tx-dot11…+ rx-noise…) = total-channel-utilization

</div><br><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">In addition, this means we are unable to calculate OBSS RX for Aruba since it is included in rx-dot11-channel-utilization.  With Arista we can calculate OBSS RX as the remaining value that makes up total-channel-utilization.</span></p><br><p dir="ltr" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 700; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Use Cases</span></p><ol style="margin-top: 0px; margin-bottom: 0px; padding-inline-start: 48px;"><li dir="ltr" aria-level="1" style="list-style-type: decimal; font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre;"><p dir="ltr" role="presentation" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Identify Rogue-induced dot11 channel utilization.</span></p></li><li dir="ltr" aria-level="1" style="list-style-type: decimal; font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre;"><p dir="ltr" role="presentation" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Identify our own infrastructure-induced dot11 channel utilization.</span></p></li><li dir="ltr" aria-level="1" style="list-style-type: decimal; font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre;"><p dir="ltr" role="presentation" style="line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt;"><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">Identify CCI, be it our own or via Rogues, occurring on the AP.</span><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;"><br><br></span></p></li></ol><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">If Arista includes OBSS-RX in rx-dot11-channel-utilization, then OBSS-RX by itself could be calculated </span><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 700; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;">if</span><span style="font-size: 11pt; font-family: Arial; color: rgb(0, 0, 0); background-color: transparent; font-weight: 400; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-variant-east-asian: normal; font-variant-position: normal; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;"> the vendor supports the per-bss counters rx-bss-dot11-channel-utilization. eg.,</span></b>

`rx-dot11-cu (assuming Aruba interpretation above) - sum(all BSS RX CU) = OBSS RX CU`

It would be up to the telemetry collector to make the correlation of which BSSIDs are part of the same radio and produce this value.  This integration tends to be cumbersome and could also be problematic in the event where all values are not collected from the same timeframe, due to problems with one part of the tree but not the other, or different subscription modes/intervals.  Due to this, a specific OBSS-RX leaf at the radio level is ideal.

Solution (do all three)
* Update verbiage in the model to be more explicit
* Add leaf for OBSS-RX at the radio level and ask vendors to support it
* Arista to include OBSS-RX in rx-dot11-channel-utilization


