### PR TITLE
Normalize and remove single 'unique' statement among model set

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,12 +24,12 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.5.0";
 
-  revision "2022-11-07" {
+  revision "2022-12-14" {
     description
       "Removal of interface list unique statement";
-    reference "2.0.0";
+    reference "1.5.0";
   }
 
   revision "2022-09-15" {

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-07" {
+    description
+      "Removal of interface list unique statement";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-07" {
+    description
+      "Removal of interface list unique statement";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -465,7 +471,6 @@ module openconfig-network-instance {
 
           list interface {
             key "id";
-            unique "config/interface config/subinterface";
 
             description
               "An interface associated with the network instance";

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,12 +48,12 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.5.0";
 
-  revision "2022-11-07" {
+  revision "2022-12-14" {
     description
       "Removal of interface list unique statement";
-    reference "2.0.0";
+    reference "1.5.0";
   }
 
   revision "2022-09-15" {


### PR DESCRIPTION
  * (M) release/models/network-instance/openconfig-network-instance.yang
  * (M) release/models/network-instance/openconfig-network-instance-l2.yang
    - Remove network-instance interface list unique statement

### Change Scope

This PR is to initiate discussion on the path forward for the use of the YANG `unique` statement in OpenConfig models.

Per https://www.rfc-editor.org/rfc/rfc6020#section-7.8.3, the `unique` statement is meant to put constraints on non-key list entry child nodes however the use throughout OpenConfig models is limited to a single use: `/network-instances/network-instance/interfaces/interface` and is a valid case of the use of this statement however for consistency purposes, I would like to raise the point that its use should either be expanded to all cases of lists where it is applicable throughout the model set or propose the removal of this statement until further decision and backwards incompatible model updates across the model set (e.g. all or nothing).

Per YANG backwards compatibility rules, this change is backwards incompatible in either case and major revision numbers need to be incremented.

### Platform Implementations

N/A
