### PR TITLE
add isis max-ecmp-paths for address family

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
 
   revision "2022-09-20" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
 
   revision "2022-09-20" {
     description
@@ -249,6 +255,17 @@ submodule openconfig-isis-routing {
       description "ISIS metric value(default=10).";
     }
   }
+  grouping isis-ecmp-config {
+    description
+      "This grouping defines ISIS ecmp configuration.";
+
+    leaf max-ecmp-paths {
+      type uint8;
+      description
+        "ISIS max-paths count.";
+    }
+
+  }
 
   grouping isis-afi-safi-list {
     description
@@ -284,6 +301,7 @@ submodule openconfig-isis-routing {
         uses isis-afi-safi-config;
         uses isis-metric-config;
         uses rt-admin-config;
+        uses isis-ecmp-config;
       }
 
       container state {
@@ -294,6 +312,7 @@ submodule openconfig-isis-routing {
         uses isis-afi-safi-config;
         uses isis-metric-config;
         uses rt-admin-config;
+        uses isis-ecmp-config;
       }
 
       uses isis-mt-list;

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
 
     revision "2022-09-20" {
     description


### PR DESCRIPTION
### Change Scope

Add max-ecmp-paths for address family.
This change is backwards compatible.
### Platform Implementations

 * Cisco IOS XR supports config max-ecmp-paths per af.
[link](https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/781/Cisco-IOS-XR-clns-isis-cfg.yang#L3414)
 * Huawei VRP supports config max-ecmp-paths per af also.
[link](https://github.com/Huawei/yang/blob/master/network-router/8.21.0/ne40e-x8x16/huawei-isis.yang#L2544)
