### PR TITLE
Add support for IPv6 RA features.

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -941,7 +941,7 @@ module openconfig-if-ip {
       router advertisement.";
 
     leaf prefix {
-      type oc-inet:ipv4-prefix;
+      type oc-inet:ipv6-prefix;
       description
         "IPv6 prefix to be advertised within the router advertisement
         message.";

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,7 +44,13 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+  
+  revision "2022-11-09" {
+    description
+      "Add additional IPv6 router-advertisement features.";
+    reference "3.1.0";
+  }
 
   revision "2019-01-08" {
     description
@@ -907,6 +913,84 @@ module openconfig-if-ip {
         "When set to true, router advertisement neighbor discovery
         messages are not transmitted on this interface.";
     }
+
+    leaf managed {
+      type boolean;
+      default false;
+      description
+        "When set to true, the managed address configuration (M) flag is set in
+        the advertised router advertisement. The M flag indicates that there are
+        addresses available via DHCPv6.";
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.2";
+    }
+
+    leaf other-config {
+      type boolean;
+      default false;
+      description
+        "When set to true, the other configuration (O) flag is set in the
+        advertised router advertisement. The O flag indicates that there is
+        other configuration available via DHCPv6 (e.g., DNS servers).";
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.2";
+    }
+  }
+
+  grouping ipv6-ra-prefix-config {
+    description
+      "Configuration parameters for an individual prefix within an IPv6
+      router advertisement.";
+    
+    leaf cidr {
+      type oc-inet:ipv4-prefix;
+      description
+        "IPv6 prefix to be advertised within the router advertisement
+        message.";
+    }
+
+    leaf valid-lifetime {
+      type uint32;
+      units seconds;
+      description
+        "The length of time that the prefix is valid relative to the time
+        the packet was sent.";
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.2";
+    }
+
+    leaf preferred-lifetime {
+      type uint32;
+      units seconds;
+      description
+        "The length of time that the address within the prefix remains
+        in the preferred state, i.e., unrestricted use is allowed by
+        upper-layer protocols. See RFC4862 for a complete definition
+        of preferred behaviours.";
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.2";
+    }
+ 
+    leaf disable-advertisement {
+      type boolean;
+      description
+        "When set to true, the prefix is not advertised within
+        router advertisement messages that are sent as a result of
+        router soliciation messages.";
+    }
+
+    leaf disable-autoconfiguration {
+      type boolean;
+      description
+        "When set to true, the prefix is marked as not to be used for stateless
+        address configuration. This is achieved by setting the autonomous address
+        configuration bit for the prefix."; 
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.1";
+    }
+
+    leaf enable-onlink {
+      type boolean;
+      description
+        "When set to true, the prefix is marked as being on link by setting the
+        L-bit for the prefix within a router advertisement.";
+      reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.1";
+    }
   }
 
   grouping ipv4-proxy-arp-config {
@@ -1141,6 +1225,42 @@ module openconfig-if-ip {
             "Operational state parameters relating to router
              advertisements for IPv6.";
           uses ipv6-ra-config;
+        }
+
+        container prefixes {
+          list prefix {
+            key "cidr";
+          
+            description
+              "List of prefixes that are to be included in the IPv6
+              router-advertisement messages for the interface. The list
+              is keyed by the IPv6 prefix in CIDR representation.";
+
+            leaf cidr {
+              type leafref {
+                path "../config/cidr";
+              }
+              description
+                "Reference to the CIDR prefix key for the prefix list.";
+            }
+          
+            container config {
+              description
+                "Configuration parameters corresponding to an IPv6 prefix
+                within the router advertisement.";
+              
+              uses ipv6-ra-prefix-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters corresponding to an IPv6 prefix
+                within the router advertisement.";
+              
+              uses ipv6-ra-prefix-config;
+            }
+          }
         }
       }
 

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -940,7 +940,7 @@ module openconfig-if-ip {
       "Configuration parameters for an individual prefix within an IPv6
       router advertisement.";
 
-    leaf cidr {
+    leaf prefix {
       type oc-inet:ipv4-prefix;
       description
         "IPv6 prefix to be advertised within the router advertisement
@@ -1233,19 +1233,25 @@ module openconfig-if-ip {
             router advertisement message.";
 
           list prefix {
-            key "cidr";
+            key "prefix";
 
             description
               "List of prefixes that are to be included in the IPv6
               router-advertisement messages for the interface. The list
-              is keyed by the IPv6 prefix in CIDR representation.";
+              is keyed by the IPv6 prefix in CIDR representation.
 
-            leaf cidr {
+              Prefixes that are listed are those that are to be
+              advertised in router advertisement messages. Where there
+              are IPv6 global addresses configured on an interface and
+              the prefix is not listed in the prefix list, it MUST NOT
+              be advertised in the router advertisement message.";
+
+            leaf prefix {
               type leafref {
-                path "../config/cidr";
+                path "../config/prefix";
               }
               description
-                "Reference to the CIDR prefix key for the prefix list.";
+                "Reference to the IPv6 prefix key for the prefix list.";
             }
 
             container config {

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -45,7 +45,7 @@ module openconfig-if-ip {
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
   oc-ext:openconfig-version "3.1.0";
-  
+
   revision "2022-11-09" {
     description
       "Add additional IPv6 router-advertisement features.";
@@ -939,7 +939,7 @@ module openconfig-if-ip {
     description
       "Configuration parameters for an individual prefix within an IPv6
       router advertisement.";
-    
+
     leaf cidr {
       type oc-inet:ipv4-prefix;
       description
@@ -966,7 +966,7 @@ module openconfig-if-ip {
         of preferred behaviours.";
       reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.2";
     }
- 
+
     leaf disable-advertisement {
       type boolean;
       description
@@ -980,7 +980,7 @@ module openconfig-if-ip {
       description
         "When set to true, the prefix is marked as not to be used for stateless
         address configuration. This is achieved by setting the autonomous address
-        configuration bit for the prefix."; 
+        configuration bit for the prefix.";
       reference "RFC4861: Neighbor Discovery for IPv6, section 4.6.1";
     }
 
@@ -1228,9 +1228,13 @@ module openconfig-if-ip {
         }
 
         container prefixes {
+          description
+            "Container for a list of prefixes that are included in the
+            router advertisement message.";
+
           list prefix {
             key "cidr";
-          
+
             description
               "List of prefixes that are to be included in the IPv6
               router-advertisement messages for the interface. The list
@@ -1243,12 +1247,12 @@ module openconfig-if-ip {
               description
                 "Reference to the CIDR prefix key for the prefix list.";
             }
-          
+
             container config {
               description
                 "Configuration parameters corresponding to an IPv6 prefix
                 within the router advertisement.";
-              
+
               uses ipv6-ra-prefix-config;
             }
 
@@ -1257,7 +1261,7 @@ module openconfig-if-ip {
               description
                 "Operational state parameters corresponding to an IPv6 prefix
                 within the router advertisement.";
-              
+
               uses ipv6-ra-prefix-config;
             }
           }


### PR DESCRIPTION
```
 * (M) release/models/interfaces/openconfig-if-ip.yang
   - Add support for explicit configuration of the M and O bits.
   - Add support for configuration of prefixes within an RA and the
     flags associated with them.
```

### Change Scope

This change adds support for setting the M and O bits within an RA advertised by a system configured for IPv6.

Additionally, this change adds support for prefixes being advertised within an RA, and specifying the flags that are described by RFC4861 for such prefixes.

The change is backwards compatible (new fields added only).

### Platform Implementations

 * JUNOS [documentation](https://www.juniper.net/documentation/us/en/software/junos/neighbor-discovery/topics/topic-map/ipv6-neighbor-discovery.html)
   - Juniper supports all fields but does not appear to support the ability to disable an advertisement.
 * Arista EOS [documentation](https://www.arista.com/en/um-eos/eos-ipv6).
   - Arista supports all fields in this change.
 * Cisco IOS XR [documentation](https://www.cisco.com/c/en/us/td/docs/ios_xr_sw/iosxr_r3-7/addr_serv/command/reference/ir37ntsk.html)
   - XR supports all fields in this change.
 * Nokia SRLinux [documentation](https://yang.srlinux.dev/v22.3.2/tree.html) (see `/interface/subinterface/ipv6/router-advertisement` and child paths)
   - SRLinux does not support the ability to disable an advertisement

The main discussion point based on these platform implementations is whether the disable advertisement leaf should be included.

### Tree Diff

This diffs current `HEAD` against the change.

```diff
▶ diff -prauwN tree1 tree2
--- tree1	2022-11-09 16:27:45.000000000 -0800
+++ tree2	2022-11-09 16:27:52.000000000 -0800
@@ -134,10 +134,31 @@ module: openconfig-if-ip
        |  |  +--rw interval?   uint32
        |  |  +--rw lifetime?   uint32
        |  |  +--rw suppress?   boolean
+       |  |  +--rw managed?        boolean
+       |  |  +--rw other-config?   boolean
        |  +--ro state
-       |     +--ro interval?   uint32
-       |     +--ro lifetime?   uint32
-       |     +--ro suppress?   boolean
+       |  |  +--ro interval?       uint32
+       |  |  +--ro lifetime?       uint32
+       |  |  +--ro suppress?       boolean
+       |  |  +--ro managed?        boolean
+       |  |  +--ro other-config?   boolean
+       |  +--rw prefixes
+       |     +--rw prefix* [cidr]
+       |        +--rw cidr      -> ../config/cidr
+       |        +--rw config
+       |        |  +--rw cidr?                        oc-inet:ipv4-prefix
+       |        |  +--rw valid-lifetime?              uint32
+       |        |  +--rw preferred-lifetime?          uint32
+       |        |  +--rw disable-advertisement?       boolean
+       |        |  +--rw disable-autoconfiguration?   boolean
+       |        |  +--rw enable-onlink?               boolean
+       |        +--ro state
+       |           +--ro cidr?                        oc-inet:ipv4-prefix
+       |           +--ro valid-lifetime?              uint32
+       |           +--ro preferred-lifetime?          uint32
+       |           +--ro disable-advertisement?       boolean
+       |           +--ro disable-autoconfiguration?   boolean
+       |           +--ro enable-onlink?               boolean
        +--rw neighbors
        |  +--rw neighbor* [ip]
        |     +--rw ip        -> ../config/ip
@@ -319,10 +340,31 @@ module: openconfig-if-ip
        |  |  +--rw interval?   uint32
        |  |  +--rw lifetime?   uint32
        |  |  +--rw suppress?   boolean
+       |  |  +--rw managed?        boolean
+       |  |  +--rw other-config?   boolean
        |  +--ro state
-       |     +--ro interval?   uint32
-       |     +--ro lifetime?   uint32
-       |     +--ro suppress?   boolean
+       |  |  +--ro interval?       uint32
+       |  |  +--ro lifetime?       uint32
+       |  |  +--ro suppress?       boolean
+       |  |  +--ro managed?        boolean
+       |  |  +--ro other-config?   boolean
+       |  +--rw prefixes
+       |     +--rw prefix* [cidr]
+       |        +--rw cidr      -> ../config/cidr
+       |        +--rw config
+       |        |  +--rw cidr?                        oc-inet:ipv4-prefix
+       |        |  +--rw valid-lifetime?              uint32
+       |        |  +--rw preferred-lifetime?          uint32
+       |        |  +--rw disable-advertisement?       boolean
+       |        |  +--rw disable-autoconfiguration?   boolean
+       |        |  +--rw enable-onlink?               boolean
+       |        +--ro state
+       |           +--ro cidr?                        oc-inet:ipv4-prefix
+       |           +--ro valid-lifetime?              uint32
+       |           +--ro preferred-lifetime?          uint32
+       |           +--ro disable-advertisement?       boolean
+       |           +--ro disable-autoconfiguration?   boolean
+       |           +--ro enable-onlink?               boolean
        +--rw neighbors
        |  +--rw neighbor* [ip]
        |     +--rw ip        -> ../config/ip
```
