### PR TITLE
Clarify static route index description to use a number

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -210,12 +210,13 @@ module openconfig-local-routing {
       specified for a static route";
 
     leaf index {
-      type uint64;
+      type string;
       description
         "An user-specified identifier utilised to uniquely reference
         the next-hop entry in the next-hop list. The value of this
         index has no semantic meaning other than for referencing
-        the entry.";
+        the entry.  It is observed that implementations typically 
+        only support a number value for this string. ";
     }
 
     leaf next-hop {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -204,7 +204,7 @@ module openconfig-local-routing {
       specified for a static route";
 
     leaf index {
-      type string;
+      type uint64;
       description
         "An user-specified identifier utilised to uniquely reference
         the next-hop entry in the next-hop list. The value of this

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,13 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2022-11-01" {
+    description
+      "Change static route nexthop index to uint64.";
+    reference "3.0.0";
+  }
 
   revision "2022-05-10" {
     description

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -215,7 +215,7 @@ module openconfig-local-routing {
         "An user-specified identifier utilised to uniquely reference
         the next-hop entry in the next-hop list. The value of this
         index has no semantic meaning other than for referencing
-        the entry.  It is observed that implementations typically 
+        the entry.  It is observed that implementations typically
         only support a number value for this string. ";
     }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,12 +43,12 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "2.0.1";
 
   revision "2022-11-01" {
     description
-      "Change static route nexthop index to uint64.";
-    reference "3.0.0";
+      "Update static route nexthop index description.";
+    reference "2.0.1";
   }
 
   revision "2022-05-10" {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -216,7 +216,7 @@ module openconfig-local-routing {
         the next-hop entry in the next-hop list. The value of this
         index has no semantic meaning other than for referencing
         the entry.  It is observed that implementations typically
-        only support a number value for this string. ";
+        only support a numeric value for this string. ";
     }
 
     leaf next-hop {


### PR DESCRIPTION
### Change Scope
This brings static route index in line with with other openconfig models containing indicies for nexthops such as the aft model.  This change is not backwards compatible.

###References
* [openconfig-aft-common.yang](https://github.com/openconfig/public/blob/00a27a5f0f3c472205ef293ab238e0530b610811/release/models/aft/openconfig-aft-common.yang#L268-L272)

*  https://github.com/openconfig/featureprofiles/pull/692
