### PR TITLE
Hardware Resource Thresholds

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -138,7 +138,7 @@ submodule openconfig-platform-common {
     leaf used-threshold-upper {
       type oc-types:percentage;
       description
-        "The used percentage value (used / (used + free) * 100) that 
+        "The used percentage value (used / (used + free) * 100) that
         when crossed will set utilization-threshold-exceeded to 'true'.";
     }
 
@@ -198,10 +198,10 @@ submodule openconfig-platform-common {
     leaf used-threshold-upper-exceeded {
       type boolean;
       description
-        "This value is set to true when the used percentage value (used / (used + free) * 100)  
-        has crossed the used-threshold-upper for this resource and false when the
-        used percentage value has crossed the configured used-threshold-upper-clear
-        value  for this resource.";
+        "This value is set to true when the used percentage value
+        (used / (used + free) * 100) has crossed the used-threshold-upper for this
+        resource and false when the used percentage value has crossed the configured
+        used-threshold-upper-clear value for this resource.";
     }
   }
 

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -195,13 +195,13 @@ submodule openconfig-platform-common {
         (Jan 1, 1970 00:00:00 UTC).";
     }
 
-    leaf threshold-exceeded {
+    leaf used-threshold-upper-exceeded {
       type boolean;
       description
-        "This value is set to true when the system usage has crossed the
-        configured threshold-upper for this resource and false when the
-        system usage has crossed the configured threshold-lower for this
-        resource.";
+        "This value is set to true when the used percentage value (used / (used + free) * 100)  
+        has crossed the used-threshold-upper for this resource and false when the
+        used percentage value has crossed the configured used-threshold-upper-clear
+        value  for this resource.";
     }
   }
 

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -146,7 +146,7 @@ submodule openconfig-platform-common {
     leaf threshold-lower {
       type oc-types:percentage;
       description
-        "The percentage value that will send an alert or system alarm when
+        "The percentage value that will reset an alert or system alarm when
         the used percentage (used / (used + free) * 100) is lower than
         this value";
     }

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -135,20 +135,18 @@ submodule openconfig-platform-common {
         "Resource name within the component.";
     }
 
-    leaf threshold-upper {
+    leaf used-threshold-upper {
       type oc-types:percentage;
       description
-        "The percentage value that will send an alert or system alarm when
-        the used percentage (used / (used + free) * 100) is higher than
-        this value";
+        "The used percentage value (used / (used + free) * 100) that 
+        when crossed will set utilization-threshold-exceeded to 'true'.";
     }
 
-    leaf threshold-lower {
+    leaf used-threshold-upper-clear {
       type oc-types:percentage;
       description
-        "The percentage value that will reset an alert or system alarm when
-        the used percentage (used / (used + free) * 100) is lower than
-        this value";
+        "The used percentage value (used / (used + free) * 100) that when
+        crossed will set utilization-threshold-exceeded to 'false'.";
     }
   }
 

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.21.1";
+  oc-ext:openconfig-version "0.22.0";
+
+  revision "2022-12-20" {
+    description
+      "Add threshold and threshold-exceeded for resource usage.";
+    reference "0.22.0";
+  }
 
   revision "2022-12-19" {
     description
@@ -128,6 +134,22 @@ submodule openconfig-platform-common {
       description
         "Resource name within the component.";
     }
+
+    leaf threshold-upper {
+      type oc-types:percentage;
+      description
+        "The percentage value that will send an alert or system alarm when
+        the used percentage (used / (used + free) * 100) is higher than
+        this value";
+    }
+
+    leaf threshold-lower {
+      type oc-types:percentage;
+      description
+        "The percentage value that will send an alert or system alarm when
+        the used percentage (used / (used + free) * 100) is lower than
+        this value";
+    }
   }
 
   grouping platform-utilization-resource-state {
@@ -171,8 +193,17 @@ submodule openconfig-platform-common {
       type oc-types:timeticks64;
       description
         "The timestamp when the high-watermark was last updated. The value
-		  is the timestamp in nanoseconds relative to the Unix Epoch
-		  (Jan 1, 1970 00:00:00 UTC).";
+        is the timestamp in nanoseconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf threshold-exceeded {
+      type boolean;
+      description
+        "This value is set to true when the system usage has crossed the
+        configured threshold-upper for this resource and false when the
+        system usage has crossed the configured threshold-lower for this
+        resource.";
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.21.1";
+  oc-ext:openconfig-version "0.22.0";
+
+  revision "2022-12-20" {
+     description
+        "Add threshold and threshold-exceeded for resource usage.";
+      reference "0.22.0";
+   }
 
   revision "2022-12-19" {
     description


### PR DESCRIPTION
### Change Scope

* Adding threshold configuration and threshold-exceeded state for platform resource utilization components.
* This change is backwards compatible
pyang output:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--rw utilization
              +--rw resources
                 +--rw resource* [name]
                    +--rw name      -> ../config/name
                    +--rw config
                    |  +--rw name?                         string
                    |  +--rw used-threshold-upper?         oc-types:percentage
                    |  +--rw used-threshold-upper-clear?   oc-types:percentage
                    +--ro state
                       +--ro name?                            string
                       +--ro used-threshold-upper?            oc-types:percentage
                       +--ro used-threshold-upper-clear?      oc-types:percentage
                       +--ro used?                            uint64
                       +--ro committed?                       uint64
                       +--ro free?                            uint64
                       +--ro max-limit?                       uint64
                       +--ro high-watermark?                  uint64
                       +--ro last-high-watermark?             oc-types:timeticks64
                       +--ro used-threshold-upper-exceeded?   boolean

```

### Platform Implementations

 * Arista `hardware capacity alert table <table> [feature <feature>] threshold <threshold>`: [link to documentation](https://www.arista.com/en/um-eos/eos-logging-of-event-notifications?searchword=threshold%20capacity)

