### PR TITLE
Add ETH_400GBASE_PSM4 PMD type to openconfig-transport-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository is primarily for publishing the models, documents, and other
 material developed by the OpenConfig operators group.
 
 For information about how to contribute to OpenConfig models, please
-see [External Submissions to OpenConfig](doc/external-contributions-guide.md).
+see [External Submissions to OpenConfig](doc/contributions-guide.md).
 
 Feedback and suggestions to improve OpenConfig models is welcomed on the
 [public mailing list](https://groups.google.com/forum/?hl=en#!forum/netopenconfig),

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -24,9 +24,9 @@ module openconfig-transport-types {
 
   oc-ext:openconfig-version "0.16.0";
 
-  revision "2022-09-20" {
+  revision "2022-10-18" {
     description
-      "Add ETH_400GBASE_PSM4 PMD type";
+      "Add ETH_400GMSA_PSM4 PMD type";
     reference "0.16.0";
   }
 
@@ -1050,9 +1050,9 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 400GBASE_DR4";
   }
 
-  identity ETH_400GBASE_PSM4 {
+  identity ETH_400GMSA_PSM4 {
     base ETHERNET_PMD_TYPE;
-    description "Ethernet compliance code: 400GBASE_PSM4";
+    description "Ethernet compliance code: 400GMSA_PSM4";
   }
 
   identity ETH_UNDEFINED {

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
+
+  revision "2022-09-20" {
+    description
+      "Add ETH_400GBASE_PSM4 PMD type";
+    reference "0.16.0";
+  }
 
   revision "2021-07-29" {
     description
@@ -1042,6 +1048,11 @@ module openconfig-transport-types {
   identity ETH_400GBASE_DR4 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 400GBASE_DR4";
+  }
+
+  identity ETH_400GBASE_PSM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_PSM4";
   }
 
   identity ETH_UNDEFINED {


### PR DESCRIPTION
[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/external-contributions-guide.md]

### Change Scope

* Add ETH_400GBASE_PSM4 PMD type to openconfig-transport-types.
* This change is backward compatible.
### Platform Implementations

Adding this since it is already an industry standard.
