### PR TITLE
Deprecate global per-level 'enabled' leaf for IS-IS.

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,13 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision "2023-01-25" {
     description
       "Per-level global enabled configuration removed, since it duplicates
       the level-capability leaf.";
-    reference "2.0.0";
+    reference "1.2.0";
   }
   revision "2022-09-20" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,8 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "2.0.0";
 
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "2.0.0";
+  }
   revision "2022-09-20" {
     description
       "Add CSNP enable to IS-IS global configuration.";

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,14 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "2.0.0";
+  }
 
   revision "2022-09-20" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,13 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision "2023-01-25" {
     description
       "Per-level global enabled configuration removed, since it duplicates
       the level-capability leaf.";
-    reference "2.0.0";
+    reference "1.2.0";
   }
 
   revision "2022-09-20" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,13 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision "2023-01-25" {
     description
       "Per-level global enabled configuration removed, since it duplicates
       the level-capability leaf.";
-    reference "2.0.0";
+    reference "1.2.0";
   }
 
   revision "2022-09-20" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,9 +54,16 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "2.0.0";
 
-    revision "2022-09-20" {
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "2.0.0";
+  }
+
+  revision "2022-09-20" {
     description
       "Add CSNP enable to IS-IS global configuration.";
     reference "1.1.0";
@@ -1328,7 +1335,6 @@ module openconfig-isis {
       description
         "This container defines ISIS level based configuration.";
 
-      uses admin-config;
       uses isis-base-level-config;
       uses isis-metric-style-config;
       uses isis-authentication-check-config;

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -69,13 +69,6 @@ module openconfig-isis {
     reference "1.2.0";
   }
 
-  revision "2023-01-25" {
-    description
-      "Per-level global enabled configuration removed, since it duplicates
-      the level-capability leaf.";
-    reference "1.2.0";
-  }
-
   revision "2022-09-20" {
     description
       "Add CSNP enable to IS-IS global configuration.";

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -299,7 +299,7 @@ module openconfig-isis {
   grouping admin-config-deprecated {
     description
       "Re-usable grouping for the enabled leaf in contexts where it is deprecated.";
-    
+
     leaf enabled {
       type boolean;
       status deprecated;

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -305,7 +305,7 @@ module openconfig-isis {
       status deprecated;
       description
         "Formerly this leaf was used to enable or disable the functionality
-        within the context specified. This leaf is DEPRECATED."
+        within the context specified. This leaf is DEPRECATED.";
     }
   }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -296,6 +296,19 @@ module openconfig-isis {
     }
   }
 
+  grouping admin-config-deprecated {
+    description
+      "Re-usable grouping for the enabled leaf in contexts where it is deprecated.";
+    
+    leaf enabled {
+      type boolean;
+      status deprecated;
+      description
+        "Formerly this leaf was used to enable or disable the functionality
+        within the context specified. This leaf is DEPRECATED."
+    }
+  }
+
   grouping isis-authentication-check-config {
     description
       "This grouping defines ISIS authentication check.";
@@ -1335,6 +1348,7 @@ module openconfig-isis {
       description
         "This container defines ISIS level based configuration.";
 
+      uses admin-config-deprecated;
       uses isis-base-level-config;
       uses isis-metric-style-config;
       uses isis-authentication-check-config;


### PR DESCRIPTION
```
* (M) release/models/isis/openconfig-isis.yang
   - Remove the per-level IS-IS enabled leaf within the global
     configuration, since it is duplicated by the level-capability
     leaf. See #97.
 * (M) release/models/isis/openconfig-isis-{routing,lsp}.yang
   - Bump model version to match master module.
```

### Change Scope

* Remove the `enabled` leaf per-level within global IS-IS configuration. Enabling levels is supported across implementations, but this leaf duplicated the `level-capability` leaf.
* See #97.


