### PR TITLE
Network-instance type/enabled and YANG/IETF type cleanup

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -7,8 +7,8 @@ submodule openconfig-network-instance-l2 {
   // import some basic types
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-interfaces { prefix "oc-if"; }
-  import ietf-yang-types { prefix "yang"; }
-  import ietf-inet-types { prefix "inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
   import openconfig-evpn-types { prefix oc-evpn-types; }
   import openconfig-evpn { prefix "oc-evpn"; }
 
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-18" {
+    description
+      "Enforce network-instance type as mandatory, removal of top-level
+      enabled leaf, migrate IETF types to OpenConfig types";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -319,7 +326,7 @@ submodule openconfig-network-instance-l2 {
       "Configuration data for MAC table entries";
 
     leaf mac-address {
-      type yang:mac-address;
+      type oc-yang:mac-address;
       description
         "MAC address for the dynamic or static MAC table
         entry";
@@ -577,7 +584,7 @@ submodule openconfig-network-instance-l2 {
     uses l2ni-l2rib-common-state;
 
     leaf host-ip {
-      type inet:ip-address;
+      type oc-inet:ip-address;
       description
         "Host IP address of the CE device for the L2RIB MAC-IP entry";
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
@@ -599,7 +606,7 @@ submodule openconfig-network-instance-l2 {
     description "L2RIB Common Property Operational State Data Grouping";
 
     leaf mac-address {
-        type yang:mac-address;
+        type oc-yang:mac-address;
         description "MAC address of the L2RIB MAC or MAC-IP entry";
     }
     leaf vlan {
@@ -706,7 +713,7 @@ submodule openconfig-network-instance-l2 {
             description "A unique entry for the next-hop.";
           }
           leaf peer-ip {
-            type inet:ip-address;
+            type oc-inet:ip-address;
             description "Next hop peer address";
           }
           leaf label {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -8,8 +8,8 @@ module openconfig-network-instance {
   prefix "oc-netinst";
 
   // import some basic types
-  import ietf-yang-types { prefix "yang"; }
-  import ietf-inet-types { prefix "inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
   import openconfig-network-instance-types { prefix "oc-ni-types"; }
   import openconfig-policy-types { prefix "oc-pol-types"; }
   import openconfig-routing-policy { prefix "oc-rpol"; }
@@ -48,7 +48,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-18" {
+    description
+      "Enforce network-instance type as mandatory, removal of top-level
+      enabled leaf, migrate IETF types to OpenConfig types";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -297,18 +304,6 @@ module openconfig-network-instance {
             "A unique name identifying the network instance";
         }
 
-        uses l2ni-instance {
-            when "./config/type = 'oc-ni-types:L2VSI'
-                  or ./config/type = 'oc-ni-types:L2P2P'
-                  or ./config/type = 'oc-ni-types:L2L3'
-                  or ./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
-                  description
-                    "Layer 2 configuration parameters included when
-                    a network instance is a Layer 2 instance or a
-                    combined L2L3 instance";
-            }
-        }
-
         container config {
           description
             "Configuration parameters relating to a network
@@ -326,6 +321,18 @@ module openconfig-network-instance {
           uses network-instance-config;
           uses network-instance-type-dependent-config;
           uses network-instance-state;
+        }
+
+        uses l2ni-instance {
+            when "./config/type = 'oc-ni-types:L2VSI'
+                  or ./config/type = 'oc-ni-types:L2P2P'
+                  or ./config/type = 'oc-ni-types:L2L3'
+                  or ./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
+                  description
+                    "Layer 2 configuration parameters included when
+                    a network instance is a Layer 2 instance or a
+                    combined L2L3 instance";
+            }
         }
 
         container evpn {
@@ -980,7 +987,7 @@ module openconfig-network-instance {
       "Configuration parameters relating to an endpoint that is
       remote from the local system";
     leaf remote-system {
-      type inet:ip-address;
+      type oc-inet:ip-address;
       description
         "The IP address of the device which hosts the
         remote end-point";
@@ -1194,6 +1201,7 @@ module openconfig-network-instance {
       type identityref {
         base "oc-ni-types:NETWORK_INSTANCE_TYPE";
       }
+      mandatory true;
       description
         "The type of network instance. The value of this leaf
         indicates the type of forwarding entries that should be
@@ -1207,13 +1215,6 @@ module openconfig-network-instance {
         of type 'DEFAULT_INSTANCE'.";
     }
 
-    leaf enabled {
-      type boolean;
-      description
-        "Whether the network instance should be configured to be
-        active on the network element";
-    }
-
     leaf description {
       type string;
       description
@@ -1222,7 +1223,7 @@ module openconfig-network-instance {
     }
 
     leaf router-id {
-      type yang:dotted-quad;
+      type oc-yang:dotted-quad;
       description
         "A identifier for the local network instance - typically
         used within associated routing protocols or signalling


### PR DESCRIPTION
  * (M) release/models/network-instance/openconfig-network-instance.yang
  * (M) release/models/network-instance/openconfig-network-instance-l2.yang
    - Enforce network-instance type as mandatory for all instances
    - Removal of top-level network-instance enabled leaf
    - Refactor IETF types to OpenConfig types

### Change Scope

Similar to https://github.com/openconfig/public/pull/738 (and can get consolidated if agreed upon as to not have back to back major revision bumps).

This change-set encompasses 3 changes and is backwards incompatible

1. Enforce the network-instance `type` to be mandatory per YANG model.  This is being discussed in https://github.com/openconfig/public/issues/726
2. Removal of the top-level network-instance `enabled` leaf.  There is no implementation reference or guidance for various instance types including `DEFAULT_INSTANCE` and question it's usage in operations
3. Refactoring legacy IETF type references to OpenConfig types

### Platform Implementations

N/A: Mostly cleanup effort and removing nodes not in use without guidance or implementation reference otherwise you can expect deviations, implementation differences or undefined behavior.
