### PR TITLE
Removal of global per network-instance MTU

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-22" {
+    description
+      "Removal of global per network-instance MTU";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -244,19 +250,6 @@ submodule openconfig-network-instance-l2 {
        uses oc-evpn:evpn-arp-proxy-top;
        uses oc-evpn:evpn-nd-proxy-top;
        uses l2ni-l2rib-top;
-    }
-  }
-
-  grouping l2ni-instance-common-config {
-    description
-      "Common configuration options which are specific to Layer 2
-      network instances";
-
-    leaf mtu {
-      type uint16;
-      description
-        "The maximum frame size which should be supported for this
-        instance for Layer 2 frames";
     }
   }
 

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-22" {
+    description
+      "Removal of global per network-instance MTU";
+    reference "2.0.0";
+  }
 
   revision "2022-09-15" {
     description
@@ -898,16 +904,6 @@ module openconfig-network-instance {
         description
           "Layer 3 VRF configuration parameters included when a
           network instance is a L3VRF or combined L2L3 instance";
-      }
-    }
-
-    uses l2ni-instance-common-config {
-      when "./type = 'oc-ni-types:L2VSI' or ./type = 'oc-ni-types:L2P2P'" +
-           " or ./type = 'oc-ni-types:L2L3'" {
-            description
-              "Layer 2 configuration parameters included when
-              a network instance is a Layer 2 instance or a
-              combined L2L3 instance";
       }
     }
   }


### PR DESCRIPTION
  * (M) release/models/network-instance/openconfig-network-instance.yang
  * (M) release/models/network-instance/openconfig-network-instance-l2.yang
    - Removal of global per network-instance MTU (config/state)

### Change Scope

Initial publishes of various models brought in nodes that either do not map to existing implementations or have no defined/expected behavior.

This patch set removes `/network-instances/network-instance/config/mtu` (as well as the corresponding state node)

Until there is implementation guidance or proof of >1 existing implementations that a per-instance MTU is supported, the suggestion is to remove such nodes from the model set as it produces issues with folks mandating full compliance to OpenConfig model-sets and/or a set of deviations a server and client must implement and understand.

Per YANG backwards compatibility rules, this change is removing a node and thus is backwards incompatible though highly unlikely to affect clients since every implementation has likely produced a deviation for this node.

### Platform Implementations

Noted Deviations:

* Cisco IOS-XR: https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/772/cisco-xr-openconfig-network-instance-deviations.yang#L76-L78
* Nokia SROS: https://github.com/nokia/7x50_YangModels/blob/master/latest_sros_22.7/openconfig/nokia-sr-openconfig-network-instance-deviations.yang#L80-L82
* Arista EOS: https://github.com/aristanetworks/yang/blob/master/EOS-4.29.0.2F/release/openconfig/models/not-supported/arista-network-instance-notsupported-deviations.yang#L2354-L2358
* Juniper JUNOS: https://github.com/Juniper/telemetry/blob/master/22.2/22.2R1/yangs/openconfig/deviation/jnx-openconfig-dev.yang#L1023-L1025
