### PR TITLE
    Add support for defining a queue identifier under queues.

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -43,8 +43,6 @@ submodule openconfig-qos-elements {
     reference "0.8.0";
   }
 
-  oc-ext:openconfig-version "0.7.0";
-
   revision "2023-02-08" {
     description
       "Remove incorrect output placement of interface-ref";

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-12-20" {
+    description
+      "Add queue identifier.";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description
@@ -559,6 +565,11 @@ submodule openconfig-qos-elements {
       type string;
       description
         "User-defined name of the queue";
+    }
+    leaf queue-id {
+      type uint8;
+      description
+        "Identifier of the queue";
     }
   }
 

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -569,7 +569,8 @@ submodule openconfig-qos-elements {
     leaf queue-id {
       type uint8;
       description
-        "Identifier of the queue";
+        "An optional identifier which may be required by some hardware to map 
+        the named queue to a hardware queue";
     }
   }
 

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -569,7 +569,7 @@ submodule openconfig-qos-elements {
     leaf queue-id {
       type uint8;
       description
-        "An optional identifier which may be required by some hardware to map 
+        "An optional identifier which may be required by some hardware to map
         the named queue to a hardware queue";
     }
   }

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-12-20" {
+    description
+      "Add queue identifier.";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,13 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-12-20" {
+    description
+      "Add queue identifier.";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,13 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2022-12-20" {
+    description
+      "Add queue identifier.";
+    reference "0.7.0";
+  }
 
   revision "2022-09-13" {
     description


### PR DESCRIPTION
* (M) qos/openconfig-qos-interfaces.yang
* (M) qos/openconfig-qos-elements.yang
* (M) qos/openconfig-qos.yang

- Add support for defining a queue identifier per queue.

This additional leaf allows the mapping of hardware or software queues to traffic classes using the system's queue identifiers (often 0-7).

<pre>
Tree view:
module: openconfig-qos
+--rw qos
    +--rw queues
        +--rw queue* [name]
            +--rw name      -> ../config/name
            +--rw config
            |  +--rw name?       string
            |  +--rw queue-id?   uint8
            +--ro state
               +--ro name?       string
               +--ro queue-id?   uint8
</pre>
Some systems allow the mapping of traffic classes to specific queues, some just apply a default mapping.

EOS:
https://www.arista.com/en/um-eos/eos-quality-of-service#xx1156350

Juniper:
https://www.juniper.net/documentation/us/en/software/junos/cos/topics/task/cos-configuring-forwarding-classes.html

