### PR TITLE
Move openconfig-telemetry `dynamic-subscription` fields to per `sensor-path`

### DIFF
--- a/release/models/telemetry/openconfig-telemetry.yang
+++ b/release/models/telemetry/openconfig-telemetry.yang
@@ -22,7 +22,15 @@ module openconfig-telemetry {
     "Data model which creates the configuration for the telemetry
      systems and functions on the device.";
 
-  oc-ext:openconfig-version "0.5.1";
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2023-01-05" {
+    description
+      "Move sample-interval, heartbeat-interval and
+      suppress-redundant dynamic-subscription fields
+      to per sensor-path.";
+    reference "0.6.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -448,9 +456,6 @@ module openconfig-telemetry {
 
                 uses telemetry-subscription-config;
                 uses telemetry-stream-destination-config;
-                uses telemetry-stream-frequency-config;
-                uses telemetry-heartbeat-config;
-                uses telemetry-suppress-redundant-config;
                 uses telemetry-qos-marking-config;
                 uses telemetry-stream-protocol-config;
                 uses telemetry-stream-encoding-config;
@@ -516,6 +521,10 @@ module openconfig-telemetry {
            values";
           //May not be necessary. Could remove.
       }
+
+      uses telemetry-stream-frequency-config;
+      uses telemetry-heartbeat-config;
+      uses telemetry-suppress-redundant-config;
   }
 
   grouping telemetry-heartbeat-config {


### PR DESCRIPTION
The `/telemetry-system/subscriptions/dynamic-subscriptions` model is based on active [gNMI Subscribe](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#351-managing-subscriptions) RPCs.  

A gNMI Subscribe [request](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto) is structured for example as follows:
```
subscribe: <
    subscription: <
        mode: SAMPLE
        sample_interval: 1000000000
        path: <
            elem: <
                name: "components"
            >
        >
    >
    subscription: <
        mode: SAMPLE
        sample_interval: 2000000000
        suppress_redundant: true
        path: <
            elem: <
                name: "interfaces"
            >
        >
    >
    subscription: <
        mode: ON_CHANGE
        heartbeat_interval: 3000000000
        path: <
            elem: <
                name: "system"
            >
        >
    >
>
```

Each `subscription` in the subscription list contains only one path, along with optional additional fields. The `sample_interval`, `suppress_redundant` and `heartbeat_interval` fields can differ for each path.

The existing model only allows for one `sample_interval`, `suppress_redundant` and `heartbeat_interval` field per `dynamic-subscription`, not per `sensor-path` (which exists as a list of paths per `dynamic-subscription`):
```
  +--rw telemetry-system
     +--rw subscriptions
        +--rw dynamic-subscriptions
           +--ro dynamic-subscription* [id]
              +--ro id              -> ../state/id
              +--ro state
              |  +--ro id?                       uint64
              |  +--ro destination-address?      oc-inet:ip-address
              |  +--ro destination-port?         uint16
              |  +--ro sample-interval?          uint64
              |  +--ro heartbeat-interval?       uint64
              |  +--ro suppress-redundant?       boolean
              |  +--ro originated-qos-marking?   oc-inet:dscp
              |  +--ro protocol?                 identityref
              |  +--ro encoding?                 identityref
              +--ro sensor-paths
                 +--ro sensor-path* [path]
                    +--ro path     -> ../state/path
                    +--ro state
                       +--ro path?             string
                       +--ro exclude-filter?   string
```

This change moves those fields so they can be specified per `sensor-path`:
```
  +--rw telemetry-system
     +--rw subscriptions
        +--rw dynamic-subscriptions
           +--ro dynamic-subscription* [id]
              +--ro id              -> ../state/id
              +--ro state
              |  +--ro id?                       uint64
              |  +--ro destination-address?      oc-inet:ip-address
              |  +--ro destination-port?         uint16
              |  +--ro originated-qos-marking?   oc-inet:dscp
              |  +--ro protocol?                 identityref
              |  +--ro encoding?                 identityref
              +--ro sensor-paths
                 +--ro sensor-path* [path]
                    +--ro path     -> ../state/path
                    +--ro state
                       +--ro path?                 string
                       +--ro exclude-filter?       string
                       +--ro sample-interval?      uint64
                       +--ro heartbeat-interval?   uint64
                       +--ro suppress-redundant?   boolean
```

As a result, an active gNMI Subscribe RPC can be modelled as a single `dynamic-subscription`. 

This change is not backwards compatible.
