### PR TITLE
Fix `.spec.yml` where name doesn't match root module name to fix online documentation.

### DIFF
--- a/release/models/ate/.spec.yml
+++ b/release/models/ate/.spec.yml
@@ -1,8 +1,6 @@
-- name: openconfig-ate
+- name: openconfig-ate-flow
   docs:
     - yang/ate/openconfig-ate-flow.yang
-    - yang/ate/openconfig-ate-intf.yang
   build:
     - yang/ate/openconfig-ate-flow.yang
-    - yang/ate/openconfig-ate-intf.yang
   run-ci: true

--- a/release/models/catalog/.spec.yml
+++ b/release/models/catalog/.spec.yml
@@ -1,4 +1,4 @@
-- name: openconfig-catalog
+- name: openconfig-module-catalog
   build:
     - yang/catalog/openconfig-module-catalog.yang
   docs:

--- a/release/models/firewall/.spec.yml
+++ b/release/models/firewall/.spec.yml
@@ -1,7 +1,12 @@
-- name: openconfig-firewall
+- name: openconfig-fw-high-availability
   docs:
     - yang/firewall/openconfig-fw-high-availability.yang
-    - yang/firewall/openconfig-fw-link-monitoring.yang
   build:
     - yang/firewall/openconfig-fw-high-availability.yang
+  run-ci: true
+- name: openconfig-fw-link-monitoring
+  docs:
+    - yang/firewall/openconfig-fw-link-monitoring.yang
+  build:
+    - yang/firewall/openconfig-fw-link-monitoring.yang
   run-ci: true

--- a/release/models/interfaces/.spec.yml
+++ b/release/models/interfaces/.spec.yml
@@ -13,6 +13,9 @@
     - yang/platform/openconfig-platform-port.yang
     - yang/platform/openconfig-platform-transceiver.yang
     - yang/interfaces/openconfig-if-sdn-ext.yang
+    - yang/p4rt/openconfig-p4rt.yang
+    - yang/optical-transport/openconfig-transport-line-common.yang
+    - yang/ate/openconfig-ate-intf.yang
   build:
     - yang/interfaces/openconfig-interfaces.yang
     - yang/interfaces/openconfig-if-ip.yang
@@ -27,4 +30,7 @@
     - yang/platform/openconfig-platform-port.yang
     - yang/platform/openconfig-platform-transceiver.yang
     - yang/interfaces/openconfig-if-sdn-ext.yang
+    - yang/p4rt/openconfig-p4rt.yang
+    - yang/optical-transport/openconfig-transport-line-common.yang
+    - yang/ate/openconfig-ate-intf.yang
   run-ci: true

--- a/release/models/network-instance/.spec.yml
+++ b/release/models/network-instance/.spec.yml
@@ -6,10 +6,12 @@
     - yang/network-instance/openconfig-evpn.yang
     - yang/network-instance/openconfig-programming-errors.yang
     - yang/aft/openconfig-aft-network-instance.yang
+    - yang/segment-routing/openconfig-rsvp-sr-ext.yang
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/network-instance/openconfig-programming-errors.yang
     - yang/aft/openconfig-aft-network-instance.yang
+    - yang/segment-routing/openconfig-rsvp-sr-ext.yang
   run-ci: true
 - name: openconfig-network-instance-bgp-rib-augment
   build:

--- a/release/models/optical-transport/.spec.yml
+++ b/release/models/optical-transport/.spec.yml
@@ -25,10 +25,14 @@
     - yang/optical-transport/openconfig-transport-line-common.yang
     - yang/optical-transport/openconfig-wavelength-router.yang
     - yang/optical-transport/openconfig-channel-monitor.yang
+  build:
+    - yang/optical-transport/openconfig-wavelength-router.yang
+  run-ci: true
+- name: openconfig-transport-line-connectivity
+  docs:
     - yang/optical-transport/openconfig-transport-line-connectivity.yang
   build:
     - yang/optical-transport/openconfig-transport-line-connectivity.yang
-    - yang/optical-transport/openconfig-wavelength-router.yang
   run-ci: true
 - name: openconfig-transport-line-protection
   docs:

--- a/release/models/platform/.spec.yml
+++ b/release/models/platform/.spec.yml
@@ -15,6 +15,10 @@
     - yang/platform/openconfig-platform-pipeline-counters.yang
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
+    - yang/p4rt/openconfig-p4rt.yang
+    - yang/system/openconfig-alarms.yang
+    - yang/optical-transport/openconfig-terminal-device.yang
+    - yang/optical-transport/openconfig-transport-line-common.yang
   build:
     - yang/platform/openconfig-platform.yang
     - yang/platform/openconfig-platform-common.yang
@@ -30,4 +34,8 @@
     - yang/platform/openconfig-platform-pipeline-counters.yang
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
+    - yang/p4rt/openconfig-p4rt.yang
+    - yang/system/openconfig-alarms.yang
+    - yang/optical-transport/openconfig-terminal-device.yang
+    - yang/optical-transport/openconfig-transport-line-common.yang
   run-ci: true

--- a/release/models/stp/.spec.yml
+++ b/release/models/stp/.spec.yml
@@ -1,4 +1,4 @@
-- name: openconfig-stp
+- name: openconfig-spanning-tree
   docs:
     - yang/stp/openconfig-spanning-tree-types.yang
     - yang/stp/openconfig-spanning-tree.yang

--- a/release/models/system/.spec.yml
+++ b/release/models/system/.spec.yml
@@ -10,8 +10,8 @@
     - yang/system/openconfig-aaa-tacacs.yang
     - yang/system/openconfig-aaa-radius.yang
     - yang/system/openconfig-alarms.yang
-    - yang/system/openconfig-messages.yang
     - yang/system/openconfig-license.yang
+    - yang/openflow/openconfig-openflow.yang
   build:
     - yang/system/openconfig-system.yang
   run-ci: true
@@ -20,3 +20,8 @@
     - yang/system/openconfig-system.yang
     - yang/system/openconfig-system-grpc.yang
   run-ci: true
+- name: openconfig-messages
+  docs:
+    - yang/system/openconfig-messages.yang
+  build:
+    - yang/system/openconfig-messages.yang


### PR DESCRIPTION
### Summary of Change
This PR fixes up the `.spec.yml` files such that for each path, there is a `.spec.yml` entry whose name matches the root module of the path so that almost all paths now point to valid links.

Example of broken link: all "openconfig-messages" paths.

### Background
The way the path links at
https://openconfig.net/projects/models/paths/index.html works is that the root module of each path is assumed to be the name of the HTML file containing the documentation of the path.

For example, the root module of `/interfaces/interface/state/name` is `openconfig-interfaces`, so the [link](https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-interfaces.html#interfaces-interface-state-name) refers to
`openconfig-interfaces.html`.

This means that for this to work, there must be
an entry in *some* `spec.yml` file whose name matches the root module for the path.

For example, the above path points to a valid link because there is a spec file with the following:
```yaml
- name: openconfig-interfaces
  docs:
      - yang/interfaces/openconfig-interfaces.yang
```

This means that if we changed the `name` field in the above YAML to `openconfig-intf`, then the path no longer points to a valid link.

Ideally, for each path we know the YAML entry which compiled it, but this is hard to do since we would have to analyze every YAML spec entry. In general, it is not guaranteed that the file defining the leaf will appear in the relevant spec entry due to module includes and submodules.

### Testing
Done locally for openconfig.net