### PR TITLE
Add @dplore as a default CODEOWNER for openconfig/public files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Definition of code OWNERS for the openconfig/public repository.
 #
 # default approvers:
-* @aashaikh @robshakir 
+* @aashaikh @robshakir @dplore
 
 # the release/models directory (all YANG content)
 # is maintained by the public-writers OpenConfig team. 


### PR DESCRIPTION
```
﻿ * (M) .github/CODEOWNERS
  - Public model writers do not have +rw for files outside of release/models.
    Add Darren Loher as a primary codeowner to expand this approval scope.
```

See PR #689 for a case where the current approvals are not sufficient for @dplore to approve changes.
