### PR TITLE
Cleaning up trailing whitespace

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -29,7 +29,7 @@ module openconfig-transport-types {
       "Add ETH_400GMSA_PSM4 PMD type";
     reference "0.17.0";
   }
-  
+
   revision "2022-09-26" {
     description
       "Add SFP28 and SFP56 form factor identities.";

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.17.0";
+  oc-ext:openconfig-version "0.17.1";
+
+  revision "2022-12-05" {
+    description
+      "Fix trailing whitespace";
+    reference "0.17.1";
+  }
 
   revision "2022-10-18" {
     description


### PR DESCRIPTION
This is to get the trailing whitespace checker to pass for other PRs
* (M) release/models/optical-transport/optical-transport/openconfig-transport-types.yang