### PR TITLE
Add remote-ports and deprecate remote-port in /system/logging

### DIFF
--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -23,7 +23,13 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2023-01-18" {
+    description
+      "Add remote-ports and deprecate remote-port.";
+    reference "0.3.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -427,10 +433,18 @@ module openconfig-system-logging {
     }
 
     leaf remote-port {
+      status deprecated;
       type oc-inet:port-number;
       default 514;
       description
         "Sets the destination port number for syslog UDP messages to
+        the server.  The default for syslog is 514.";
+    }
+
+    leaf-list remote-ports {
+      type oc-inet:port-number;
+      description
+        "Sets the destination port numbers for syslog UDP messages to
         the server.  The default for syslog is 514.";
     }
   }


### PR DESCRIPTION
### Change Scope

* Add `remote-ports` leaf-list and deprecate the `remote-port` leaf in /system/logging.
* This is backwards compatible.

### Reference Implementations

* rsyslog: https://www.rsyslog.com/doc/v8-stable/configuration/modules/imudp.html#port
* syslog-ng: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/46#TOPIC-1829084
Note that while syslog-ng's [port] option is a single number, we can still configure multiple ports for a single destination like so:
```
destination d_tcp1 { network("10.1.2.3" port(1999)); };
destination d_tcp2 { network("10.1.2.3" port(2000)); };

log {
     source(s_net_tcp);
     destination (d_tcp1);
     destination (d_tcp2);
};
```
