### PR TITLE
Update VLAN interface member list to be keyed

### DIFF
--- a/release/models/vlan/openconfig-vlan.yang
+++ b/release/models/vlan/openconfig-vlan.yang
@@ -26,7 +26,13 @@ module openconfig-vlan {
     "This module defines configuration and state variables for VLANs,
     in addition to VLAN parameters associated with interfaces";
 
-  oc-ext:openconfig-version "3.2.1";
+  oc-ext:openconfig-version "4.0.0";
+
+  revision "2022-11-17" {
+    description
+      "Update VLAN interface member list to be keyed";
+    reference "4.0.0";
+  }
 
   revision "2021-07-28" {
     description
@@ -149,14 +155,25 @@ module openconfig-vlan {
       "List of interfaces / subinterfaces belonging to the VLAN.";
 
     container members {
+      config false;
+
       description
         "Enclosing container for list of member interfaces";
 
       list member {
-        config false;
         description
           "List of references to interfaces / subinterfaces
           associated with the VLAN.";
+
+        key "interface";
+
+        leaf interface {
+          type leafref {
+            path "../state/interface";
+          }
+          description
+            "Reference to the list key";
+        }
 
         uses oc-if:base-interface-ref-state;
       }


### PR DESCRIPTION
  * (M) release/models/vlan/openconfig-vlan.yang
    - Update VLAN interface member list to follow keyed list
      conventions and move config=false up to the members container

### Change Scope

Per https://github.com/openconfig/public/blob/master/doc/openconfig_style_guide.md#list

```
Lists without keys must not be used unless the openconfig-extensions atomic extension is set for the list's surrounding container. Some transport protocols (e.g., gNMI) do not have a mechanism to refer to individual elements within a list with no key, and this ensures that telemetry updates for such lists include all elements, rather than partial updates being sent.
```

This change makes the VLAN interface member list keyed to (a) conform to the guidelines set forth above and (b) for optimization of deletion of single list members

Per YANG backwards-compatibility guidelines, the list is now keyed thus backwards compatibility is not preserved and the major version is incremented

### Platform Implementations

N/A: Modeling to conform to guidelines and optimization
