### PR TITLE
modify /interfaces/interface/loopback-mode to allow specification of loopback-mode-type

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -53,7 +53,7 @@ module openconfig-interfaces {
 
   oc-ext:openconfig-version "3.0.0";
 
-  revision "2022-09-28" {
+  revision "2022-10-25" {
     description
       "change loopback-mode to align with available modes";
     reference "3.0.0";

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -12,6 +12,7 @@ module openconfig-interfaces {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-transport-types { prefix oc-opt-types; }
 
   // meta
   organization "OpenConfig working group";
@@ -50,7 +51,13 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2022-09-28" {
+    description
+      "change loopback-mode to align with available modes";
+    reference "3.0.0";
+  }
 
   revision "2021-04-06" {
     description
@@ -390,12 +397,11 @@ module openconfig-interfaces {
     }
 
     leaf loopback-mode {
-      type boolean;
-      default false;
+      type oc-opt-types:loopback-mode-type;
       description
-        "When set to true, the interface is logically looped back,
-        such that packets that are forwarded via the interface
-        are received on the same interface.";
+        "Sets the loopback type on the interface. Setting the
+        mode to something besides NONE activates the loopback in
+        the specified mode.";
     }
 
     uses interface-common-config;


### PR DESCRIPTION
### Change Scope

* this changes the noted leaf from a `boolean` to `loopback-mode-type`.  
* this is a backward **incompatible** change. 

the leaf, as currently defined (boolean), indicates whether the interface is looped onto itself. more broadly, interfaces can be looped in either direction.  the `loopback-mode` should allow for the specification of the direction of the loopback as defined in the optical-transport models.

### pyang output
```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw name             -> ../config/name
        +--rw config
        |  +--rw name?            string
        |  +--rw type             identityref
        |  +--rw mtu?             uint16
        |  +--rw loopback-mode?   oc-opt-types:loopback-mode-type << leaf of interest
        |  +--rw description?     string
        |  +--rw enabled?         boolean
        +--ro state
        |  +--ro name?            string
        |  +--ro type             identityref
        |  +--ro mtu?             uint16
        |  +--ro loopback-mode?   oc-opt-types:loopback-mode-type << leaf of interest
        |  +--ro description?     string
        |  +--ro enabled?         boolean
        |  +--ro ifindex?         uint32
        |  +--ro admin-status     enumeration
        |  +--ro oper-status      enumeration
        |  +--ro last-change?     oc-types:timeticks64
        |  +--ro logical?         boolean
        |  +--ro management?      boolean
        |  +--ro cpu?             boolean
        |  +--ro counters

 { ... snipped ... }

        +--rw hold-time
        |  +--rw config
        |  |  +--rw up?     uint32
        |  |  +--rw down?   uint32
        |  +--ro state
        |     +--ro up?     uint32
        |     +--ro down?   uint32
        +--rw subinterfaces

{ ... snipped ... }
```