### PR TITLE
[WiFi] Replace uptime counter with timestamp

### DIFF
--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -13,6 +13,7 @@ module openconfig-ap-manager {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-wifi-types { prefix oc-wifi; }
+  import openconfig-types { prefix oc-types; }
 
   // Meta
   organization "OpenConfig working group";
@@ -25,7 +26,13 @@ module openconfig-ap-manager {
     "This module defines the top level configuration and state data for a
     system which manages Access Points.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-09-20" {
+    description
+      "Replace uptime counter with up-time oc-types:timeticks64 timestamp.";
+    reference "2.0.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -132,11 +139,13 @@ module openconfig-ap-manager {
         "The current operational state of the AP.";
     }
 
-    leaf uptime {
-      type uint32;
-      units seconds;
+    leaf up-time {
+      type oc-types:timeticks64;
+      units nanoseconds;
       description
-        "Seconds this AP has been in the op-state of 'UP'.";
+        "Timestamp when this AP last changed its op-state to 'UP'. The value is
+        the timestamp in nanoseconds relative to the Unix Epoch (Jan 1, 1970
+        00:00:00 UTC).";
     }
 
     leaf enabled {

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -26,7 +26,7 @@ module openconfig-ap-manager {
     "This module defines the top level configuration and state data for a
     system which manages Access Points.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.3.0";
 
   revision "2023-01-17" {
     description

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -32,7 +32,7 @@ module openconfig-ap-manager {
     description
       "Replace uptime counter with up-time oc-types:timeticks64 timestamp. Sets
       uptime leaf to deprecated.";
-    reference "2.0.0";
+    reference "1.3.0";
   }
 
   revision "2022-05-24" {

--- a/release/models/wifi/openconfig-ap-manager.yang
+++ b/release/models/wifi/openconfig-ap-manager.yang
@@ -28,9 +28,10 @@ module openconfig-ap-manager {
 
   oc-ext:openconfig-version "2.0.0";
 
-  revision "2022-09-20" {
+  revision "2023-01-17" {
     description
-      "Replace uptime counter with up-time oc-types:timeticks64 timestamp.";
+      "Replace uptime counter with up-time oc-types:timeticks64 timestamp. Sets
+      uptime leaf to deprecated.";
     reference "2.0.0";
   }
 
@@ -146,6 +147,14 @@ module openconfig-ap-manager {
         "Timestamp when this AP last changed its op-state to 'UP'. The value is
         the timestamp in nanoseconds relative to the Unix Epoch (Jan 1, 1970
         00:00:00 UTC).";
+    }
+
+    leaf uptime {
+      type uint32;
+      units seconds;
+      status deprecated;
+      description
+        "Seconds this AP has been in the op-state of 'UP'.";
     }
 
     leaf enabled {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,13 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.1";
-
-  revision "2022-09-13" {
-    description
-      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
-    reference "1.1.1";
-  }
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2022-03-24" {
     description
@@ -1356,16 +1350,10 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf rx-phy-rate {
+      leaf phy-rate {
         type uint16;
         description
-          "Last used PHY rate received from connected client.";
-      }
-
-      leaf tx-phy-rate {
-        type uint16;
-        description
-          "Last used PHY rate transmitted to connected client.";
+          "Last used PHY rate of connected client.";
       }
 
       leaf connection-mode {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.1.1";
+
+  revision "2022-09-13" {
+    description
+      "Split the client phy-rate leaf into separate rx/tx phy-rate leaves.";
+    reference "1.1.1";
+  }
 
   revision "2022-03-24" {
     description
@@ -1350,10 +1356,16 @@ module openconfig-wifi-mac {
           "Number of Spatial Streams supported by the client.";
       }
 
-      leaf phy-rate {
+      leaf rx-phy-rate {
         type uint16;
         description
-          "Last used PHY rate of connected client.";
+          "Last used PHY rate received from connected client.";
+      }
+
+      leaf tx-phy-rate {
+        type uint16;
+        description
+          "Last used PHY rate transmitted to connected client.";
       }
 
       leaf connection-mode {


### PR DESCRIPTION
### Change Scope

This changes the leaf "uptime" under openconfig-ap-manager.yang from a uint32 counter to a new leaf of "up-time" which will be a timeticks64.  This is to make telemetry ingestion less churn heavy.  The intent of the leaf does not change.

This change is not backwards compatible as a leaf is replaced.

### Platform Implementations

oc-types:timeticks64 is used throughout other models and it should be trivial to implement.  
