### PR TITLE
Add base-mac-address

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.20.0";
+  oc-ext:openconfig-version "0.21.0";
+
+  revision "2022-09-26" {
+    description
+      "Add state data for base-mac-address.";
+    reference "0.21.0";
+  }
 
   revision "2022-08-31" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -69,9 +69,10 @@ module openconfig-platform {
 
   revision "2022-09-26" {
     description
-      "Add new state data for component CLEI code.";
+      "Add state data for base-mac-address.";
     reference "0.21.0";
   }
+
   revision "2022-08-31" {
     description
       "Add new state data for component CLEI code.";

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,8 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.20.0";
+  oc-ext:openconfig-version "0.21.0";
 
+  revision "2022-09-26" {
+    description
+      "Add new state data for component CLEI code.";
+    reference "0.21.0";
+  }
   revision "2022-08-31" {
     description
       "Add new state data for component CLEI code.";

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -551,7 +551,7 @@ module openconfig-platform {
     leaf base-mac-address {
       type oc-yang:mac-address;
       description
-        "This is a MAC address representing the root or primary MAC 
+        "This is a MAC address representing the root or primary MAC
         address for a component.  Only components such as CHASSIS and
         CONTROLLER_CARD are expected to providea base-mac-address.  The
         base mac-address for CHASSIS and a PRIMARY CONTROLLER_CARD may

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -542,6 +542,15 @@ module openconfig-platform {
         device, one as primary and the other as secondary, should both
         report the same value.";
     }
+    leaf base-mac-address {
+      type oc-yang:mac-address;
+      description
+        "This is a MAC address representing the root or primary MAC 
+        address for a component.  Only components such as CHASSIS and
+        CONTROLLER_CARD are expected to providea base-mac-address.  The
+        base mac-address for CHASSIS and a PRIMARY CONTROLLER_CARD may
+        contain the same value."
+    }
   }
 
   grouping platform-component-temp-alarm-state {

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -553,8 +553,8 @@ module openconfig-platform {
       type oc-yang:mac-address;
       description
         "This is a MAC address representing the root or primary MAC
-        address for a component.  Only components such as CHASSIS and
-        CONTROLLER_CARD are expected to providea base-mac-address.  The
+        address for a component.  Components such as CHASSIS and
+        CONTROLLER_CARD are expected to provide a base-mac-address.  The
         base mac-address for CHASSIS and a PRIMARY CONTROLLER_CARD may
         contain the same value.";
     }

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -547,6 +547,7 @@ module openconfig-platform {
         device, one as primary and the other as secondary, should both
         report the same value.";
     }
+
     leaf base-mac-address {
       type oc-yang:mac-address;
       description
@@ -554,8 +555,9 @@ module openconfig-platform {
         address for a component.  Only components such as CHASSIS and
         CONTROLLER_CARD are expected to providea base-mac-address.  The
         base mac-address for CHASSIS and a PRIMARY CONTROLLER_CARD may
-        contain the same value."
+        contain the same value.";
     }
+
   }
 
   grouping platform-component-temp-alarm-state {


### PR DESCRIPTION
### Change Scope
* Add base-mac-address leaf `/components/component/state/base-mac-address`.
* This change is backwards compatible

### Platform Implementations
* [JunOS - show chassis mac address](https://www.juniper.net/documentation/us/en/software/junos/chassis/topics/ref/command/show-chassis-mac-addresses.html)
* [Arista EOS - show version](https://www.arista.com/en/um-eos/eos-command-line-interface-cli#xx1125082)
* [Nokia SRL - show version](https://infocenter.nokia.com/public/SRLINUX200R6A/index.jsp?topic=%2Fcom.srlinux.interfaceconfig%2Fhtml%2Fcli-interface.html)

