### PR TITLE
Add support for vendor specific hardware drop counters

### DIFF
--- a/doc/vendor_counter_guide.md
+++ b/doc/vendor_counter_guide.md
@@ -14,7 +14,8 @@ Each implementor should augment `/components/component/integrated-circuit/pipeli
 
 If these aggregate counters are implemented, the sum of the vendor-specific counters must match the aggregate counters.
 
-If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation.   The packet-processing-aggregate counter should be incremented in this scenario as expected above.  Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the adverse-aggregate drop counter with noise of intended packet drops.
+If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation.   The `packet-processing-aggregate` counter should be incremented in this scenario as expected above.  Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the `adverse-aggregate` drop counter with noise of intended packet drops.
+
 ## Example
 
 This following is a sample augmentation file.

--- a/doc/vendor_counter_guide.md
+++ b/doc/vendor_counter_guide.md
@@ -6,12 +6,15 @@ This document provides the guidelines for the vendor-specific portions of openco
 
 ## Usage: Vendor-specific pipeline drop counter
 
-Each implementor should augment `/components/component/integrated-circuit/pipeline-counter/drop/vendor` with their own vendor and platform containers. Within the platform container, that container may use the utility grouping `oc-ppc:pipeline-vendor-drop-containers` that provides the adverse/congestion/packet-processing specific containers. For each set of adverse/congestion/packet-processing counters augmented into `oc-ppc:pipeline-vendor-drop-containers`, the sum of the counters should be included in the values of the aggregate leaves:
+Each implementor should augment `/components/component/integrated-circuit/pipeline-counter/drop/vendor` with their own vendor and platform containers. The naming of the platform container may consist of the platform name, ASIC family, or a combination of both platform and ASIC family. Within the platform container, that container may use the utility grouping `oc-ppc:pipeline-vendor-drop-containers` that provides the adverse/congestion/packet-processing specific containers. For each set of adverse/congestion/packet-processing counters augmented into `oc-ppc:pipeline-vendor-drop-containers`, the sum of the counters should be included in the values of the aggregate leaves:
 
-- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/adverse/state` aggregate into `.../pipeline-counter/drop/state/adverse-aggregate`
-- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/congestion/state`  aggregate into `.../pipeline-counter/drop/state/congestion-aggregate`
-- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/packet-processing/state` aggregate into `.../pipeline-counter/drop/state/packet-processing-aggregate`
+- Counters within `.../pipeline-counter/drop/vendor/<vendor>/<platform>/adverse/state` aggregate into `.../pipeline-counter/drop/state/adverse-aggregate`
+- Counters within `.../pipeline-counter/drop/vendor/<vendor>/<platform>/congestion/state`  aggregate into `.../pipeline-counter/drop/state/congestion-aggregate`
+- Counters within `.../pipeline-counter/drop/vendor/<vendor>/<platform>/packet-processing/state` aggregate into `.../pipeline-counter/drop/state/packet-processing-aggregate`
 
+If these aggregate counters are implemented, the sum of the vendor-specific counters must match the aggregate counters.
+
+If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation. Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the adverse-aggregate drop counter with noise of intended packet drops.
 ## Example
 
 This following is a sample augmentation file.
@@ -117,4 +120,3 @@ module: openconfig-platform
                               +--ro acme-ppc:packet-processing-reason-counter-b?    oc-yang:counter64
                               +--ro acme-ppc:packet-processing-reason-counter-c?    oc-yang:counter64
 ```
-

--- a/doc/vendor_counter_guide.md
+++ b/doc/vendor_counter_guide.md
@@ -1,0 +1,120 @@
+# Vendor-Specific Augmentation for Pipeline Counter
+
+**Contributors**: roland@arista.com
+
+This document provides the guidelines for the vendor-specific portions of openconfig-pipeline-counters.yang. As implementations differ from vendor to vendor and platform to platform, a process of adding vendor-specific counters will be defined here.
+
+## Usage: Vendor-specific pipeline drop counter
+
+Each implementor should augment `/components/component/integrated-circuit/pipeline-counter/drop/vendor` with their own vendor and platform containers. Within the platform container, that container may use the utility grouping `oc-ppc:pipeline-vendor-drop-containers` that provides the adverse/congestion/packet-processing specific containers. For each set of adverse/congestion/packet-processing counters augmented into `oc-ppc:pipeline-vendor-drop-containers`, the sum of the counters should be included in the values of the aggregate leaves:
+
+- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/adverse/state` aggregate into `.../pipeline-counter/drop/state/adverse-aggregate`
+- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/congestion/state`  aggregate into `.../pipeline-counter/drop/state/congestion-aggregate`
+- Counters within  `.../pipeline-counter/drop/vendor/<vendor>/<platform>/packet-processing/state` aggregate into `.../pipeline-counter/drop/state/packet-processing-aggregate`
+
+## Example
+
+This following is a sample augmentation file.
+
+- Vendor: Acme
+- Platform: AsicFamily
+
+### Example YANG Augmentation
+
+release/platform/acme-asicfamily-drop-augments.yang
+
+```yang
+grouping acme-asicfamily-adverse-drop-counters {
+  leaf adverse-reason-counter-a {
+    type oc-yang:counter64;
+  }
+
+  leaf adverse-reason-counter-b {
+    type oc-yang:counter64;
+  }
+
+  leaf adverse-reason-counter-c {
+    type oc-yang:counter64;
+  }
+}
+
+grouping acme-asicfamily-congestion-drop-counters {
+  leaf congestion-reason-counter-a {
+    type oc-yang:counter64;
+  }
+
+  leaf congestion-reason-counter-b {
+    type oc-yang:counter64;
+  }
+
+  leaf congestion-reason-counter-c {
+    type oc-yang:counter64;
+  }
+}
+
+grouping acme-asicfamily-packet-processing-drop-counters {
+  leaf packet-processing-reason-counter-a {
+    type oc-yang:counter64;
+  }
+
+  leaf packet-processing-reason-counter-b {
+    type oc-yang:counter64;
+  }
+
+  leaf packet-processing-reason-counter-c {
+    type oc-yang:counter64;
+  }
+}
+
+augment "/components/component/integrated-circuit/pipeline-counter/drop/vendor" {
+  container acme {
+    container asic-family {
+      uses oc-ppc:pipeline-vendor-drop-containers;
+    }
+  }
+}
+
+augment "/components/component/integrated-circuit/pipeline-counter/drop/vendor/acme/asic-family/adverse/state" {
+  uses acme-asicfamily-adverse-drop-counters;
+}
+
+augment "/components/component/integrated-circuit/pipeline-counter/drop/vendor/acme/asic-family/congestion/state" {
+  uses acme-asicfamily-congestion-drop-counters;
+}
+
+augment "/components/component/integrated-circuit/pipeline-counter/drop/vendor/acme/asic-family/adverse/state" {
+  uses acme-asicfamily-packet-processing-drop-counters;
+}
+```
+
+Note: Namespaces omitted from `augment <path>` for brevity
+
+### Example pyang tree
+
+```text
+module: openconfig-platform
+  +--rw components
+     +--rw component* [name]
+        +--rw integrated-circuit
+           +--ro oc-ppc:pipeline-counters
+              +--ro oc-ppc:drop
+                 +--ro oc-ppc:vendor
+                    +--ro acme-ppc:acme
+                      +--ro acme-ppc:asic-family
+                        +--ro oc-ppc:adverse
+                           +--ro oc-ppc:state
+                              +--ro acme-ppc:adverse-reason-counter-a?    oc-yang:counter64
+                              +--ro acme-ppc:adverse-reason-counter-b?    oc-yang:counter64
+                              +--ro acme-ppc:adverse-reason-counter-c?    oc-yang:counter64
+                        +--ro oc-ppc:congestion
+                           +--ro oc-ppc:state
+                              +--ro acme-ppc:congestion-reason-counter-a?    oc-yang:counter64
+                              +--ro acme-ppc:congestion-reason-counter-b?    oc-yang:counter64
+                              +--ro acme-ppc:congestion-reason-counter-c?    oc-yang:counter64
+                        +--ro oc-ppc:packet-processing
+                           +--ro oc-ppc:state
+                              +--ro acme-ppc:packet-processing-reason-counter-a?    oc-yang:counter64
+                              +--ro acme-ppc:packet-processing-reason-counter-b?    oc-yang:counter64
+                              +--ro acme-ppc:packet-processing-reason-counter-c?    oc-yang:counter64
+```
+

--- a/doc/vendor_counter_guide.md
+++ b/doc/vendor_counter_guide.md
@@ -14,7 +14,7 @@ Each implementor should augment `/components/component/integrated-circuit/pipeli
 
 If these aggregate counters are implemented, the sum of the vendor-specific counters must match the aggregate counters.
 
-If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation. Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the adverse-aggregate drop counter with noise of intended packet drops.
+If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation.   The packet-processing-aggregate counter should be incremented in this scenario as expected above.  Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the adverse-aggregate drop counter with noise of intended packet drops.
 ## Example
 
 This following is a sample augmentation file.

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,14 +65,14 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.2";
+  oc-ext:openconfig-version "0.3.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  revision "2022-09-19" {
+  revision "2022-11-09" {
     description
       "Add container for vendor specific drop counters.";
-    reference "0.2.2";
+    reference "0.3.0";
   }
 
   revision "2022-01-19" {

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -1101,45 +1101,64 @@ module openconfig-platform-pipeline-counters {
 
     container vendor {
       description
-        "Counters within these containers are defined and populated by vendors.
+        "Counters within these containers are defined and augmented by vendors.
         As each ASIC and vendor has different implementation and internal
         parts where packets may be dropped at any point in time. Providing
-        specific hardware counters provides better visibility into traffic drop.";
+        specific hardware counters provides better visibility into traffic drop.
 
-      container adverse {
+        The recommended useage of this container is to create an augment at
+        .../pipeline-counter/drop/vendor that contains additional vendor/platform
+        specific containers.
+
+        e.g.
+        augment /components/component/integrated-circuit/pipeline-counter/drop/vendor {
+          container <vendor name> {
+            container <platform name> {
+              uses pipeline-vendor-drop-containers;
+            }
+          }
+        }";
+    }
+  }
+
+  grouping pipeline-vendor-drop-containers {
+    description
+      "A utility grouping for vendors to insert when augmenting the vendor
+      drop counters container .../pipeline-counter/drop/vendor.";
+
+    container adverse {
+      description
+        "These counters capture where the switch is unexpectedly dropping
+        packets. Occurrence of these drops on a stable (no recent hardware
+        or config changes) and otherwise healthy switch needs further
+        investigation.";
+
+      container state {
         description
-          "These counters capture where the switch is unexpectedly dropping
-          packets. Occurrence of these drops on a stable (no recent hardware
-          or config changes) and otherwise healthy switch needs further
-          investigation.";
-
-        container state {
-          description
-            "State container for vendor specific adverse counters.";
-        }
+          "State container for vendor specific adverse counters.";
       }
+    }
 
-      container congestion {
+    container congestion {
+      description
+        "These counters track expected conditions of packet drops due to
+        internal congestion in some block of the hardware that may not be
+        visible in through other congestion indicators like interface
+        discards or queue drop counters.";
+
+      container state {
         description
-          "These counters track expected conditions of packet drops due to
-          internal congestion in some block of the hardware that may not be
-          visible in through other congestion indicators like interface
-          discards or queue drop counters.";
-
-        container state {
-          description
-            "State container for vendor specific congestion counters.";
-        }
+          "State container for vendor specific congestion counters.";
       }
+    }
 
-      container packet-processing {
+    container packet-processing {
+      description
+        "These counters represent the conditions in which packets are dropped
+        due to legitimate forwarding decisions (ACL drops, No Route etc.)";
+      container state {
         description
-          "These counters represent the conditions in which packets are dropped
-          due to legitimate forwarding decisions (ACL drops, No Route etc.)";
-        container state {
-          description
-            "State container for vendor specific packet processing counters.";
-        }
+          "State container for vendor specific packet processing counters.";
       }
     }
   }

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.2.2";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-09-19" {
+    description
+      "Add container for vendor specific drop counters.";
+    reference "0.2.2";
+  }
 
   revision "2022-01-19" {
     description
@@ -94,10 +100,10 @@ module openconfig-platform-pipeline-counters {
       counters.";
 
     container pipeline-counters {
+      config false;
       description
         "Top-level container for the packet, drop, and error counters for the
         five NPU sub-blocks.";
-      config false;
       container packet {
         description
           "IC packet counters for all five NPU sub-blocks.";
@@ -178,6 +184,14 @@ module openconfig-platform-pipeline-counters {
       container drop {
         description
           "IC drop counters for all five NPU sub-blocks.";
+        container state {
+          description
+            "State container for IC drop counters";
+
+          uses pipeline-drop-packet-state;
+        }
+
+
         container interface-block {
           description
             "The IC interface subsystem connects the IC to the external PHY or
@@ -248,6 +262,8 @@ module openconfig-platform-pipeline-counters {
             uses pipeline-drop-packet-host-interface-block-state;
           }
         }
+
+        uses pipeline-vendor-drop-packets;
       }
 
       container errors {
@@ -963,11 +979,11 @@ module openconfig-platform-pipeline-counters {
 
     leaf active {
       type boolean;
+      default false;
       description
         "The error is currently in an active state. When the system detects
         that the specified threshold is exceeded, this value should be set to
         true.";
-      default false;
       oc-ext:telemetry-on-change;
     }
 
@@ -1046,6 +1062,86 @@ module openconfig-platform-pipeline-counters {
 
     uses pipeline-errors-common;
 
+  }
+
+  grouping pipeline-drop-packet-state {
+    description
+      "Grouping of pipeline drop packet state.";
+
+    leaf adverse-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch is
+        unexpectedly dropping packets. Occurrence of these drops on a stable
+        (no recent hardware or config changes) and otherwise healthy
+        switch needs further investigation.";
+    }
+
+    leaf congestion-aggregate {
+      type oc-yang:counter64;
+      description
+        "This tracks the aggregation of all counters where the expected
+        conditions of packet drops due to internal congestion in some block of
+        the hardware that may not be visible in through other congestion
+        indicators like interface discards or queue drop counters.";
+    }
+
+    leaf packet-processing-aggregate {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to legitimate forwarding decisions (ACL drops,
+        No Route etc.)";
+    }
+  }
+
+  grouping pipeline-vendor-drop-packets {
+    description
+      "Grouping for vendor specific drop packets";
+
+    container vendor {
+      description
+        "Counters within these containers are defined and populated by vendors.
+        As each ASIC and vendor has different implementation and internal
+        parts where packets may be dropped at any point in time. Providing
+        specific hardware counters provides better visibility into traffic drop.";
+
+      container adverse {
+        description
+          "These counters capture where the switch is unexpectedly dropping
+          packets. Occurrence of these drops on a stable (no recent hardware
+          or config changes) and otherwise healthy switch needs further
+          investigation.";
+
+        container state {
+          description
+            "State container for vendor specific adverse counters.";
+        }
+      }
+
+      container congestion {
+        description
+          "These counters track expected conditions of packet drops due to
+          internal congestion in some block of the hardware that may not be
+          visible in through other congestion indicators like interface
+          discards or queue drop counters.";
+
+        container state {
+          description
+            "State container for vendor specific congestion counters.";
+        }
+      }
+
+      container packet-processing {
+        description
+          "These counters represent the conditions in which packets are dropped
+          due to legitimate forwarding decisions (ACL drops, No Route etc.)";
+        container state {
+          description
+            "State container for vendor specific packet processing counters.";
+        }
+      }
+    }
   }
 
   augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit" {

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -1118,20 +1118,31 @@ module openconfig-platform-pipeline-counters {
             }
           }
         }";
+
+      reference "doc/vendor_counter_guide.md";
     }
   }
 
   grouping pipeline-vendor-drop-containers {
     description
       "A utility grouping for vendors to insert when augmenting the vendor
-      drop counters container .../pipeline-counter/drop/vendor.";
+      drop counters container .../pipeline-counter/drop/vendor.
+
+      Counters that cannot differentiate between adverse, congestion, and
+      packet-processing should still be exposed as a vendor-specific,
+      packet-processing counter.";
+
+    reference "doc/vendor_counter_guide.md";
 
     container adverse {
       description
         "These counters capture where the switch is unexpectedly dropping
         packets. Occurrence of these drops on a stable (no recent hardware
         or config changes) and otherwise healthy switch needs further
-        investigation.";
+        investigation.
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/adverse-aggregate";
 
       container state {
         description
@@ -1144,7 +1155,10 @@ module openconfig-platform-pipeline-counters {
         "These counters track expected conditions of packet drops due to
         internal congestion in some block of the hardware that may not be
         visible in through other congestion indicators like interface
-        discards or queue drop counters.";
+        discards or queue drop counters.
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/congestion-aggregate";
 
       container state {
         description
@@ -1155,7 +1169,11 @@ module openconfig-platform-pipeline-counters {
     container packet-processing {
       description
         "These counters represent the conditions in which packets are dropped
-        due to legitimate forwarding decisions (ACL drops, No Route etc.)";
+        due to legitimate forwarding decisions (ACL drops, No Route etc.)
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/packet-processing-aggregate";
+
       container state {
         description
           "State container for vendor specific packet processing counters.";


### PR DESCRIPTION
- (M) release/models/platform/openconfig-platform-pipeline-counters.yang

### Change Scope

This request creates a location in /components/component/integrated-circuit/pipeline-counters/drop where vendors may populate platform specific drop counters. The goal is to define a process for vendors to create and publish their internal counters and aggregate the corresponding counters. With counters categorized with severity, the switch can aggregate based on severity while retaining counter transparency.

More details in the [original proposal](https://docs.google.com/document/d/1bLbeG8Wp1vkaxQg4hCF-1G2XJLSCpjcwMD8eftByM2Y/edit).

There are two major differences from the original proposal that was made:
- No vendor type was needed as this could be abstracted in a generic `vendor` container. Each vendor should augment this container in order to add the vendor and platform name.
- Adverse/Congestion/Packet Processing counter types are not needed, instead it is split between their individual containers.

#### Vendor independent section
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--ro oc-ppc:pipeline-counters
              +--ro oc-ppc:drop
                 +--ro oc-ppc:state
                    +--ro oc-ppc:adverse-aggregate?             oc-yang:counter64
                    +--ro oc-ppc:congestion-aggregate?          oc-yang:counter64
                    +--ro oc-ppc:packet-processing-aggregate?   oc-yang:counter64
                 +--ro oc-ppc:vendor
```

#### Vendor dependent section
Example vendor augment
```
augment "/components/component/integrated-circuit/pipeline-counter/drop/vendor" {
  container <vendor name> {
    container <platform name> {
      uses pipeline-vendor-drop-containers;
    }
  }
}
```

Example pyang
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--ro oc-ppc:pipeline-counters
              +--ro oc-ppc:drop
                 +--ro oc-ppc:vendor
                    +--ro <vendor name>
                      +--ro <platform name>
                        +--ro oc-ppc:adverse
                           +--ro oc-ppc:state
                        +--ro oc-ppc:congestion
                           +--ro oc-ppc:state
                        +--ro oc-ppc:packet-processing
                           +--ro oc-ppc:state
```


### Platform Implementations

 * Cisco ASR 9000: [link to documentation](https://community.cisco.com/t5/service-providers-knowledge-base/asr9000-xr-troubleshooting-packet-drops-and-understanding-np/ta-p/3126715)
 * Cisco Nexus 5000: [link to documentation](https://www.cisco.com/c/en/us/support/docs/switches/nexus-5000-series-switches/116172-technote-product-00.html)
 * Juniper: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/junos-overview/topics/concept/using-show-commands-for-packet-drops.html)
 * Arista:  `show hardware counter drop`
   * A sample of possible counters are listed in the Appendix A of the [original proposal](https://docs.google.com/document/d/1bLbeG8Wp1vkaxQg4hCF-1G2XJLSCpjcwMD8eftByM2Y/edit#heading=h.7035it1ttmrt)