### PR TITLE
Remove ISIS instance leaf

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-09-20" {
+    description
+      "Remove ISIS instance leaf in favor of network-instance protocol
+      instance.";
+    reference "2.0.0";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,14 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-09-20" {
+    description
+      "Remove ISIS instance leaf in favor of network-instance protocol
+      instance.";
+    reference "2.0.0";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,14 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-09-20" {
+    description
+      "Remove ISIS instance leaf in favor of network-instance protocol
+      instance.";
+    reference "2.0.0";
+  }
 
   revision "2022-05-10" {
     description
@@ -187,14 +194,6 @@ module openconfig-isis {
   grouping isis-global-config {
     description
       "This grouping defines global configuration options for ISIS router.";
-
-    // multi-instance
-    leaf instance {
-      type string;
-      default 0;
-      description
-        "ISIS Instance.";
-    }
 
     leaf-list net {
       type oc-isis-types:net;


### PR DESCRIPTION
  * (M) release/models/isis/openconfig-isis-lsp.yang
  * (M) release/models/isis/openconfig-isis-routing.yang
  * (M) release/models/isis/openconfig-isis.yang
    - Remove ISIS instance leaf in favor of network-instance protocol
      instance name

### Change Scope

It appears that when `/isis` was relocated under `/network-instances`, while we
inherit the concept of multiple protocol instances by way of the `protocol`
list, that the ISIS domain retained the concept of multi-instance within making
the concept redundant and ambiguous.

This change removes the leaf `instance` within the ISIS domain in favor of the
protocol instance `name` to signal multi-instance support of a protocol.

Per YANG standards, this change is backwards incompatible but also highly
unlikely implementations have supported such due to the ambiguity.  The major
version has thus been updated as a result.

### Platform Implementations

N/A: This change is to resolve ambiguity in the modeling and multi-instance
support is still intact per the protocol list name.
