### PR TITLE
Add control word support for EVPN

### DIFF
--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -734,12 +734,12 @@ module openconfig-evpn {
 
     leaf control-word-enabled {
       type boolean;
-      description 
+      description
         "When true, the control When true, the control
         word is signaled and sent.";
       reference
             "RFC8214 Virtual Private Wire Service Support
-            in Ethernet VPN 
+            in Ethernet VPN
             draft-ietf-bess-rfc7432bis-05 BGP MPLS-Based
              Ethernet VPN";
     }

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -734,9 +734,14 @@ module openconfig-evpn {
 
     leaf control-word-enabled {
       type boolean;
-      description "When true, the control word is sent.";
+      description 
+        "When true, the control When true, the control
+        word is signaled and sent.";
       reference
-            "RFC 7432: BGP MPLS-Based Ethernet VPN page-49";
+            "RFC8214 Virtual Private Wire Service Support
+            in Ethernet VPN 
+            draft-ietf-bess-rfc7432bis-05 BGP MPLS-Based
+             Ethernet VPN";
     }
   }
 

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -735,8 +735,7 @@ module openconfig-evpn {
     leaf control-word-enabled {
       type boolean;
       description
-        "When true, the control When true, the control
-        word is signaled and sent.";
+        "When true, the control word is signaled and sent.";
       reference
             "RFC8214 Virtual Private Wire Service Support
             in Ethernet VPN

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,13 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
+
+ revision "2023-01-24" {
+   description
+     "Add control word support";
+   reference   "0.4.0";
+  }
 
   revision "2021-06-28" {
    description
@@ -724,6 +730,13 @@ module openconfig-evpn {
         network-instance/config.";
       reference
         "RFC 7432: BGP MPLS-Based Ethernet VPN page-18";
+    }
+
+    leaf control-word-enabled {
+      type boolean;
+      description "When true, the control word is sent.";
+      reference
+            "RFC 7432: BGP MPLS-Based Ethernet VPN page-49";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* It adds a new leaf in the EVPN Instance configuration to enable/disable sending the control word.
* This feature should be enabled/disabled depending on the use case.
* The change is backwards compatible
### Platform Implementations

 * Juniper: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/evpn-vxlan/topics/concept/evpn-vpws-control-word.html)
 * Cisco: [link to documentation](https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5xx/l2vpn/77x/b-l2vpn-cg-77x-ncs540/evpn-features.html#Cisco_Concept.dita_ae7b73ff-834a-4adf-9e91-4322a302f4a7) 
 * Nokia: [link to documentation](https://documentation.nokia.com/sr/22-10-2/books/layer-2-services-evpn/evpn.html#ai9enrmqee)
 * Huawei 

* Cisco configuration example:
```
evpn
--
evi 1
bgp
rd XXX:XX
route-target import  XXX:XXX
route-target export   XXX:XXX
!
control-word-disable
```