### PR TITLE
Remove incorrect QoS output interface-ref

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-11-30" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -38,7 +38,7 @@ submodule openconfig-qos-elements {
 
   oc-ext:openconfig-version "0.7.0";
 
-  revision "2022-11-30" {
+  revision "2023-02-08" {
     description
       "Remove incorrect output placement of interface-ref";
     reference "0.7.0";

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -27,7 +27,7 @@ submodule openconfig-qos-interfaces {
 
   oc-ext:openconfig-version "0.7.0";
 
-  revision "2022-11-30" {
+  revision "2023-02-08" {
     description
       "Remove incorrect output placement of interface-ref";
     reference "0.7.0";

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-11-30" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description
@@ -864,7 +870,6 @@ submodule openconfig-qos-interfaces {
         uses qos-interface-output-state;
       }
 
-      uses oc-if:interface-ref;
       uses qos-interface-classifier-top;
       uses qos-interface-queue-root-top;
       uses qos-interface-scheduler-top;

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,13 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-11-30" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -31,7 +31,7 @@ submodule openconfig-qos-mem-mgmt {
 
   oc-ext:openconfig-version "0.7.0";
 
-  revision "2022-11-30" {
+  revision "2023-02-08" {
     description
       "Remove incorrect output placement of interface-ref";
     reference "0.7.0";

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -29,7 +29,7 @@ module openconfig-qos {
 
   oc-ext:openconfig-version "0.7.0";
 
-  revision "2022-11-30" {
+  revision "2023-02-08" {
     description
       "Remove incorrect output placement of interface-ref";
     reference "0.7.0";

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,13 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-11-30" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description


### PR DESCRIPTION
  * (M) release/models/qos/openconfig-qos.yang
  * (M) release/models/qos/openconfig-qos-elements.yang
  * (M) release/models/qos/openconfig-qos-interfaces.yang
  * (M) release/models/qos/openconfig-qos-mem-mgmt.yang
    - Remove incorrect interface-ref under interfaces output container

### Change Scope

It appears ever since the initial publish of the QoS models, an incorrect `interface-ref` has existed at the following path:

`/qos/interfaces/interface/output`

```
module: openconfig-qos
  +--rw qos
     +--rw interfaces
        +--rw interface* [interface-id]
           +--rw output
              +--rw interface-ref
                 +--rw config
                 |  +--rw interface?      -> /oc-if:interfaces/interface/name
                 |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                 +--ro state
                    +--ro interface?      -> /oc-if:interfaces/interface/name
                    +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
```

Whereas the same grouping is already identified as a direct descendant container of the interface list

```
module: openconfig-qos
  +--rw qos
     +--rw interfaces
        +--rw interface* [interface-id]
           +--rw interface-ref
              +--rw config
              |  +--rw interface?      -> /oc-if:interfaces/interface/name
              |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
              +--ro state
                 +--ro interface?      -> /oc-if:interfaces/interface/name
                 +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
```

While this change is in theory backwards incompatible due to the removal of the container and child nodes, it is unlikely this has any implementation thus only the minor versions of the affected models have been incremented.

### Platform Implementations

No known implementations to date.  Of the support visible in the public domain, the only implementation claiming OpenConfig QoS support deviates these nodes as `not-supported`
