### PR TITLE
Add port list and selector-set to system logging

### DIFF
--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -306,7 +306,7 @@ module openconfig-system-logging {
   // grouping statements
 
   grouping logging-selector-set-state {
-    description 
+    description
       "Operational state data for logging-selector-set-state";
   }
 
@@ -515,7 +515,7 @@ module openconfig-system-logging {
 
     list port-selector {
       key "remote-port selector-set-name";
-      description 
+      description
         "This list defines ports associated with selector-sets.  If no
         port-selector is configured, then all logs are sent.";
 
@@ -523,7 +523,7 @@ module openconfig-system-logging {
         type leafref {
           path "/system/logging/remote-servers/remote-server/config/remote-ports";
         }
-        description 
+        description
           "Associate a selector-set to a remote-port.";
       }
 
@@ -531,7 +531,7 @@ module openconfig-system-logging {
         type leafref {
           path "/system/logging/selector-sets/selector-set/config/name";
         }
-        description 
+        description
           "Name of the selector set used to filter logs sent to this
           port";
       }

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -506,16 +506,25 @@ module openconfig-system-logging {
         port-selector list";
     }
 
-    list port-selector {
-      key "destination-port selector-set-name";
-      description 
-        "A list of ports associated selector.";
+    leaf-list remote-ports {
+      type oc-inet:port-number;
+      description
+        "Sets the destination port numbers for syslog UDP messages to
+        the server.  The default for syslog is 514.";
+    }
 
-      leaf destination-port {
-        type oc-inet:port-number;
+    list port-selector {
+      key "remote-port selector-set-name";
+      description 
+        "This list defines ports associated with selector-sets.  If no
+        port-selector is configured, then all logs are sent.";
+
+      leaf remote-port {
+        type leafref {
+          path "/system/logging/remote-servers/remote-server/config/remote-ports";
+        }
         description 
-          "Sets the destination port numbers for syslog messages to
-          the server.";
+          "Associate a selector-set to a remote-port.";
       }
 
       leaf selector-set-name {

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -23,7 +23,13 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2023-02-01" {
+    description
+      "Add selector-set and destination-port list to remote-servers.";
+    reference "0.5.0";
+  }
 
   revision "2022-12-29" {
     description
@@ -136,7 +142,6 @@ module openconfig-system-logging {
     reference
       "IETF RFC 5424 - The Syslog Protocol";
   }
-
 
   identity NTP {
     base SYSLOG_FACILITY;
@@ -300,11 +305,63 @@ module openconfig-system-logging {
 
   // grouping statements
 
+  grouping logging-selector-set-state {
+    description 
+      "Operational state data for logging-selector-set-state";
+  }
+
+  grouping logging-selector-set-top {
+    description
+      "Configuration for named lists of selectors";
+
+    container selector-sets {
+      description
+        "Enclosing container";
+
+      list selector-set {
+        key "name";
+        description
+          "List of selectors for log messages";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to prefix name list key";
+        }
+
+        container config {
+          description
+            "Configuration data for selector sets";
+
+          uses logging-selectors-config;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state data ";
+
+          uses logging-selectors-config;
+          uses logging-selectors-state;
+        }
+      }
+    }
+  }
+
   grouping logging-selectors-config {
     description
       "Configuration data for logging selectors";
 
-    leaf facility {
+    leaf name {
+      type string;
+      description
+        "name of the selector, used to reference in the selector-set";
+    }
+
+    leaf-list facility {
       type identityref {
         base SYSLOG_FACILITY;
       }
@@ -312,7 +369,7 @@ module openconfig-system-logging {
         "Specifies the facility, or class of messages to log";
     }
 
-    leaf severity {
+    leaf-list severity {
       type syslog-severity;
       description
         "Specifies that only messages of the given severity (or
@@ -441,10 +498,35 @@ module openconfig-system-logging {
 
     leaf remote-port {
       type oc-inet:port-number;
+      status deprecated;
       default 514;
       description
         "Sets the destination port number for syslog UDP messages to
-        the server.  The default for syslog is 514.";
+        the server.  This leaf is deprecated in favor of using the
+        port-selector list";
+    }
+
+    list port-selector {
+      key "destination-port selector-set-name";
+      description 
+        "A list of ports associated selector.";
+
+      leaf destination-port {
+        type oc-inet:port-number;
+        description 
+          "Sets the destination port numbers for syslog messages to
+          the server.";
+      }
+
+      leaf selector-set-name {
+        type leafref {
+          path "/system/logging/selector-sets/selector-set/config/name";
+        }
+        description 
+          "Name of the selector set used to filter logs sent to this
+          port";
+      }
+
     }
   }
 
@@ -490,6 +572,7 @@ module openconfig-system-logging {
 
           uses logging-remote-config;
           uses logging-remote-state;
+          uses logging-selector-set-state;
         }
         uses logging-selectors-top;
       }
@@ -506,6 +589,7 @@ module openconfig-system-logging {
 
       uses logging-console-top;
       uses logging-remote-top;
+      uses logging-selector-set-top;
     }
   }
   // data definition statements


### PR DESCRIPTION
### Change Scope
The objective of this change is to allow two features:
* definition of more than one port per logging server 
* The ability to select the logging severities and facilities mapped to each port.
This allows an operator to send different logging messages to different ports.  For example, to send debug messages to one port and errors to another port.  This is a practical aid in filtering and scaling the large quantities logs on remote logging servers.

### Change summary
* builds off of #790 by adding 
* A port-selector list which associates a selector-set with a reference to remote-ports leaflist
* The selector-set contains leaf lists for logging severity and facility
* This change is backwards compatible

###Tree output
<pre>
module: openconfig-system
  +--rw system
     +--rw logging
     |  +--rw remote-servers
     |  |  +--rw remote-server* [host]
     |  |     +--rw host         -> ../config/host
     |  |     +--rw config
     |  |     |  +--rw host?               oc-inet:host
     |  |     |  +--rw source-address?     oc-inet:ip-address
     |  |     |  +--rw network-instance?   oc-ni:network-instance-ref
<b>     |  |     |  x--rw remote-port?        oc-inet:port-number
     |  |     |  +--rw remote-ports*        oc-inet:port-number
     |  |     |  +--rw port-selector* [remote-port selector-set-name]
     |  |     |     +--rw remote-port    -> /system/logging/remote-servers/remote-server/config/remote-ports
     |  |     |     +--rw selector-set-name    -> /system/logging/selector-sets/selector-set/config/name </b>
     |  |     +--ro state
     |  |     |  +--ro host?               oc-inet:host
     |  |     |  +--ro source-address?     oc-inet:ip-address
     |  |     |  +--ro network-instance?   oc-ni:network-instance-ref
<b>     |  |     |  x--ro remote-port?        oc-inet:port-number   <i><--- deprecated</i>
     |  |     |  +--ro port-selector* [remote-port selector-set-name]
     |  |     |     +--ro remote-port     -> /system/logging/remote-servers/remote-server/config/remote-ports
     |  |     |     +--ro selector-set-name    -> /system/logging/selector-sets/selector-set/config/name </b>
     |  |     +--rw selectors
     |  |        +--rw selector* [facility severity]
     |  |           +--rw facility    -> ../config/facility
     |  |           +--rw severity    -> ../config/severity
     |  |           +--rw config
     |  |           |  +--rw name?       string
     |  |           |  +--rw facility*   identityref
     |  |           |  +--rw severity*   syslog-severity
     |  |           +--ro state
     |  |              +--ro name?       string
     |  |              +--ro facility*   identityref
     |  |              +--ro severity*   syslog-severity
<b>     |  +--rw selector-sets
     |     +--rw selector-set* [name]
     |        +--rw name      -> ../config/name
     |        +--rw config
     |        |  +--rw name?       string
     |        |  +--rw facility*   identityref
     |        |  +--rw severity*   syslog-severity
     |        +--ro state
     |           +--ro name?       string
     |           +--ro facility*   identityref
     |           +--ro severity*   syslog-severity </b>

</pre>

### Reference Implementations

* Cisco IOS XR [docs](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/system_monitoring/command/reference/b-sysmon-cr-asr9k/b-sysmon-cr-asr9k_chapter_0100.html) - `logging ... port <x>`. 

* Arista EOS [docs](https://www.arista.com/assets/data/docs/Manuals/EOS-4.17.0F-Manual.pdf) - `logging [VRF_INSTANCE] host syslog_host [PORT] [PROT_TYPE]`. 
Arista does support specifying multiple ports to the same remote-host in one single CLI command, i.e.
```
logging host 127.0.0.1 500 501 513 514 515
```
`show logging` will then shows:
```
...
    Logging to '127.0.0.1' port 500 in VRF default via udp
    Logging to '127.0.0.1' port 501 in VRF default via udp
    Logging to '127.0.0.1' port 513 in VRF default via udp
    Logging to '127.0.0.1' port 514 in VRF default via udp
    Logging to '127.0.0.1' port 515 in VRF default via udp
...
```

* Nokia [docs](https://yang.srlinux.dev/v22.3.2?pathType=Config&hidePrefix=false&path=%2Fsrl_nokia-system%3Asystem%2Fsrl_nokia-logging%3Alogging%2Fremote-server%5Bhost%3D*%5D%2Fhost) - SRLinux supports a leaf `remote-port`

* Juniper [docs](https://www.juniper.net/documentation/us/en/software/junos/junos-overview/topics/ref/statement/port-edit-system.html) - `edit system syslog host FOO port BAR`
