### PR TITLE
ospf - add prefixes to identities and fix typos in when statements

### DIFF
--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,7 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
 
   revision "2022-02-10" {
     description

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,9 +23,15 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
 
-   revision "2022-02-10" {
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
+
+  revision "2022-02-10" {
     description
       "Fix spelling error in retransmission-queue-length leaf.";
     reference "0.4.0";

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,7 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
 
   revision "2022-02-10" {
     description

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,7 +23,13 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
 
   revision "2022-02-10" {
     description

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,7 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
 
   revision "2022-02-10" {
     description
@@ -1405,7 +1411,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf link-type {
-      when "../type = 'TE_LINK_TYPE'" {
+      when "../type = 'oc-ospf-types:TE_LINK_TYPE'" {
         description
           "Include the link-type field only when the sub-TLV type was a TE
           link type";
@@ -1434,7 +1440,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf link-id {
-      when "../type = 'TE_LINK_ID'" {
+      when "../type = 'oc-ospf-types:TE_LINK_ID'" {
         description
           "Include the link ID field only when the sub-TLV type was a TE
           Link identifier";
@@ -1503,7 +1509,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf maximum-reservable-bandwidth {
-      when "../type = 'oc-ospf-types:TE_LINK_MAXIUMUM_RESERVABLE_BANDWIDTH'" {
+      when "../type = 'oc-ospf-types:TE_LINK_MAXIMUM_RESERVABLE_BANDWIDTH'" {
         description
           "Include the maximum reservable bandwidth field only when the
           sub-TLV type is the maximum reservable bandwidth";
@@ -1602,7 +1608,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf-list local-ipv6-addresses {
-      when "../type = 'oc-ospf-types:NODE_LOCAL_IPV6_ADDRESS'" {
+      when "../type = 'oc-ospf-types:NODE_IPV6_LOCAL_ADDRESS'" {
         description
           "Include the local IPv6 addresses when the type of the sub-TLV
           indicfates that this is the contained data";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,7 +34,13 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-02-07" {
+    description
+      "Add missing prefixes and fix typos in when statements";
+    reference "2.0.1";
+  }
 
   revision "2022-02-10" {
     description


### PR DESCRIPTION
Signed-off-by: Donald Hunter <donald.hunter@gmail.com>

### Change Scope

* Bugfixes in openconfig-ospfv2-lsdb.yang
* Revision statements added to openconfig-ospfv2 and submodules

Verified with yanglint.