### PR TITLE
Creating mutually exclusive tcp details

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -388,7 +388,7 @@ module openconfig-acl {
 
   grouping access-list-entries-top {
     description
-      "Access list entries to level container";
+      "Access list entries top level container";
 
     container acl-entries {
       description

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -394,12 +394,32 @@ module openconfig-packet-match {
         "Destination port or range";
     }
 
-    leaf-list tcp-flags {
-      type identityref {
-        base oc-pkt-match-types:TCP_FLAGS;
+    container transport-details {
+      choice explicit-or-builtin {
+        case explicit-flags {
+          leaf-list tcp-flags {
+            type identityref {
+              base oc-pkt-match-types:TCP_FLAGS;
+            }
+            description
+              "List of TCP flags to match";
+          }
+          leaf match {
+            type enumeration {
+              enum ANY;
+              enum ALL;
+          }
+        }
+        case builtin {
+          leaf keyword {
+            type enumeration {
+              enum TCP-ESTABLISHED;
+              enum TCP-INITIAL;
+              enum FRAGMENT;
+            }
+          }
+        }
       }
-      description
-        "List of TCP flags to match";
     }
   }
 


### PR DESCRIPTION
Adding match-any / match-all necessary for a useful flags list Adding common keywords such as established and fragments, which cannot be used at the same time as explicit flags matching.

### Change Scope

* It is very common for ACLs to be written using keywords such as "established" across a range of vendors.
* Having a tcp-flags leaf list is nice, but incomplete, as you'd need to specify whether you wish to match-any or match-all.
* This change is **not** backward compatible.

### Platform Implementations

 * Cisco: [acl guide](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_data_acl/configuration/15-sy/sec-data-acl-15-sy-book/sec-refine-ip-al.html) 
 * Juniper: [stateless match conditions](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/firewall-filter-stateless-match-conditions-bit-field-values.html) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].
