### PR TITLE
Added new model for route summary

### DIFF
--- a/release/models/network-instance/.spec.yml
+++ b/release/models/network-instance/.spec.yml
@@ -5,6 +5,7 @@
     - yang/network-instance/openconfig-evpn-types.yang
     - yang/network-instance/openconfig-evpn.yang
     - yang/network-instance/openconfig-programming-errors.yang
+    - yang/network-instance/openconfig-route-summary.yang
     - yang/aft/openconfig-aft-network-instance.yang
     - yang/segment-routing/openconfig-rsvp-sr-ext.yang
     - yang/segment-routing/openconfig-segment-routing.yang
@@ -12,6 +13,7 @@
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/network-instance/openconfig-programming-errors.yang
+    - yang/network-instance/openconfig-route-summary.yang
     - yang/aft/openconfig-aft-network-instance.yang
     - yang/segment-routing/openconfig-rsvp-sr-ext.yang
   run-ci: true

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -53,7 +53,7 @@ module openconfig-route-summary {
       type oc-yang-types:counter64;
     }
 
-    leaf installed-count {
+    leaf aft-count {
       description
         "Number of AFT routes installed in the hardware for the given source.";
       type oc-yang-types:counter64;

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -18,8 +18,8 @@ module openconfig-route-summary {
     www.openconfig.net";
 
   description
-    "This module provides summary of route counts per source of routing
-     information for each network instance.";
+    "This module provides summary of route counts per route type for each network
+    instance.";
 
   oc-ext:openconfig-version "1.0.0";
 
@@ -31,29 +31,25 @@ module openconfig-route-summary {
 
   grouping route-counter {
     description
-      "Operational state information indicating the number of routes that
-       are learnt from each source of routing information. A source is
-       defined in terms of the protocol that installed the routes into the
-       device RIB.";
+      "Route type counter item.";
 
     leaf source {
       description
-        "The source of the routing entries, expressed in terms of the
-         installing protocol.";
+        "Route type that keys the route count list.";
 
       type identityref {
         base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
       }
     }
 
-    leaf rib-count {
+    leaf total-count {
       description
         "Total number of routes in the AFT for the given source. This count includes
         routes which may not be installed due to hardware constraints.";
       type oc-yang-types:counter64;
     }
 
-    leaf aft-count {
+    leaf installed-count {
       description
         "Number of AFT routes installed in the hardware for the given source.";
       type oc-yang-types:counter64;

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -3,7 +3,7 @@ module openconfig-route-summary {
 
   namespace "http://openconfig.net/yang/route-summary";
 
-  prefix "openconfig-route-summary";
+  prefix "oc-rtsummary";
 
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-yang-types { prefix "oc-yang-types"; }

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -20,7 +20,6 @@ module openconfig-route-summary {
   description
     "This module provides summary of route counts per source of routing
      information for each network instance.";
-    instance.";
 
   oc-ext:openconfig-version "1.0.0";
 
@@ -39,7 +38,8 @@ module openconfig-route-summary {
 
     leaf source {
       description
-        "Route type that keys the route count list.";
+        "The source of the routing entries, expressed in terms of the
+         installing protocol.";
 
       type identityref {
         base "oc-pol-types:INSTALL_PROTOCOL_TYPE";

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -49,9 +49,24 @@ module openconfig-route-summary {
   grouping route-summary {
     list route-count {
       key "route-type";
-      uses route-counter;
+
       description
         "Route types that keys the route count list.";
+
+      leaf route-type {
+        type leafref {
+          path "../state/route-type";
+        }
+        description
+          "Reference to the protocol type.";
+      }
+
+      container state {
+        description
+          "State parameters for the route summary list entry.";
+        uses route-counter;
+      }
+
     }
     description
       "Route count by route type.";

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -65,17 +65,17 @@ module openconfig-route-summary {
       "A summary of route count by route type.";
 
     list route-count {
-      key "source";
+      key "origin-protocol";
 
       description
         "Route types that keys the route count list.";
 
-      leaf source {
+      leaf origin-protocol {
         type leafref {
-          path "../state/source";
+          path "../state/origin-protocol";
         }
         description
-          "Reference to the source of he route.";
+          "Reference to the source of the route.";
       }
 
       container state {

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -30,35 +30,43 @@ module openconfig-route-summary {
   }
 
   grouping route-counter {
-    leaf route-type {
+    description
+      "Route type counter item.";
+
+    leaf source {
+      description
+        "Route type that keys the route count list.";
       type identityref {
         base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
       }
-      description
-        "Route type that keys the route count list.";
     }
-    leaf count {
+
+    leaf total-count {
+      description
+        "Total number of routes in the AFT for the given source. This count includes
+        routes which may not be installed due to hardware constraints.";
       type oc-yang-types:counter64;
-      description
-        "Count for the route type.";
     }
-    description
-      "Route type counter item.";
+    leaf installed-count {
+      description
+        "Number of AFT routes installed in the hardware for the given source.";
+      type oc-yang-types:counter64;
+    }
   }
 
   grouping route-summary {
     list route-count {
-      key "route-type";
+      key "source";
 
       description
         "Route types that keys the route count list.";
 
-      leaf route-type {
+      leaf source {
         type leafref {
-          path "../state/route-type";
+          path "../state/source";
         }
         description
-          "Reference to the protocol type.";
+          "Reference to the source of he route.";
       }
 
       container state {
@@ -69,7 +77,7 @@ module openconfig-route-summary {
 
     }
     description
-      "Route count by route type.";
+      "A summary of route count by route type.";
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv6-unicast" {

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -18,7 +18,8 @@ module openconfig-route-summary {
     www.openconfig.net";
 
   description
-    "This module provides summary of route counts per route type for each network
+    "This module provides summary of route counts per source of routing
+     information for each network instance.";
     instance.";
 
   oc-ext:openconfig-version "1.0.0";

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -42,16 +42,20 @@ module openconfig-route-summary {
       }
     }
 
-    leaf total-count {
+    container total-count {
       description
-        "Total number of routes in the AFT for the given source. This count includes
-        routes which may not be installed due to hardware constraints.";
-      type oc-yang-types:counter64;
+        "A collection of route counts.";
+      uses total-count;
     }
+  }
 
-    leaf installed-count {
+  grouping total-count {
+    description
+      "A collection of route counts.";
+
+    leaf fib-count {
       description
-        "Number of AFT routes installed in the hardware for the given source.";
+        "Total number of routes in the FIB.";
       type oc-yang-types:counter64;
     }
   }

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -1,0 +1,81 @@
+module openconfig-route-summary {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/route-summary";
+
+  prefix "openconfig-route-summary";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang-types"; }
+  import openconfig-policy-types { prefix "oc-pol-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module provides summary of route counts per route type for each network
+    instance.";
+
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-12-21" {
+    description
+      "Initial version.";
+    reference "1.0.0";
+  }
+
+  grouping route-counter {
+    leaf route-type {
+      type identityref {
+        base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
+      }
+      description
+        "Route type that keys the route count list.";
+    }
+    leaf count {
+      type oc-yang-types:counter64;
+      description
+        "Count for the route type.";
+    }
+    description
+      "Route type counter item.";
+  }
+
+  grouping route-summary {
+    list route-count {
+      key "route-type";
+      uses route-counter;
+      description
+        "Route types that keys the route count list.";
+    }
+    description
+      "Route count by route type.";
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv6-unicast" {
+    container summary {
+      uses route-summary;
+      description
+        "IPv4 route summary for the network instance.";
+    }
+    description
+      "Augment the network-instance model with the route summary container for
+      IPv4.";
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv4-unicast" {
+    container summary {
+      uses route-summary;
+      description
+        "IPv6 route summary for the network instance.";
+    }
+    description
+      "Augment the network-instance model with the route summary container for
+      IPv6.";
+  }
+}

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -46,7 +46,7 @@ module openconfig-route-summary {
       }
     }
 
-    leaf total-count {
+    leaf rib-count {
       description
         "Total number of routes in the AFT for the given source. This count includes
         routes which may not be installed due to hardware constraints.";

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -33,7 +33,7 @@ module openconfig-route-summary {
     description
       "Route type counter item.";
 
-    leaf source {
+    leaf origin-protocol {
       description
         "Route type that keys the route count list.";
 

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -36,6 +36,7 @@ module openconfig-route-summary {
     leaf source {
       description
         "Route type that keys the route count list.";
+
       type identityref {
         base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
       }
@@ -47,6 +48,7 @@ module openconfig-route-summary {
         routes which may not be installed due to hardware constraints.";
       type oc-yang-types:counter64;
     }
+
     leaf installed-count {
       description
         "Number of AFT routes installed in the hardware for the given source.";
@@ -55,6 +57,9 @@ module openconfig-route-summary {
   }
 
   grouping route-summary {
+    description
+      "A summary of route count by route type.";
+
     list route-count {
       key "source";
 
@@ -74,31 +79,30 @@ module openconfig-route-summary {
           "State parameters for the route summary list entry.";
         uses route-counter;
       }
-
     }
-    description
-      "A summary of route count by route type.";
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv6-unicast" {
+    description
+      "Augment the network-instance model with the route summary container for
+      IPv4.";
+
     container summary {
       uses route-summary;
       description
         "IPv4 route summary for the network instance.";
     }
-    description
-      "Augment the network-instance model with the route summary container for
-      IPv4.";
   }
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv4-unicast" {
+    description
+      "Augment the network-instance model with the route summary container for
+      IPv6.";
+
     container summary {
       uses route-summary;
       description
         "IPv6 route summary for the network instance.";
     }
-    description
-      "Augment the network-instance model with the route summary container for
-      IPv6.";
   }
 }

--- a/release/models/network-instance/openconfig-route-summary.yang
+++ b/release/models/network-instance/openconfig-route-summary.yang
@@ -32,7 +32,10 @@ module openconfig-route-summary {
 
   grouping route-counter {
     description
-      "Route type counter item.";
+      "Operational state information indicating the number of routes that
+       are learnt from each source of routing information. A source is
+       defined in terms of the protocol that installed the routes into the
+       device RIB.";
 
     leaf source {
       description


### PR DESCRIPTION
Initial proposal to model route summary in a network instance. There will be a route summary for IPv4 and IPv6 respectively. Each route summary will be a list of route counts keyed by the protocol type.

### Change Scope

* Adding a new module named `route-summary`.
```
$ pyang -p release/models -f tree release/models/network-instance/openconfig-route-summary.yang
module: openconfig-route-summary

  augment /oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv6-unicast:
    +--ro summary
       +--ro route-count* [origin-protocol]
          +--ro origin-protocol    -> ../state/origin-protocol
          +--ro state
             +--ro origin-protocol?   identityref
             +--ro total-count
                +--ro fib-count?   oc-yang-types:counter64
  augment /oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/oc-ni:ipv4-unicast:
    +--ro summary
       +--ro route-count* [origin-protocol]
          +--ro origin-protocol    -> ../state/origin-protocol
          +--ro state
             +--ro origin-protocol?   identityref
             +--ro total-count
                +--ro fib-count?   oc-yang-types:counter64
 ```

The rendered network-instance tree looks like:
<pre>
pyang -f tree -p release/models/*/* --tree-path=/network-instances/network-instance

module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
[... snip ...]
        +--ro afts
        |  +--ro ipv4-unicast
        |  |  +--ro ipv4-entry* [prefix]
        |  |  |  +--ro prefix    -> ../state/prefix
        |  |  |  +--ro state
        |  |  |     +--ro prefix?                                     oc-inet:ipv4-prefix
        |  |  |     +--ro counters
        |  |  |     |  +--ro packets-forwarded?          oc-yang:counter64
        |  |  |     |  +--ro octets-forwarded?           oc-yang:counter64
        |  |  |     |  +--ro packets-forwarded-backup?   oc-yang:counter64
        |  |  |     |  +--ro octets-forwarded-backup?    oc-yang:counter64
        |  |  |     +--ro entry-metadata?                             binary
        |  |  |     +--ro origin-protocol?                            identityref
        |  |  |     +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
        |  |  |     +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
        |  |  |     +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
        |  |  |     +--ro oc-aftni:origin-network-instance?           oc-ni:network-instance-ref
       <b> |  |  +--ro oc-rtsummary:summary
        |  |     +--ro oc-rtsummary:route-count* [origin-protocol]
        |  |        +--ro oc-rtsummary:origin-protocol    -> ../state/origin-protocol
        |  |        +--ro oc-rtsummary:state
        |  |           +--ro oc-rtsummary:origin-protocol?   identityref
        |  |           +--ro oc-rtsummary:total-count
        |  |              +--ro oc-rtsummary:fib-count?   oc-yang-types:counter64. </b>
        |  +--ro ipv6-unicast
        |  |  +--ro ipv6-entry* [prefix]
        |  |  |  +--ro prefix    -> ../state/prefix
        |  |  |  +--ro state
        |  |  |     +--ro prefix?                                     oc-inet:ipv6-prefix
        |  |  |     +--ro counters
        |  |  |     |  +--ro packets-forwarded?          oc-yang:counter64
        |  |  |     |  +--ro octets-forwarded?           oc-yang:counter64
        |  |  |     |  +--ro packets-forwarded-backup?   oc-yang:counter64
        |  |  |     |  +--ro octets-forwarded-backup?    oc-yang:counter64
        |  |  |     +--ro entry-metadata?                             binary
        |  |  |     +--ro origin-protocol?                            identityref
        |  |  |     +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
        |  |  |     +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
        |  |  |     +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
        |  |  |     +--ro oc-aftni:origin-network-instance?           oc-ni:network-instance-ref
        <b>|  |  +--ro oc-rtsummary:summary
        |  |     +--ro oc-rtsummary:route-count* [origin-protocol]
        |  |        +--ro oc-rtsummary:origin-protocol    -> ../state/origin-protocol
        |  |        +--ro oc-rtsummary:state
        |  |           +--ro oc-rtsummary:origin-protocol?   identityref
        |  |           +--ro oc-rtsummary:total-count
        |  |              +--ro oc-rtsummary:fib-count?   oc-yang-types:counter64</b>

</pre>
* This change is backwards compatible.
