### PR TITLE
Add uRPF drop counter in the lookup subsystem.

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.2.2";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-09-23" {
+    description
+      "Add uRPF drop counter in the lookup subsystem.";
+    reference "0.2.2";
+  }
 
   revision "2022-01-19" {
     description
@@ -812,6 +818,12 @@ module openconfig-platform-pipeline-counters {
       type oc-yang:counter64;
       description
         "Packets dropped due to firewall or acl terms.";
+    }
+
+    leaf urpf-total-drops {
+      type oc-yang:counter64;
+      description
+        "Total number of packets dropped by NPU due to failing uRPF check.";
     }
 
   }


### PR DESCRIPTION
- (M) release/models/platform/openconfig-platform-pipeline-counters.yang

### Change Scope

This change adds uRPF drop counters to the lookup subsystem. The counter represents dropped packets failing uRPF check on the forwarding path. This counter locations is specific for vendor platforms, which report uRPF drops on per-chip basis.
The change is backwards compatible.

### Platform Implementations

#### Cisco (IOS-XR)
Cisco IOS-XR on ASR9K and NCS platforms reports per-chip uPPF drops as `bcmRxTrapUcLooseRpfFai`.

CLI: `show controller npu stats traps-all instance 0 location <chip> | in Rpf`

Vendor telemetry path: `Cisco-IOS-XR-fretta-bcm-dpa-npu-stats-oper:dpa/stats/nodes/node/npu-numbers/npu-number/display/trap-ids/trap-id/packet-dropped`

#### Arista
Reports per-chip uRPF drops as dropVoqInRpf counter.

CLI: `show hardware counter drop`.

Vendor telemetry path: `/Smash/hardware/counter/internalDrop/SandCounters/internalDrop`

