### PR TITLE
Add csnp-enable-on-p2p-links leaf to IS-IS global configuration.

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+    revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
 
   revision "2022-05-10" {
     description
@@ -253,6 +259,13 @@ module openconfig-isis {
       description
         "When set to true, IS will always flood the LSP that triggered an SPF
      before the router actually runs the SPF computation.";
+    }
+
+    leaf csnp-enable-on-p2p-links {
+      type boolean;
+      default true;
+      description
+        "When set to true, ISIS will always enable CSNP on P2P Links.";
     }
 
     leaf hello-padding {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -263,7 +263,7 @@ module openconfig-isis {
 
     leaf csnp-enable-on-p2p-links {
       type boolean;
-      default false;
+      default true;
       description
         "When set to true, ISIS will always enable CSNP on P2P Links.";
     }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -263,7 +263,7 @@ module openconfig-isis {
 
     leaf csnp-enable-on-p2p-links {
       type boolean;
-      default true;
+      default false;
       description
         "When set to true, ISIS will always enable CSNP on P2P Links.";
     }


### PR DESCRIPTION

### Original Problem

We need to be able to disable CSNP on a global level. This requires specifying csnp enable/disable for p2p links at global IS-IS configuration. 

### Proposed Solution
 Add a csnp-enable-on-p2p-links leaf of type boolean  to isis-global-config, set to false by default.

References:

All these references, indicating configuring the interval at an interface level. This model aims at globally enabling/disabling csnp.

Arista:
https://www.arista.com/zh/support/toi/eos-4-27-0f/14859-is-is-csnp-generation-interval

Juniper:
https://www.juniper.net/documentation/us/en/software/junos/is-is/topics/example/isis-csnp-interval.html

Cisco:
https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/iproute_isis/command/irs-cr-book/irs-a1.html#wp1741698451
