### PR TITLE
Maoc

### DIFF
--- a/release/models/system/openconfig-system-redundancy.yang
+++ b/release/models/system/openconfig-system-redundancy.yang
@@ -1,0 +1,361 @@
+module openconfig-system-redundancy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/system/redundancy";
+
+  prefix "oc-sys-red";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-platform { prefix oc-platform; }
+  
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines the configuration and operational state data
+    related to redundant systems, such as two supervisors in a device.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-07-20" {
+    description
+      "Initial revision with management-active redundancy";
+    reference "0.1.0";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+  identity SYSTEM_MANAGEMENT_MONITOR_MODE_BASE {
+    description
+      "Base identity for monitor modes for redundant management links.";
+  }
+
+  identity SYSTEM_MANAGEMENT_MONITOR_LINK_STATE {
+    base SYSTEM_MANAGEMENT_MONITOR_MODE_BASE;
+    description
+      "Monitor link-state of redundant management links.";
+  }
+
+  identity SYSTEM_MANAGEMENT_MONITOR_NEIGHBOR {
+    base SYSTEM_MANAGEMENT_MONITOR_MODE_BASE;
+    description
+      "Monitor nieghbor reachability via redundant management links.";
+  }
+
+  // typedef statements
+
+  // grouping statements
+  grouping management-active-link-controller-card-config {
+    description
+      "Configuration data for controller card components.";
+     
+    leaf name {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/oc-platform:name";
+      }
+      description
+        "References the controller card component.";
+    }
+
+    leaf-list interface {
+      type leafref {
+        path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+      }
+      ordered-by user;
+
+      description
+        "Ordered list of redundant management links for 
+        managment-active interface when this controller
+        card is active.";
+    }
+  }
+
+  grouping management-active-link-controller-card-state {
+    description
+      "Operational state data for controller card components.";  
+  }
+
+  grouping management-active-link-controller-card-list {
+    description
+      "Top-level grouping for list of controller card components.";
+
+    container controller-cards {
+      description
+        "Top-level container for list of controller card components.";
+      
+      list controller-card {
+        key "name";
+        description
+          "Controller card name";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+
+          description
+            "References the controller card name";
+        }
+
+        container config {
+          description
+            "Configuration data for controller card components.";
+          uses management-active-link-controller-card-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for controller card components.";
+          uses management-active-link-controller-card-config;
+          uses management-active-link-controller-card-state;
+        }
+      }
+    }
+  }
+
+  grouping management-active-link-config {
+    description
+      "Configuration data for management-active interface current active.";
+  }
+
+  grouping management-active-link-state {
+    description
+      "Operational state data for management-active interface current active.";
+
+    leaf active-controller-card {
+      type leafref {
+        path "../../controller-cards/controller-card/name";
+      }
+
+      description
+        "References the active controller card component";
+    }
+
+    leaf active-interface {
+      type leafref {
+        path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+      }
+
+      description
+        "References the active management link";
+    }
+  }
+
+  grouping management-active-link-top {
+    description
+      "Top-level grouping for management-active interface current active data.";
+
+    container link {
+      description
+        "";
+
+      container config {
+        description
+          "Configuration data for management-active interface current active.";
+        uses management-active-link-config;
+
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for management-active interface current active.";
+
+        uses management-active-link-config;
+        uses management-active-link-state;
+      }
+
+      uses management-active-link-controller-card-list;
+    }
+  }
+
+  grouping management-active-neighbor-monitor-config {
+    description
+      "Configuration data for neighbor monitor.";
+
+    leaf neighbor-monitor {
+      type oc-inet:ip-address;
+      description
+        "Neighbor address to be monitored.";
+    }
+
+    leaf monitor-interval {
+      type uint32;
+      units "milliseconds";
+      description
+        "Interval for sending ARP or NS request packets to the neighbor.";
+    }
+
+    leaf timeout-multiplier {
+      type uint32;
+      description
+        "Maximum number of missed ARP or NA replies from the neighbor after
+        which the failover occurs.";
+    }
+  }
+
+  grouping management-active-neighbor-monitor-state {
+    description
+      "Operational state data for neighbor monitor.";
+  }
+
+  grouping management-active-neighbor-monitor-top {
+    description
+      "Top-level grouping for neighbor monitor data.";
+
+    container neighbor-monitor {
+      description
+        "Top-level container for neighbor monitor data.";
+
+      container config {
+        description
+          "Configuration data for neighbor monitor.";
+
+        uses management-active-neighbor-monitor-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for neighbor monitor.";
+
+        uses management-active-neighbor-monitor-config;
+        uses management-active-neighbor-monitor-state;
+      }
+    }
+  }
+
+  grouping redundancy-management-active-config {
+    description
+      "Configuration data for management-active interface redundancy.";
+
+    leaf enabled {
+      type boolean;
+      description
+        "Enables and disables management-active interface redundancy";
+    }
+
+    leaf monitor-mode {
+      type identityref {
+        base SYSTEM_MANAGEMENT_MONITOR_MODE_BASE;
+      }
+      default SYSTEM_MANAGEMENT_MONITOR_LINK_STATE;
+      description
+        "Monitor mode for management-active interface redundanct links.";
+    }
+
+    choice fallback-delay {
+      default infinity;
+      case delay {
+        leaf delay {
+          type uint32;
+          units "seconds";
+          description
+            "Delay after which a higher priority management link
+            will be considered to fallback after it has come up";
+        }
+      }
+      case infinity {
+        leaf infinity {
+           type empty;
+           description
+             "Dont automatically fallback to a higher priority 
+             management link after it has come up.";
+        }
+      }
+    }
+  }
+
+  grouping redundancy-management-active-state {
+    description
+      "Operational state data for management-active interface redundancy.";
+
+    leaf last-redundancy-config-change {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+
+      description
+        "This timestamp indicates the time redundancy configuration
+        was last applied to management-active interface.
+        The value is the timestamp in nanoseconds relative
+        to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf last-redundancy-link-change {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+
+      description
+        "This timestamp indicates the time active link was
+        last changed for management-active interface.
+        The value is the timestamp in nanoseconds relative
+        to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+  
+  grouping redundancy-management-active-top {
+    description
+      "Top-level grouping for management-active interface redundancy data.";
+
+    container management-active {
+      description
+        "Top-level container for management-active interface redundancy
+        data. The management-active is a logical interface on
+        modular systems providing out of band access to the active
+        controller card";
+
+      container config {
+        description
+          "Configuration data for management-active interface redundancy.";
+
+        uses redundancy-management-active-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for management-active interface redundancy.";
+
+        uses redundancy-management-active-config;
+        uses redundancy-management-active-state;
+      }
+
+      uses management-active-neighbor-monitor-top;
+      uses management-active-link-top;
+    }
+  }
+  
+  grouping system-redundancy-top {
+    description
+      "Top-level grouping for system level redundancy features.";
+
+    container redundancy {
+      description
+        "Top-level container for system level redundancy features.";
+
+      uses redundancy-management-active-top;
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/release/models/system/openconfig-system-redundancy.yang
+++ b/release/models/system/openconfig-system-redundancy.yang
@@ -58,7 +58,7 @@ module openconfig-system-redundancy {
   // typedef statements
 
   // grouping statements
-  grouping management-active-link-controller-card-config {
+  grouping management-active-controller-card-config {
     description
       "Configuration data for controller card components.";
      
@@ -83,12 +83,12 @@ module openconfig-system-redundancy {
     }
   }
 
-  grouping management-active-link-controller-card-state {
+  grouping management-active-controller-card-state {
     description
       "Operational state data for controller card components.";  
   }
 
-  grouping management-active-link-controller-card-list {
+  grouping management-active-controller-card-list {
     description
       "Top-level grouping for list of controller card components.";
 
@@ -113,26 +113,26 @@ module openconfig-system-redundancy {
         container config {
           description
             "Configuration data for controller card components.";
-          uses management-active-link-controller-card-config;
+          uses management-active-controller-card-config;
         }
 
         container state {
           config false;
           description
             "Operational state data for controller card components.";
-          uses management-active-link-controller-card-config;
-          uses management-active-link-controller-card-state;
+          uses management-active-controller-card-config;
+          uses management-active-controller-card-state;
         }
       }
     }
   }
 
-  grouping management-active-link-config {
+  grouping management-active-current-active-config {
     description
       "Configuration data for management-active interface current active.";
   }
 
-  grouping management-active-link-state {
+  grouping management-active-current-active-state {
     description
       "Operational state data for management-active interface current active.";
 
@@ -155,18 +155,18 @@ module openconfig-system-redundancy {
     }
   }
 
-  grouping management-active-link-top {
+  grouping management-active-redundant-link-top {
     description
-      "Top-level grouping for management-active interface current active data.";
+      "Top-level grouping for management-active interface redundant links.";
 
-    container link {
+    container redundant-link {
       description
-        "";
+        "Top-level container for management-active interface redundant links.";
 
       container config {
         description
           "Configuration data for management-active interface current active.";
-        uses management-active-link-config;
+        uses management-active-current-active-config;
 
       }
 
@@ -175,11 +175,11 @@ module openconfig-system-redundancy {
         description
           "Operational state data for management-active interface current active.";
 
-        uses management-active-link-config;
-        uses management-active-link-state;
+        uses management-active-current-active-config;
+        uses management-active-current-active-state;
       }
 
-      uses management-active-link-controller-card-list;
+      uses management-active-controller-card-list;
     }
   }
 
@@ -335,7 +335,7 @@ module openconfig-system-redundancy {
       }
 
       uses management-active-neighbor-monitor-top;
-      uses management-active-link-top;
+      uses management-active-redundant-link-top;
     }
   }
   

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -15,6 +15,7 @@ module openconfig-system {
   import openconfig-aaa { prefix oc-aaa; }
   import openconfig-system-logging { prefix oc-log; }
   import openconfig-system-terminal { prefix oc-sys-term; }
+  import openconfig-system-redundancy { prefix oc-sys-red; }
   import openconfig-procmon { prefix oc-proc; }
   import openconfig-platform { prefix oc-platform; }
   import openconfig-alarms { prefix oc-alarms; }
@@ -46,8 +47,14 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.16.0";
+  oc-ext:openconfig-version "0.17.0";
 
+  revision "2022-12-22" {
+    description
+      "Adding system redundancy models.";
+    reference "0.17.0";
+  }
+  
   revision "2022-09-28" {
     description
       "Add last configuration timestamp leaf.";
@@ -1248,6 +1255,7 @@ module openconfig-system {
       uses oc-messages:messages-top;
       uses oc-license:license-top;
       uses system-macaddr-top;
+      uses oc-sys-red:system-redundancy-top;
     }
   }
 


### PR DESCRIPTION

### Change Scope

* Adding release/models/system/openconfig-system-redundancy.yang model for management-active interface redundancy. The management-active is a logical interface on modular systems providing out of band access to the active controller card. We are adding redundancy feature to the management-active interface with following features
   * There are two monitor modes
      * The `SYSTEM_MANAGEMENT_MONITOR_LINK_STATE` monitors the link-state of redundant links
      * The `SYSTEM_MANAGEMENT_MONITOR_NEIGHBOR` monitors neighbor reachability via redundant links. 
         * The `monitor-interval` specifies the interval in milliseconds for sending ARP or NS request packets to the neighbor
         * The `timeout-multiplier` specifies the maximum number of missed ARP or NA replies from the neighbor after which the failover occurs to the next redundant link.
         * The implementation currently supports monitoring only an IPv6 neighbor 
   * The `fallback-delay` specifies the delay in seconds after which a higher priority management link will be considered to fallback after it has come up. We can also specify `infinity`, which means never automatically fallback.
   * Ordered list of redundant management links are specified per controller card. When the controller card is active, the corresponding links are used for management-active interface redundancy.
 * This is a new model and so should be backward compatible

pyang output

```
module: openconfig-system
  +--rw system
     +--rw redundancy
        +--rw management-active
           +--rw config
           |  +--rw enabled?          boolean
           |  +--rw monitor-mode?     identityref
           |  +--rw (fallback-delay)?
           |     +--:(delay)
           |     |  +--rw delay?      uint32
           |     +--:(infinity)
           |        +--rw infinity?   empty
           +--ro state
           |  +--ro enabled?                         boolean
           |  +--ro monitor-mode?                    identityref
           |  +--ro (fallback-delay)?
           |  |  +--:(delay)
           |  |  |  +--ro delay?                     uint32
           |  |  +--:(infinity)
           |  |     +--ro infinity?                  empty
           |  +--ro last-redundancy-config-change?   oc-types:timeticks64
           |  +--ro last-redundancy-link-change?     oc-types:timeticks64
           +--rw neighbor-monitor
           |  +--rw config
           |  |  +--rw neighbor-monitor?     oc-inet:ip-address
           |  |  +--rw monitor-interval?     uint32
           |  |  +--rw timeout-multiplier?   uint32
           |  +--ro state
           |     +--ro neighbor-monitor?     oc-inet:ip-address
           |     +--ro monitor-interval?     uint32
           |     +--ro timeout-multiplier?   uint32
           +--rw redundant-link
              +--rw config
              +--ro state
              |  +--ro active-controller-card?   -> ../../controller-cards/controller-card/name
              |  +--ro active-interface?         -> /oc-if:interfaces/interface/name
              +--rw controller-cards
                 +--rw controller-card* [name]
                    +--rw name      -> ../config/name
                    +--rw config
                    |  +--rw name?        -> /oc-platform:components/component/name
                    |  +--rw interface*   -> /oc-if:interfaces/interface/name
                    +--ro state
                       +--ro name?        -> /oc-platform:components/component/name
                       +--ro interface*   -> /oc-if:interfaces/interface/name
```
### Platform Implementations

 * Arista: This is a new feature for which public facing doc is being written. Here is the CLI config and show commands.
 

```
(s1)(config-if-Ma0)#show active
interface Management0
   ip address 172.30.181.48/25
   ipv6 address fd7a:629f:52a4:b0ab::ac1e:b530/64
   redundancy monitor neighbor ipv6 fd7a:629f:52a4:b0ab::1
   redundancy supervisor 1 interface primary Management1/1 backup Management1/2 Management2/1
   redundancy supervisor 2 interface primary Management2/1 backup Management2/2 Management1/1
 
(s1)(config-if-Ma0)#show redundancy ma0
Management0
  Redundancy: Enabled
  Redundancy active interface: Management1/1
  Last redundancy link change: 23 seconds ago
  Last redundancy config change: 12 seconds ago
  Redundancy monitor: neighbor fd7a:629f:52a4:b0ab::1, interval 200 milliseconds, multiplier 3
  Redundancy fallback-delay: infinity
  Redundancy interfaces: primary Management1/1 (up), backup Management1/2 (up), backup Management2/1 (up)

```
