### PR TITLE
add last configuration timestamp leaf

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -290,15 +290,6 @@ module openconfig-system {
         information such as the current system date and time, uptime,
         last login timestamp, etc.";
     }
-
-    leaf last-configuration-timestamp {
-      type oc-types:timeticks64;
-      units "nanoseconds";
-      description
-        "Indicates the timestamp at which the last configuration change
-        was made. This may may be through CLI, OpenConfig or some other
-        mechanism.";
-    }
   }
 
   grouping mount-point-state {

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -374,7 +374,7 @@ module openconfig-system {
       units "nanoseconds";
       description
         "Indicates the timestamp at which the last configuration change
-        was made. This may may be through CLI, OpenConfig or some other
+        was made. This may may be through CLI, gNMI or some other
         mechanism.";
     }
   }

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -373,9 +373,9 @@ module openconfig-system {
       type oc-types:timeticks64;
       units "nanoseconds";
       description
-        "Indicates the timestamp at which the last configuration change
-        was made. This may may be through CLI, gNMI or some other
-        mechanism.";
+        "Indicates the monotonically increasing timestamp at which the
+        last configuration change was made. This may may be through CLI, 
+        gNMI or some other mechanism.";
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -377,6 +377,15 @@ module openconfig-system {
           value of the state/software-version leaf in the component
           of type OPERATING_SYSTEM.";
     }
+
+    leaf last-configuration-timestamp {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "Indicates the timestamp at which the last configuration change
+        was made. This may may be through CLI, OpenConfig or some other
+        mechanism.";
+    }
   }
 
   grouping mount-points-top {

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -374,7 +374,7 @@ module openconfig-system {
       units "nanoseconds";
       description
         "Indicates the monotonically increasing timestamp at which the
-        last configuration change was made. This may may be through CLI, 
+        last configuration change was made. This may may be through CLI,
         gNMI or some other mechanism.";
     }
   }

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -46,7 +46,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
+
+  revision "2022-09-28" {
+    description
+      "Add last configuration timestamp leaf.";
+    reference "0.16.0";
+  }
 
   revision "2022-07-25" {
     description
@@ -283,6 +289,15 @@ module openconfig-system {
         system.  They system may append additional standard
         information such as the current system date and time, uptime,
         last login timestamp, etc.";
+    }
+
+    leaf last-configuration-timestamp {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "Indicates the timestamp at which the last configuration change
+        was made. This may may be through CLI, OpenConfig or some other
+        mechanism.";
     }
   }
 


### PR DESCRIPTION
Some users may have a desire to know if the configuration on the box has changed. Subscribing to the entire tree could work, however, all the state leafs would have to be filtered out. This proposes a new leaf `last-configuration-timestamp` which represents the timestamp at which the last configuration was made on the box. E.g. an OpenConfig Set request would update this time stamp or a CLI configuration change on the box would update this timestamp. However, counters data being updated in the YANG tree does not update this timestamp. This provides a mean by which a user can subscribe to the leaf to determine if configuration was made on the box.

*pyang output*

```
module: openconfig-system
  +--rw system
     +--rw config
     |  +--rw hostname?       oc-inet:domain-name
     |  +--rw domain-name?    oc-inet:domain-name
     |  +--rw login-banner?   string
     |  +--rw motd-banner?    string
     +--ro state
     |  +--ro hostname?                       oc-inet:domain-name
     |  +--ro domain-name?                    oc-inet:domain-name
     |  +--ro login-banner?                   string
     |  +--ro motd-banner?                    string
     |  +--ro current-datetime?               oc-yang:date-and-time
     |  +--ro boot-time?                      oc-types:timeticks64
     |  +--ro software-version?               string
     |  +--ro last-configuration-timestamp?   oc-types:timeticks64
```
## References
* [Cisco IOS XR - show configuration running-config](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r3-9/system_management/command/reference/yr39xr12k_chapter5.html#wp1406184717)
* [Juniper JunOS - show system commit](https://www.juniper.net/documentation/us/en/software/junos/cli/topics/ref/command/show-system-commit.html)

Resolves #545 