### PR TITLE
Fix timestamp documentation

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.21.0";
+  oc-ext:openconfig-version "0.21.1";
+
+  revision "2022-12-19" {
+    description
+      "Update last-high-watermark timestamp documentation.";
+    reference "0.21.1";
+  }
 
   revision "2022-09-26" {
     description
@@ -164,7 +170,9 @@ submodule openconfig-platform-common {
     leaf last-high-watermark {
       type oc-types:timeticks64;
       description
-        "The time when the high-watermark was last updated";
+        "The timestamp when the high-watermark was last updated. The value
+		  is the timestamp in nanoseconds relative to the Unix Epoch
+		  (Jan 1, 1970 00:00:00 UTC).";
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.21.0";
+  oc-ext:openconfig-version "0.21.1";
+
+  revision "2022-12-19" {
+    description
+      "Update last-high-watermark timestamp documentation.";
+    reference "0.21.1";
+  }
 
   revision "2022-09-26" {
     description

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -46,7 +46,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.16.0";
+  oc-ext:openconfig-version "0.16.1";
+
+  revision "2022-12-19" {
+    description
+      "Update last configuration timestamp documentation.";
+    reference "0.16.1";
+  }
 
   revision "2022-09-28" {
     description
@@ -375,7 +381,8 @@ module openconfig-system {
       description
         "Indicates the monotonically increasing timestamp at which the
         last configuration change was made. This may may be through CLI,
-        gNMI or some other mechanism.";
+        gNMI or some other mechanism. The value is the timestamp in
+        nanoseconds relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* Update documentation to be more specific to which time epoch to use
  * /components/component/<component-type>/utilization/resources/resource/state/last-high-watermark
  * /system/state/last-configuration-timestamp
* This change is backwards compatible