### PR TITLE
add network-instance for logging server

### DIFF
--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -10,7 +10,7 @@ module openconfig-system-logging {
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-inet-types { prefix oc-inet; }
-
+  import openconfig-network-instance { prefix oc-ni; }
 
   // meta
   organization "OpenConfig working group";
@@ -23,7 +23,13 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2022-12-29" {
+    description
+      "Add network-instance for remote logging servers";
+    reference "0.4.1";
+  }
 
   revision "2018-11-21" {
     description
@@ -424,6 +430,12 @@ module openconfig-system-logging {
       type oc-inet:ip-address;
       description
         "Source IP address for packets to the log server";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance used to find the log server.";
     }
 
     leaf remote-port {

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -435,7 +435,8 @@ module openconfig-system-logging {
     leaf network-instance {
       type oc-ni:network-instance-ref;
       description
-        "The network instance used to find the log server.";
+        "The network instance used to reach the log server.  If no
+        instance is specified, DEFAULT_INSTANCE is used.";
     }
 
     leaf remote-port {


### PR DESCRIPTION
### Change Scope

* Add network-instance to system logging to allow a remote syslog server to be accessed via a network-instance
* This change is backwards compatible
```
     +--rw logging
     |  +--rw console
     |  |  +--rw config
     |  |  +--ro state
     |  |  +--rw selectors
     |  |     +--rw selector* [facility severity]
     |  |        +--rw facility    -> ../config/facility
     |  |        +--rw severity    -> ../config/severity
     |  |        +--rw config
     |  |        |  +--rw facility?   identityref
     |  |        |  +--rw severity?   syslog-severity
     |  |        +--ro state
     |  |           +--ro facility?   identityref
     |  |           +--ro severity?   syslog-severity
     |  +--rw remote-servers
     |     +--rw remote-server* [host]
     |        +--rw host         -> ../config/host
     |        +--rw config
     |        |  +--rw host?               oc-inet:host
     |        |  +--rw source-address?     oc-inet:ip-address
     |        |  +--rw network-instance?   oc-ni:network-instance-ref
     |        |  +--rw remote-port?        oc-inet:port-number
     |        +--ro state
     |        |  +--ro host?               oc-inet:host
     |        |  +--ro source-address?     oc-inet:ip-address
     |        |  +--ro network-instance?   oc-ni:network-instance-ref
     |        |  +--ro remote-port?        oc-inet:port-number
     |        +--rw selectors
     |           +--rw selector* [facility severity]
     |              +--rw facility    -> ../config/facility
     |              +--rw severity    -> ../config/severity
     |              +--rw config
     |              |  +--rw facility?   identityref
     |              |  +--rw severity?   syslog-severity
     |              +--ro state
     |                 +--ro facility?   identityref
     |                 +--ro severity?   syslog-severity
```

### Platform Implementations

 * [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-monitoring/70x/b-system-monitoring-cg-cisco8k-70x/implementing_system_logging.html#concept_hgp_lj4_43b) supports logging to a remote server in a vrf
 * [Arista EOS](https://aristanetworks.force.com/AristaCommunity/s/article/logging-basic-syslog-and-beyond) supports logging to a remote server in a vrf
 * [JunOS](https://www.juniper.net/documentation/us/en/software/junos/junos-getting-started/topics/topic-map/management-interface-in-non-default-instance.html) supports logging in different / non-default network instances
