### PR TITLE
Add openconfig-vlan-types to interface documentation generation.

### DIFF
--- a/release/models/interfaces/.spec.yml
+++ b/release/models/interfaces/.spec.yml
@@ -16,6 +16,7 @@
     - yang/p4rt/openconfig-p4rt.yang
     - yang/optical-transport/openconfig-transport-line-common.yang
     - yang/ate/openconfig-ate-intf.yang
+    - yang/vlan/openconfig-vlan-types.yang
   build:
     - yang/interfaces/openconfig-interfaces.yang
     - yang/interfaces/openconfig-if-ip.yang


### PR DESCRIPTION
```
 * (M) release/models/interfaces/.spec.yml
  - Add openconfig-vlan-types to the interfaces documentation build
    rule. VLAN types are referenced in the interfaces model such that
    it would be useful to have this in the documentation.
```

### Change Scope

 * Documentation only change.
