### PR TITLE
Update openconfig-policy-types.yang

### DIFF
--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -275,7 +275,7 @@ module openconfig-policy-types {
 
       10.244.136.79/31
 
-      the derived direct route is
+      the derived DIRECTLY_CONNECTED route is
 
       10.244.136.78/31
 

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -259,7 +259,7 @@ module openconfig-policy-types {
     reference
       "RFC 5440";
   }
-  
+
   identity LOCAL {
     base INSTALL_PROTOCOL_TYPE;
     description

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -29,7 +29,7 @@ module openconfig-policy-types {
   revision "2022-11-08" {
     description
       "Add INSTALL_PROTOCOL_TYPE local.";
-    reference "3.2.2";
+    reference "3.2.3";
   }
 
   revision "2022-02-11" {

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -24,7 +24,13 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.2.2";
+  oc-ext:openconfig-version "3.2.3";
+
+  revision "2022-11-08" {
+    description
+      "Add INSTALL_PROTOCOL_TYPE local.";
+    reference "3.2.2";
+  }
 
   revision "2022-02-11" {
     description
@@ -252,5 +258,29 @@ module openconfig-policy-types {
       "Path Computation Element Communication Protocol";
     reference
       "RFC 5440";
+  }
+  
+  identity LOCAL {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "A local route.
+
+      Local routes define a route for the one specific IP
+      address configured on the router interface. They are
+      created in association with directly connected routes.
+      Local routes must end with a /32 in the case of ipv4
+      or /128 for ipv6.
+      For example, when configuring an interface with the ip
+      address
+
+      10.244.136.79/31
+
+      the derived direct route is
+
+      10.244.136.78/31
+
+      and the derived local route is
+
+      10.244.136.79/32.";
   }
 }

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -279,7 +279,7 @@ module openconfig-policy-types {
 
       10.244.136.78/31
 
-      and the derived local route is
+      and the derived LOCAL route is
 
       10.244.136.79/32.";
   }


### PR DESCRIPTION
Add new INSTALL_PROTOCOL_TYPE local to openconfig-policy-types.yang.

### Change Scope

* [Please briefly describe the change that is being made to the models.]
We add a new install protocol type named local to openconfig-policy-types.yang.

* [Please indicate whether this change is backwards compatible.]
This addition causes no backwards compatibility problems, only adding to OC.

### Platform Implementations

 * Cisco Reference and Implementation Output: [link to documentation](https://www.cisco.com/c/en/us/support/docs/ip/ip-routing/116264-technote-ios-00.html)
 * Juniper Reference and Implementation Output: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/command/show-route-detail.html)