### PR TITLE
Convert `.../bgp/rib/attr-sets/attr-set/as-path/as-segment` and `as4-segment` to keyed lists

### DIFF
--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -24,7 +24,13 @@ submodule openconfig-rib-bgp-attributes {
     attributes for use in BGP RIB tables.";
 
 
-  oc-ext:openconfig-version "0.8.1";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-11-21" {
+    description
+      "Convert as-segment to a keyed list.";
+    reference "0.9.0";
+  }
 
   revision "2022-06-06" {
     description
@@ -81,6 +87,12 @@ submodule openconfig-rib-bgp-attributes {
     description
       "Data for representing BGP AS-PATH attribute";
 
+    leaf index {
+      type uint64;
+      description
+        "A unique index identifying the AS-PATH segment.";
+    }
+
     leaf type {
       type oc-bgpt:as-path-segment-type;
       description
@@ -117,8 +129,18 @@ submodule openconfig-rib-bgp-attributes {
         RFC 5065 - Autonomous System Confederations for BGP";
 
       list as-segment {
+        key "index";
+
         description
-          "Unkeyed list of AS PATH segments";
+          "List of AS-PATH segments";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "A unique index identifying the AS-PATH segment.";
+        }
 
         container state {
           config false;

--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -26,9 +26,9 @@ submodule openconfig-rib-bgp-attributes {
 
   oc-ext:openconfig-version "0.9.0";
 
-  revision "2022-11-21" {
+  revision "2022-12-20" {
     description
-      "Convert as-segment to a keyed list.";
+      "Convert as-segment and as4-segment to keyed lists.";
     reference "0.9.0";
   }
 
@@ -88,9 +88,13 @@ submodule openconfig-rib-bgp-attributes {
       "Data for representing BGP AS-PATH attribute";
 
     leaf index {
-      type uint64;
+      type uint32;
       description
-        "A unique index identifying the AS-PATH segment.";
+        "A unique ordering index starting from 0 identifying the position of
+        the AS-PATH segment in the list of segments.
+
+        The index MUST start from 0 and end at (length-1), where length is the
+        number of segments in the list of AS-PATH segments.";
     }
 
     leaf type {
@@ -129,6 +133,7 @@ submodule openconfig-rib-bgp-attributes {
         RFC 5065 - Autonomous System Confederations for BGP";
 
       list as-segment {
+        oc-ext:telemetry-atomic;
         key "index";
 
         description
@@ -139,7 +144,8 @@ submodule openconfig-rib-bgp-attributes {
             path "../state/index";
           }
           description
-            "A unique index identifying the AS-PATH segment.";
+            "Reference to the unique ordering index starting from 0 identifying
+            the position of the AS-PATH segment in the list of segments.";
         }
 
         container state {
@@ -170,13 +176,25 @@ submodule openconfig-rib-bgp-attributes {
           "RFC 6793 - BGP Support for Four-octet AS Number Space";
 
       list as4-segment {
+        oc-ext:telemetry-atomic;
+        key "index";
+
         description
-          "Unkeyed list of AS PATH segments";
+          "List of AS4-PATH segments";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the unique ordering index starting from 0 identifying
+            the position of the AS4-PATH segment in the list of segments.";
+        }
 
         container state {
           config false;
           description
-            "Opstate data for AS-PATH segments";
+            "Opstate data for AS4-PATH segments";
 
           uses bgp-as-path-attr-state;
         }

--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -115,6 +115,7 @@ submodule openconfig-rib-bgp-attributes {
       "Top-level grouping for AS-PATH attribute data";
 
     container as-path {
+      oc-ext:telemetry-atomic;
       description
         "Enclosing container for the list of AS path segments.
 
@@ -133,7 +134,6 @@ submodule openconfig-rib-bgp-attributes {
         RFC 5065 - Autonomous System Confederations for BGP";
 
       list as-segment {
-        oc-ext:telemetry-atomic;
         key "index";
 
         description
@@ -164,6 +164,7 @@ submodule openconfig-rib-bgp-attributes {
       "Top-level grouping for AS4-PATH attribute data";
 
     container as4-path {
+      oc-ext:telemetry-atomic;
       description
         "This is the path encoded with 4-octet
         AS numbers in the optional transitive AS4_PATH attribute.
@@ -176,7 +177,6 @@ submodule openconfig-rib-bgp-attributes {
           "RFC 6793 - BGP Support for Four-octet AS Number Space";
 
       list as4-segment {
-        oc-ext:telemetry-atomic;
         key "index";
 
         description

--- a/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
@@ -23,9 +23,9 @@ submodule openconfig-rib-bgp-shared-attributes {
 
   oc-ext:openconfig-version "0.9.0";
 
-  revision "2022-11-21" {
+  revision "2022-12-20" {
     description
-      "Convert as-segment to a keyed list.";
+      "Convert as-segment and as4-segment to keyed lists.";
     reference "0.9.0";
   }
 

--- a/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-shared-attributes {
     "This submodule contains structural data definitions for
     attribute sets shared across routes.";
 
-  oc-ext:openconfig-version "0.8.1";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-11-21" {
+    description
+      "Convert as-segment to a keyed list.";
+    reference "0.9.0";
+  }
 
   revision "2022-06-06" {
     description

--- a/release/models/rib/openconfig-rib-bgp-table-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-table-attributes.yang
@@ -23,9 +23,9 @@ submodule openconfig-rib-bgp-table-attributes {
 
   oc-ext:openconfig-version "0.9.0";
 
-  revision "2022-11-21" {
+  revision "2022-12-20" {
     description
-      "Convert as-segment to a keyed list.";
+      "Convert as-segment and as4-segment to keyed lists.";
     reference "0.9.0";
   }
 

--- a/release/models/rib/openconfig-rib-bgp-table-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-table-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-table-attributes {
     "This submodule contains common data definitions for data
     related to a RIB entry, or RIB table.";
 
-  oc-ext:openconfig-version "0.8.1";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-11-21" {
+    description
+      "Convert as-segment to a keyed list.";
+    reference "0.9.0";
+  }
 
   revision "2022-06-06" {
     description

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -32,9 +32,9 @@ submodule openconfig-rib-bgp-tables {
 
   oc-ext:openconfig-version "0.9.0";
 
-  revision "2022-11-21" {
+  revision "2022-12-20" {
     description
-      "Convert as-segment to a keyed list.";
+      "Convert as-segment and as4-segment to keyed lists.";
     reference "0.9.0";
   }
 

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -30,7 +30,13 @@ submodule openconfig-rib-bgp-tables {
     "This submodule contains structural data definitions for
     BGP routing tables.";
 
-  oc-ext:openconfig-version "0.8.1";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-11-21" {
+    description
+      "Convert as-segment to a keyed list.";
+    reference "0.9.0";
+  }
 
   revision "2022-06-06" {
     description

--- a/release/models/rib/openconfig-rib-bgp.yang
+++ b/release/models/rib/openconfig-rib-bgp.yang
@@ -67,7 +67,13 @@ module openconfig-rib-bgp {
     eligible for sending (advertising) to the neighbor after output
     policy rules have been applied.";
 
-  oc-ext:openconfig-version "0.8.1";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-11-21" {
+    description
+      "Convert as-segment to a keyed list.";
+    reference "0.9.0";
+  }
 
   revision "2022-06-06" {
     description

--- a/release/models/rib/openconfig-rib-bgp.yang
+++ b/release/models/rib/openconfig-rib-bgp.yang
@@ -69,9 +69,9 @@ module openconfig-rib-bgp {
 
   oc-ext:openconfig-version "0.9.0";
 
-  revision "2022-11-21" {
+  revision "2022-12-20" {
     description
-      "Convert as-segment to a keyed list.";
+      "Convert as-segment and as4-segment to keyed lists.";
     reference "0.9.0";
   }
 


### PR DESCRIPTION
### Change Scope

* Use an `uint32` index value as the key.
* Non-backward compatible.

### Rationale behind Change
Some OpenConfig tooling (e.g. gNMI, ygot, Ondatra) currently don't provide good support for unkeyed lists. The root problem being gNMI as a path-based configuration cannot indexed into the unkeyed list, forcing a non-leaf representation.

While unkeyed lists can sometimes be a natural representation of some device state ([ref](https://github.com/openconfig/public/pull/750#discussion_r1051282375)), using a keyed list would circumvent this issue. The downside is that there is extra work on the device side to stream the indices of the previous unkeyed list, but this is perceived to be a small price to pay to simplify the tooling.