### PR TITLE
Remove unused import from openconfig-acl

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -11,7 +11,6 @@ module openconfig-acl {
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-extensions { prefix oc-ext; }
-  import openconfig-inet-types { prefix oc-inet; }
 
   // meta
   organization "OpenConfig working group";
@@ -35,7 +34,13 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.0";
+  oc-ext:openconfig-version "1.3.1";
+
+  revision "2022-12-20" {
+    description
+      "Remove unused openconfig-inet-types import";
+    reference "1.3.1";
+  }
 
   revision "2022-06-01" {
     description


### PR DESCRIPTION
  * (M) release/models/acl/openconfig-acl.yang
    - Remove unused openconfig-inet-types import

### Change Scope

Previous modifications to openconfig-acl introduced an unused import `openconfig-inet-types`.  This PR removes the import and increments the patch version.

This change is backwards compatible

### Platform Implementations

N/A: Backwards compatible cleanup
