### PR TITLE
Fix defined-sets `.spec.yml` file

### DIFF
--- a/release/models/defined-sets/.spec.yml
+++ b/release/models/defined-sets/.spec.yml
@@ -1,4 +1,4 @@
-- name: openconfig-acl-defined-sets
+- name: openconfig-defined-sets
   docs:
     - yang/defined-sets/openconfig-defined-sets.yang
   build:


### PR DESCRIPTION
Match name with YANG file (fixes online documentation):

```yang
module openconfig-defined-sets {
}
```