### PR TITLE
Add uRPF aggregate drop counter to pipeline-drop-packet-state.

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-12-01" {
+    description
+      "Add uRPF aggregate drop counter.";
+    reference "0.3.1";
+  }
 
   revision "2022-11-09" {
     description
@@ -1093,6 +1099,14 @@ module openconfig-platform-pipeline-counters {
         packets are dropped due to legitimate forwarding decisions (ACL drops,
         No Route etc.)";
     }
+
+    leaf urpf-aggregate {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to failing uRPF lookup check.";
+    }
+
   }
 
   grouping pipeline-vendor-drop-packets {

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -1104,7 +1104,9 @@ module openconfig-platform-pipeline-counters {
       type oc-yang:counter64;
       description
         "This aggregation of counters represents the conditions in which
-        packets are dropped due to failing uRPF lookup check.";
+        packets are dropped due to failing uRPF lookup check.  This counter
+        and the packet-processing-aggregate counter should be incremented
+        for each uRPF packet drop.";
     }
 
   }


### PR DESCRIPTION
- (M) release/models/platform/openconfig-platform-pipeline-counters.yang

### Change Scope

This change adds uRPF aggregate drop counter to pipeline drop packet state. This counter represents dropped packets failing uRPF check on the forwarding path. This counter locations is specific for vendor platforms, which report uRPF drops on per-chip basis.
The change is backwards compatible.

### Platform Implementations

#### Cisco (IOS-XR)
Cisco IOS-XR on ASR9K and NCS platforms reports per-chip uPPF drops as `bcmRxTrapUcLooseRpfFai`.

CLI: `show controller npu stats traps-all instance 0 location <chip> | in Rpf`

Vendor telemetry path: `Cisco-IOS-XR-fretta-bcm-dpa-npu-stats-oper:dpa/stats/nodes/node/npu-numbers/npu-number/display/trap-ids/trap-id/packet-dropped`

#### Arista
Reports per-chip uRPF drops as `dropVoqInRpf` counter.

CLI: `show hardware counter drop`.

Vendor telemetry path: `/Smash/hardware/counter/internalDrop/SandCounters/internalDrop`
