### PR TITLE
Update ACL sequence-id to start from 1

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,9 +34,15 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.2.2";
+  oc-ext:openconfig-version "2.0.0";
 
-  revision "2022-01-14" {
+  revision "2022-10-05" {
+    description
+      "Change sequence-id unit32 range to begin with 1";
+    reference "2.0.0";
+  }
+
+revision "2022-01-14" {
     description
       "Fix when statements for MIXED mode ACLs";
     reference "1.2.2";
@@ -360,7 +366,9 @@ module openconfig-acl {
       "Access List Entries (ACE) config.";
 
     leaf sequence-id {
-      type uint32;
+      type uint32 {
+        range 1..4294967039;
+      }
       description
         "The sequence id determines the order in which ACL entries
         are applied.  The sequence id must be unique for each entry


### PR DESCRIPTION
### Change Scope

* It is observed a number of network OS implementations do not support starting ACL's at '0', but rather start at '1'.
* This change is not backwards compatible

### Platform Implementations

* [Cisco  IP ACL sequence number range](https://www.cisco.com/en/US/docs/ios-xml/ios/sec_data_acl/configuration/15-2mt/sec-acl-seq-num.html#GUID-C6FA179D-880C-4812-9062-F5A85F6F8D10)

* [Arista EOS IP ACL](https://www.arista.com/en/um-eos/eos-acls-and-route-maps#xx1149143)

