### PR TITLE
Vendor-specific control-plane traffic counters

### DIFF
--- a/doc/vendor_counter_guide.md
+++ b/doc/vendor_counter_guide.md
@@ -2,7 +2,7 @@
 
 **Contributors**: roland@arista.com
 
-This document provides the guidelines for the vendor-specific portions of openconfig-pipeline-counters.yang. As implementations differ from vendor to vendor and platform to platform, a process of adding vendor-specific counters will be defined here.
+This document provides the guidelines for the vendor-specific portions of openconfig-platform. As implementations differ from vendor to vendor and platform to platform, a process of adding vendor-specific counters will be defined here.
 
 ## Usage: Vendor-specific pipeline drop counter
 
@@ -16,7 +16,7 @@ If these aggregate counters are implemented, the sum of the vendor-specific coun
 
 If an integrated-circuit has a vendor-specific packet drop counter which cannot differentiate between packet-processing, congestion and adverse drops, then that counter should still be exposed as a vendor-specific packet-processing counter with an appropriate description in the vendor's augmentation.   The `packet-processing-aggregate` counter should be incremented in this scenario as expected above.  Such a counter is undesirable as it means this hardware cannot meet the goal for identifying adverse packet drops in the ASIC, but it is better not to ruin the fidelity of the `adverse-aggregate` drop counter with noise of intended packet drops.
 
-## Example
+## Example: Vendor-specific pipeline drop counter
 
 This following is a sample augmentation file.
 
@@ -120,4 +120,72 @@ module: openconfig-platform
                               +--ro acme-ppc:packet-processing-reason-counter-a?    oc-yang:counter64
                               +--ro acme-ppc:packet-processing-reason-counter-b?    oc-yang:counter64
                               +--ro acme-ppc:packet-processing-reason-counter-c?    oc-yang:counter64
+```
+
+## Usage: Vendor-specific control-plane traffic counter
+
+Each implementor should augment `/components/component/integrated-circuit/control-plane-traffic/vendor` with their own `<vendor>/<platform>/state` containers. The naming of the platform container may consist of the platform name, ASIC family, or a combination of both platform and ASIC family. Within the state container, it should define vendor-specific counter containers. Each control-plane traffic counter may use the utility grouping `oc-ic:control-plane-traffic-vendor-counters` that provides the queued/dropped leaves. For each counters augmented into `<vendor>/<platform>/state`, the sum of the counters should be included in the values of the aggregate leaves:
+
+- Counters within `.../control-plane-traffic/vendor/<vendor>/<platform>/state/<counter>/queued` aggregate into `.../control-plane-traffic/state/total-queued`
+- Counters within `.../control-plane-traffic/vendor/<vendor>/<platform>/state/<counter>/queued-bytes` aggregate into `.../control-plane-traffic/state/total-queued-bytes`
+- Counters within `.../control-plane-traffic/vendor/<vendor>/<platform>/state/<counter>/dropped` aggregate into `.../control-plane-traffic/state/total-dropped`
+- Counters within `.../control-plane-traffic/vendor/<vendor>/<platform>/state/<counter>/dropped-bytes` aggregate into `.../control-plane-traffic/state/total-dropped-bytes`
+
+If these aggregate counters are implemented, the sum of the vendor-specific counters must match the aggregate counters.
+
+## Example: Vendor-specific pipeline drop counter
+
+This following is a sample augmentation file.
+
+- Vendor: Acme
+- Platform: AsicFamily
+
+### Example YANG Augmentation
+
+release/platform/acme-asicfamily-control-plane-traffic-augments.yang
+
+```yang
+grouping acme-asicfamily-control-plane-traffic-counters {
+  container queue-counter-a {
+	 uses oc-ppc:control-plane-traffic-vendor-counters;
+  }
+
+  container queue-counter-b {
+	 uses oc-ppc:control-plane-traffic-vendor-counters;
+  }
+
+  container queue-counter-c {
+	 uses oc-ppc:control-plane-traffic-vendor-counters;
+  }
+}
+
+augment "/components/component/integrated-circuit/pipeline-counters/control-plane-traffic/vendor" {
+  container acme {
+    container asic-family {
+      container state {
+        uses acme-asicfamily-control-plane-traffic-counters;
+      }
+    }
+  }
+}
+```
+
+Note: Namespaces omitted from `augment <path>` for brevity
+
+### Example pyang tree
+
+```text
+module: openconfig-platform
+  +--rw components
+     +--rw component* [name]
+        +--rw integrated-circuit
+           +--ro oc-ppc:pipeline-counters
+              +--ro oc-ppc:control-plane-traffic
+                 +--ro oc-ppc:vendor
+                    +--ro acme-ppc:acme
+                       +--ro acme-ppc:asic-family
+                          +--ro acme-ppc:state
+                             +--ro acme-ppc:queue-counter-a
+                             +--ro acme-ppc:queue-counter-b
+                             +--ro acme-ppc:queue-counter-c
 ```

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -69,7 +69,7 @@ module openconfig-platform-pipeline-counters {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  revision "2022-11-29" {
+  revision "2022-02-03" {
     description
       "Add vendor-specific control-plane traffic queue counters";
     reference "0.4.0";
@@ -1142,7 +1142,8 @@ module openconfig-platform-pipeline-counters {
           }
         }";
 
-      reference "doc/vendor_counter_guide.md";
+      reference
+        "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
     }
   }
 
@@ -1155,7 +1156,8 @@ module openconfig-platform-pipeline-counters {
       packet-processing should still be exposed as a vendor-specific,
       packet-processing counter.";
 
-    reference "doc/vendor_counter_guide.md";
+    reference
+      "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
 
     container adverse {
       description
@@ -1248,7 +1250,7 @@ module openconfig-platform-pipeline-counters {
         "This counter counts the number of packets enqueued.
 
         This counter should contribute to the total aggregate of
-        .../pipeline-counters/control-plane-traffic/state/total-queued.";
+        .../pipeline-counters/control-plane-traffic/state/queued-aggregate.";
     }
 
     leaf queued-bytes {
@@ -1257,7 +1259,7 @@ module openconfig-platform-pipeline-counters {
         "This counter counts the number of bytes enqueued.
 
         This counter should contribute to the total aggregate of
-        .../pipeline-counters/control-plane-traffic/state/total-queued-bytes.";
+        .../pipeline-counters/control-plane-traffic/state/queued-bytes-aggregate.";
     }
 
     leaf dropped {
@@ -1266,7 +1268,7 @@ module openconfig-platform-pipeline-counters {
         "This counter counts the number of packets dropped.
 
         This counter should contribute to the total aggregate of
-        .../pipeline-counters/control-plane-traffic/state/total-dropped.";
+        .../pipeline-counters/control-plane-traffic/state/dropped-aggregate.";
     }
 
     leaf dropped-bytes {
@@ -1275,7 +1277,7 @@ module openconfig-platform-pipeline-counters {
         "This counter counts the number of bytes dropped.
 
         This counter should contribute to the total aggregate of
-        .../pipeline-counters/control-plane-traffic/state/total-dropped-bytes.";
+        .../pipeline-counters/control-plane-traffic/state/dropped-bytes-aggregate.";
     }
   }
 
@@ -1323,7 +1325,8 @@ module openconfig-platform-pipeline-counters {
             }
           }";
 
-        reference "doc/vendor_counter_guide.md";
+        reference
+          "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
       }
     }
   }

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -69,7 +69,7 @@ module openconfig-platform-pipeline-counters {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  revision "2022-02-03" {
+  revision "2023-02-03" {
     description
       "Add vendor-specific control-plane traffic queue counters";
     reference "0.4.0";

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,14 +65,14 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.4.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
   revision "2022-11-29" {
     description
       "Add vendor-specific control-plane traffic queue counters";
-    reference "0.3.1";
+    reference "0.4.0";
   }
 
   revision "2022-11-09" {

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2022-11-29" {
+    description
+      "Add vendor-specific control-plane traffic queue counters";
+    reference "0.3.1";
+  }
 
   revision "2022-11-09" {
     description
@@ -410,6 +416,8 @@ module openconfig-platform-pipeline-counters {
           }
         }
       }
+
+      uses pipeline-control-plane-top;
     }
   }
 
@@ -444,7 +452,6 @@ module openconfig-platform-pipeline-counters {
         "Outgoing bytes towards the line interfaces or fabric from the
         integrated-circuit interface subsystem block.";
     }
-
   }
 
   grouping pipeline-counters-common-high-low-packets {
@@ -1106,7 +1113,7 @@ module openconfig-platform-pipeline-counters {
         parts where packets may be dropped at any point in time. Providing
         specific hardware counters provides better visibility into traffic drop.
 
-        The recommended useage of this container is to create an augment at
+        The recommended usage of this container is to create an augment at
         .../pipeline-counter/drop/vendor that contains additional vendor/platform
         specific containers.
 
@@ -1177,6 +1184,130 @@ module openconfig-platform-pipeline-counters {
       container state {
         description
           "State container for vendor specific packet processing counters.";
+      }
+    }
+  }
+
+  grouping control-plane-traffic-counters-state {
+    description
+      "Control plane traffic counter state grouping.";
+
+    leaf total-queued {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch has enqueued
+        traffic related to the control-plane.";
+    }
+
+    leaf total-queued-bytes {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters in bytes where the switch has
+        enqueued traffic related to the control-plane.";
+    }
+
+    leaf total-dropped {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch has dropped
+        traffic related to the control-plane.";
+    }
+
+    leaf total-dropped-bytes {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters in bytes where the switch has
+        dropped traffic related to the control-plane.";
+    }
+  }
+
+  grouping control-plane-traffic-vendor-counters {
+    description
+      "A utility grouping for vendors to use when augmenting the vendor-specific
+      control-plane traffic container.";
+
+    leaf queued {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of packets enqueued.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/total-queued.";
+    }
+
+    leaf queued-bytes {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of bytes enqueued.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/total-queued-bytes.";
+    }
+
+    leaf dropped {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of packets dropped.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/total-dropped.";
+    }
+
+    leaf dropped-bytes {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of bytes dropped.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/total-dropped-bytes.";
+    }
+  }
+
+  grouping pipeline-control-plane-top {
+    description
+      "Top-level structural grouping for control-plane traffic counters.";
+
+    container control-plane-traffic {
+      description
+        "Counters that are related to traffic destined to the control-plane.";
+
+      container state {
+        config false;
+        description
+          "State container for control-plane traffic counters.";
+
+        uses control-plane-traffic-counters-state;
+      }
+
+      container vendor {
+        description
+          "Counters within these containers are defined and augmented by vendors.
+          As each ASIC and vendor has different implementation and internal
+          parts where packets may be dropped at any point in time. Providing
+          vendor-specific counters provides better visibility into control-plane traffic.
+
+          The recommended usage of this container is to create an augment at
+          .../pipeline-counter/control-plane-traffic/vendor that contains additional
+          vendor/platform specific containers.
+
+          e.g.
+          augment /components/component/integrated-circuit/pipeline-counter/control-plane-traffic/vendor {
+            container <vendor name> {
+              container <platform name> {
+                container state {
+                  leaf counter-a {
+                    uses control-plane-traffic-vendor-counters;
+                  }
+
+                  leaf counter-b {
+                    uses control-plane-traffic-vendor-counters;
+                  }
+                }
+              }
+            }
+          }";
+
+        reference "doc/vendor_counter_guide.md";
       }
     }
   }

--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -1192,28 +1192,28 @@ module openconfig-platform-pipeline-counters {
     description
       "Control plane traffic counter state grouping.";
 
-    leaf total-queued {
+    leaf queued-aggregate {
       type oc-yang:counter64;
       description
         "This captures the aggregation of all counters where the switch has enqueued
         traffic related to the control-plane.";
     }
 
-    leaf total-queued-bytes {
+    leaf queued-bytes-aggregate {
       type oc-yang:counter64;
       description
         "This captures the aggregation of all counters in bytes where the switch has
         enqueued traffic related to the control-plane.";
     }
 
-    leaf total-dropped {
+    leaf dropped-aggregate {
       type oc-yang:counter64;
       description
         "This captures the aggregation of all counters where the switch has dropped
         traffic related to the control-plane.";
     }
 
-    leaf total-dropped-bytes {
+    leaf dropped-bytes-aggregate {
       type oc-yang:counter64;
       description
         "This captures the aggregation of all counters in bytes where the switch has


### PR DESCRIPTION
### Change Scope

* (M) doc/vendor_counter_guide.md
  - Updated guide on how to augment /components/component/integrated-circuit/control-plane/vendor
* (M) release/models/platform/openconfig-platform-pipeline-counters.yang
  - Add support with a vendor container for queued/dropped packets/bytes
  - Add support for aggregate counters of each queued/dropped total packets/bytes
* These changes are backwards compatible

#### pyang Output
Model changes:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--ro oc-ppc:pipeline-counters
              +--ro oc-ppc:control-plane-traffic
                 +--ro oc-ppc:state
                 |  +--ro oc-ppc:total-queued?          oc-yang:counter64
                 |  +--ro oc-ppc:total-queued-bytes?    oc-yang:counter64
                 |  +--ro oc-ppc:total-dropped?         oc-yang:counter64
                 |  +--ro oc-ppc:total-dropped-bytes?   oc-yang:counter64
                 +--ro oc-ppc:vendor
```
Vendor-specific model example:
```
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw integrated-circuit
           +--ro oc-ppc:pipeline-counters
              +--ro oc-ppc:control-plane-traffic
                 +--ro oc-ppc:vendor
                    +--ro acme-ppc:acme
                       +--ro acme-ppc:asic-family
                          +--ro acme-ppc:state
                             +--ro acme-ppc:queue-counter-a
                             +--ro acme-ppc:queue-counter-b
                             +--ro acme-ppc:queue-counter-c
```

### Platform Implementations

 * Arista Sand: [link to documentation](https://aristanetworks.force.com/AristaCommunity/s/article/troubleshooting-based-on-control-plane-policing-copp-for-sand-platform)
