### PR TITLE
Removal of network-instance enabled-address-families leaf-list

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-08" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description

--- a/release/models/network-instance/openconfig-network-instance-l3.yang
+++ b/release/models/network-instance/openconfig-network-instance-l3.yang
@@ -23,7 +23,13 @@ module openconfig-network-instance-l3 {
     Layer 3 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-08" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -125,21 +131,6 @@ module openconfig-network-instance-l3 {
       "Configuration and operational state parameters relevant
       to network instances that include a Layer 3 type";
 
-  }
-
-  grouping l3ni-instance-common-config {
-    description
-      "Configuration parameters that are common to L3 network
-      instances other than the default instance";
-
-    leaf-list enabled-address-families {
-      type identityref {
-        base octypes:ADDRESS_FAMILY;
-      }
-      description
-        "The address families that are to be enabled for this
-        network instance.";
-    }
   }
 
   grouping l3ni-route-limit-structural {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -293,7 +293,12 @@ module openconfig-network-instance {
         key "name";
 
         description
-          "Network instances configured on the local system";
+          "Network instances configured on the local system
+
+          IPv4 and IPv6 forwarding are enabled by default within an L3
+          network-instance and subsequently, routes can be populated
+          into the network-instance using protocols that enable IPv4 and
+          IPv6 configuration without explicitly enabling these.";
 
         leaf name {
           type leafref {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-08" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -892,14 +898,6 @@ module openconfig-network-instance {
   grouping network-instance-type-dependent-config {
     description
       "Type dependent network instance configuration";
-
-    uses oc-ni-l3:l3ni-instance-common-config {
-      when "./type = 'oc-ni-types:L3VRF' or ./type = 'oc-ni-types:L2L3'" {
-        description
-          "Layer 3 VRF configuration parameters included when a
-          network instance is a L3VRF or combined L2L3 instance";
-      }
-    }
 
     uses l2ni-instance-common-config {
       when "./type = 'oc-ni-types:L2VSI' or ./type = 'oc-ni-types:L2P2P'" +


### PR DESCRIPTION
  * (M) release/models/network-instance/openconfig-network-instance.yang
  * (M) release/models/network-instance/openconfig-network-instance-l2.yang
  * (M) release/models/network-instance/openconfig-network-instance-l3.yang
    - Removal of unnecessary enabled-address-families leaf-list node

### Change Scope

The `enabled-address-families` leaf-list currently exists at the top level of network-instances, lacks implementation guidance and is questionable in operational reality.

* This node appears specifically derived from one implementations native behaviors specific to IP based VRFs - Are there vendor references to this leaf-list?
* The model defines this at an AF level only but the single implementation above does this based on AF + SAF
* The model uses an identityref that does not gate the other possible identities (L2_ETHERNET, MPLS + any future) so it would require implementation detail to gate this outside of the data-model
* Implementation guidance, expectations or vendor support is not documented
* Is this really a sane operational workflow for what are meant to be operator use-cases?  Would anyone ever enable/disable L3 protocols such as IPv4 or IPv6 per instance at runtime?  What if all child nodes (such as bound interfaces or protocols) contain configuration for these protocols?  What is the expected behavior?  Would all such instances cease to function?

This PR is to propose removal of undefined and undocumented behavior for this leaf-list.

Due to the nature of this change and removal of the leaf-list, this change is deemed backwards incompatible thus the major version is incremented.

### Platform Implementations

N/A: Lacks overall purpose and appears to be derived from a single native implementation.
