### PR TITLE
Add enabled-address-families back for backward compatibility. 

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.0.0";
+  oc-ext:openconfig-version "4.1.0";
+
+  revision "2022-12-22" {
+    description
+      "Add enabled-address-families leaf-list back for backward
+      compatibility";
+    reference "4.1.0";
+  }
 
   revision "2022-12-21" {
     description

--- a/release/models/network-instance/openconfig-network-instance-l3.yang
+++ b/release/models/network-instance/openconfig-network-instance-l3.yang
@@ -152,7 +152,7 @@ module openconfig-network-instance-l3 {
       description
         "The address families that are to be enabled for this
         network instance. This leaf has been deprecated. It is
-        kept in the model for back compatibility and will be
+        kept in the model for backward compatibility and will be
         removed.";
     }
   }

--- a/release/models/network-instance/openconfig-network-instance-l3.yang
+++ b/release/models/network-instance/openconfig-network-instance-l3.yang
@@ -23,7 +23,14 @@ module openconfig-network-instance-l3 {
     Layer 3 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2022-12-22" {
+    description
+      "Add enabled-address-families leaf-list back for backward
+      compatibility";
+    reference "2.1.0";
+  }
 
   revision "2022-11-08" {
     description
@@ -131,6 +138,23 @@ module openconfig-network-instance-l3 {
       "Configuration and operational state parameters relevant
       to network instances that include a Layer 3 type";
 
+  }
+
+  grouping l3ni-instance-common-config {
+    description
+      "Configuration parameters that are common to L3 network
+      instances other than the default instance";
+
+    leaf-list enabled-address-families {
+      type identityref {
+        base octypes:ADDRESS_FAMILY;
+      }
+      description
+        "The address families that are to be enabled for this
+        network instance. This leaf has been deprecated. It is
+        kept in the model for back compatibility and will be
+        removed.";
+    }
   }
 
   grouping l3ni-route-limit-structural {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.0.0";
+  oc-ext:openconfig-version "4.1.0";
+
+  revision "2022-12-22" {
+    description
+      "Add enabled-address-families leaf-list back for backward
+      compatibility";
+    reference "4.1.0";
+  }
 
   revision "2022-12-21" {
     description
@@ -332,6 +339,7 @@ module openconfig-network-instance {
             "Configuration parameters relating to a network
             instance";
           uses network-instance-config;
+          uses network-instance-type-dependent-config;
         }
 
 
@@ -341,6 +349,7 @@ module openconfig-network-instance {
             "Operational state parameters relating to a network
             instance";
           uses network-instance-config;
+          uses network-instance-type-dependent-config;
           uses network-instance-state;
         }
 
@@ -558,7 +567,7 @@ module openconfig-network-instance {
               An implementation is expected to create entries within
               this list when the relevant protocol context is enabled.
               i.e., when a BGP instance is created with IPv4 and IPv6
-              address families enabled, the protocol=BGP,
+              address families enabled, the protocol=qBGP,
               address-family=IPv4 table is created by the system.";
 
             leaf protocol {
@@ -912,6 +921,19 @@ module openconfig-network-instance {
             }
           }
         }
+      }
+    }
+  }
+
+  grouping network-instance-type-dependent-config {
+    description
+      "Type dependent network instance configuration";
+
+    uses oc-ni-l3:l3ni-instance-common-config {
+      when "./type = 'oc-ni-types:L3VRF' or ./type = 'oc-ni-types:L2L3'" {
+        description
+          "Layer 3 VRF configuration parameters included when a
+          network instance is a L3VRF or combined L2L3 instance";
       }
     }
   }

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -567,7 +567,7 @@ module openconfig-network-instance {
               An implementation is expected to create entries within
               this list when the relevant protocol context is enabled.
               i.e., when a BGP instance is created with IPv4 and IPv6
-              address families enabled, the protocol=qBGP,
+              address families enabled, the protocol=BGP,
               address-family=IPv4 table is created by the system.";
 
             leaf protocol {


### PR DESCRIPTION
Even though the leaf is deprecated some existing implementation still uses it. It is better to keep it in the model for sometime for backward compatibility.