### PR TITLE
Add support for AND/OR for flags; built-in flag match criteria.

### DIFF
--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -481,7 +481,7 @@ module openconfig-packet-match {
           description
             "Specifies that the mode for matching details at the transport
             layer is to using implementation built-ins which may map to
-            multiple explicit flags.";
+            multiple flags.";
         }
       }
       description
@@ -505,11 +505,11 @@ module openconfig-packet-match {
             "Matches of the explicit-details-flags field are treated
             as an AND of the values in the list.";
         }
-      }  
+      }
       description
         "Specifies how the contents of the explicit-details-flags list
-        are to be treated. ANY implies that any of the flags must be
-        matched, where ALL indicates that all the flags must be matched.";
+        are to be treated. ANY implies that any of the flags may match,
+        where ALL indicates that all the flags must be matched.";
       when "../detail-mode = 'EXPLICIT'" {
         description
           "This leaf is only valid when the mode for matches is specified to

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -28,7 +28,15 @@ module openconfig-packet-match {
     field is omitted from a match expression, the effect is a
     wildcard ('any') for that field.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2023-01-27" {
+    description
+      "Update the mechanism to match detailed transport flags,
+      adding means for AND/OR in the explicitly specified flags
+      and commonly supported match aliases.";
+    reference "2.0.0";
+  }
 
   revision "2022-06-01" {
     description
@@ -462,12 +470,97 @@ module openconfig-packet-match {
           to match the destination port";
     }
 
-    leaf-list tcp-flags {
+    leaf detail-mode {
+      type enumeration {
+        enum EXPLICIT {
+          description
+            "Specifies that the mode for matching details at the transport
+             layer is to explicitly match transport flags.";
+        }
+        enum BUILTIN {
+          description
+            "Specifies that the mode for matching details at the transport
+            layer is to using implementation built-ins which may map to
+            multiple explicit flags.";
+        }
+      }
+      description
+        "Mode that is used for matching detailed fields at the transport
+        layer. When EXPLICIT is specified, the implementation should
+        match based on the explicit flags that are specified in the
+        corresponding leaf. When BUILTIN is specified, the implementation
+        must expand the contents of the corresponding leaf to the flags
+        and/or fields that match the pre-defined built-in values.";
+    }
+
+    leaf explicit-detail-match-mode {
+      type enumeration {
+        enum ANY {
+          description
+            "Matches of the explicit-detail-flags field are treated as
+            an OR between the values in the list.";
+        }
+        enum ALL {
+          description
+            "Matches of the explicit-details-flags field are treated
+            as an AND of the values in the list.";
+        }
+      }   
+      description
+        "Specifies how the contents of the explicit-details-flags list
+        are to be treated. ANY implies that any of the flags must be
+        matched, where ALL indicates that all the flags must be matched.";
+      when "../detail-mode = 'EXPLICIT'" {
+        description
+          "This leaf is only valid when the mode for matches is specified to
+          be explicit.";
+      }
+    }
+
+    leaf-list explicit-tcp-flags {
       type identityref {
         base oc-pkt-match-types:TCP_FLAGS;
       }
       description
-        "List of TCP flags to match";
+        "An explicit list of the TCP flags that are to be matched. The
+        mechanism for the match is specified by the explicit-detail-match-mode
+        leaf.";
+      when "../detail-mode = 'EXPLICIT'" {
+        description
+          "This leaf is only valid when the mode for matches is specified to
+          be explicit.";
+      }
+    }
+
+    leaf builtin-detail { 
+      type enumeration {
+        enum TCP_INITIAL {
+          description
+            "Matches the first packet of a TCP session based on a packet
+            not having the ACK flag set, and having the SYN flag set.";
+        }
+        enum TCP_ESTABLISHED {
+          description
+            "Matches an established TCP session based on a packet having
+            the ACK or RST flags set. This does not match the first 
+            packet.";
+        }
+        enum FRAGMENT {
+          description
+            "Matches non-zero values of the fragment-offset field, indicating
+            this packet is a follow up to a fragmented datagram.";
+        }
+      }
+      description
+        "Specifies a built-in (alias) for a match condition that matches
+        multiple flags, or specifies particular logic as to the flag matches
+        to be implemented. This leaf is only valid when the detail-match-mode
+        leaf is BUILTIN.";
+      when "../detail-mode = 'BUILTIN'" {
+        description
+          "This leaf is only valid when the mode for matches is specified to
+          be builtin.";
+      }
     }
   }
 

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -505,7 +505,7 @@ module openconfig-packet-match {
             "Matches of the explicit-details-flags field are treated
             as an AND of the values in the list.";
         }
-      }   
+      }  
       description
         "Specifies how the contents of the explicit-details-flags list
         are to be treated. ANY implies that any of the flags must be
@@ -532,7 +532,7 @@ module openconfig-packet-match {
       }
     }
 
-    leaf builtin-detail { 
+    leaf builtin-detail {
       type enumeration {
         enum TCP_INITIAL {
           description
@@ -542,7 +542,7 @@ module openconfig-packet-match {
         enum TCP_ESTABLISHED {
           description
             "Matches an established TCP session based on a packet having
-            the ACK or RST flags set. This does not match the first 
+            the ACK or RST flags set. This does not match the first
             packet.";
         }
         enum FRAGMENT {


### PR DESCRIPTION
```
 * (M) release/models/acl/openconfig-packet-match.yang
   - Forked from PR #758 by @sourcequench.
   - Adds support for a details match mode that allows explicit
     flags or builtin aliases to be used as a transport details
     match criteria.
   - Adds support for an ANY/ALL match specification for flags.
   - Adds support for builtins like 'TCP_ESTABLISHED' that are
     commonly supported.
```

**Forked from #758 by @sourcequench**

Adding match-any / match-all necessary for a useful flags list Adding common keywords such as established and fragments, which cannot be used at the same time as explicit flags matching.

### Change Scope

* It is very common for ACLs to be written using keywords such as "established" across a range of vendors.
* Having a tcp-flags leaf list is nice, but incomplete, as you'd need to specify whether you wish to match-any or match-all.
* This change is **not** backward compatible.
  * This change could be made backwards compatible by not removing the `tcp-flags` leaf and instead marking
    it as deprecated.

### Platform Implementations

 * Cisco: [acl guide](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_data_acl/configuration/15-sy/sec-data-acl-15-sy-book/sec-refine-ip-al.html) 
 * Juniper: [stateless match conditions](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/firewall-filter-stateless-match-conditions-bit-field-values.html) and/or
   implementation output.

## Tree Diff

```diff
--- /tmp/old    2023-01-27 07:15:57.008752876 -0800
+++ /tmp/new    2023-01-27 07:16:05.810753068 -0800
@@ -98,13 +98,19 @@ module: openconfig-acl
      |           |  |  +--rw source-port-set?        -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |  +--rw destination-port?       oc-pkt-match-types:port-num-range
      |           |  |  +--rw destination-port-set?   -> /oc-sets:defined-sets/port-sets/port-set/name
-     |           |  |  +--rw tcp-flags*              identityref
+     |           |  |  +--rw detail-mode?                  enumeration
+     |           |  |  +--rw explicit-detail-match-mode?   enumeration
+     |           |  |  +--rw explicit-tcp-flags*           identityref
+     |           |  |  +--rw builtin-detail?               enumeration
      |           |  +--ro state
      |           |     +--ro source-port?            oc-pkt-match-types:port-num-range
      |           |     +--ro source-port-set?        -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |     +--ro destination-port?       oc-pkt-match-types:port-num-range
      |           |     +--ro destination-port-set?   -> /oc-sets:defined-sets/port-sets/port-set/name
-     |           |     +--ro tcp-flags*              identityref
+     |           |     +--ro detail-mode?                  enumeration
+     |           |     +--ro explicit-detail-match-mode?   enumeration
+     |           |     +--ro explicit-tcp-flags*           identityref
+     |           |     +--ro builtin-detail?               enumeration
      |           +--rw input-interface
      |           |  +--rw config
      |           |  +--ro state
```
