### PR TITLE
openconfig-transport-types.yang add ETH_100GBASE_DR PMD type

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -1051,6 +1051,11 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 100GBASE_FR";
   }
 
+  identity ETH_100GBASE_DR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_DR";
+  }
+
   identity ETH_400GBASE_ZR {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 400GBASE_ZR";

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,12 +22,12 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.17.2";
+  oc-ext:openconfig-version "0.18.1";
 
   revision "2023-02-08" {
     description
       "Add ETH_100GBASE_DR PMD type";
-    reference "0.17.2";
+    reference "0.18.1";
   }
 
   revision "2022-12-05" {

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.17.1";
+  oc-ext:openconfig-version "0.17.2";
+
+  revision "2023-02-08" {
+    description
+      "Add ETH_100GBASE_DR PMD type";
+    reference "0.17.2";
+  }
 
   revision "2022-12-05" {
     description


### PR DESCRIPTION
100G-DR (range 500m) is interoperable with 100G-FR (2km). This addition is backwards compatible.

Co-authored-by: Likai Liu <liulk@google.com>