### PR TITLE
Refactor resource utilization

### DIFF
--- a/release/models/platform/.spec.yml
+++ b/release/models/platform/.spec.yml
@@ -16,6 +16,7 @@
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
     - yang/platform/openconfig-platform-healthz.yang
+    - yang/platform/openconfig-platform-utilization.yang
     - yang/p4rt/openconfig-p4rt.yang
     - yang/system/openconfig-alarms.yang
     - yang/optical-transport/openconfig-terminal-device.yang
@@ -36,6 +37,7 @@
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
     - yang/platform/openconfig-platform-healthz.yang
+    - yang/platform/openconfig-platform-utilization.yang
     - yang/p4rt/openconfig-p4rt.yang
     - yang/system/openconfig-alarms.yang
     - yang/optical-transport/openconfig-terminal-device.yang

--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -8,7 +8,6 @@ submodule openconfig-platform-common {
 
   import openconfig-platform-types { prefix oc-platform-types; }
   import openconfig-extensions { prefix oc-ext; }
-  import openconfig-types { prefix oc-types; }
 
   organization "OpenConfig working group";
 
@@ -20,7 +19,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.22.0";
+  oc-ext:openconfig-version "0.23.0";
+
+  revision "2023-02-10" {
+    description
+      "Refactor platform utilization.";
+    reference "0.23.0";
+  }
 
   revision "2022-12-20" {
     description
@@ -79,131 +84,6 @@ submodule openconfig-platform-common {
   // typedef statements
 
   // grouping statements
-
-  grouping platform-utilization-top {
-    description
-      "Top level of utilization.";
-
-    container utilization {
-      description
-        "Utilization of the component.";
-
-      container resources {
-        description
-          "Enclosing container for the resources in this component.";
-
-        list resource {
-          key "name";
-          description
-            "List of resources, keyed by resource name.";
-
-          leaf name {
-            type leafref {
-              path "../config/name";
-            }
-            description
-              "References the resource name.";
-          }
-
-          container config {
-            description
-              "Configuration data for each resource.";
-
-            uses platform-utilization-resource-config;
-          }
-
-          container state {
-            config false;
-            description
-              "Operational state data for each resource.";
-
-            uses platform-utilization-resource-config;
-            uses platform-utilization-resource-state;
-          }
-        }
-      }
-    }
-  }
-
-  grouping platform-utilization-resource-config {
-    description
-      "Configuration data for utilization resource.";
-
-    leaf name {
-      type string;
-      description
-        "Resource name within the component.";
-    }
-
-    leaf used-threshold-upper {
-      type oc-types:percentage;
-      description
-        "The used percentage value (used / (used + free) * 100) that
-        when crossed will set utilization-threshold-exceeded to 'true'.";
-    }
-
-    leaf used-threshold-upper-clear {
-      type oc-types:percentage;
-      description
-        "The used percentage value (used / (used + free) * 100) that when
-        crossed will set utilization-threshold-exceeded to 'false'.";
-    }
-  }
-
-  grouping platform-utilization-resource-state {
-    description
-      "Operational state data for utilization resource.";
-
-    leaf used {
-      type uint64;
-      description
-        "Number of entries currently in use for the resource.";
-    }
-
-    leaf committed {
-      type uint64;
-      description
-        "Number of entries currently reserved for this resource. This is only
-        relevant to tables which allocate a block of resource for a given
-        feature.";
-    }
-
-    leaf free {
-      type uint64;
-      description
-        "Number of entries available to use.";
-    }
-
-    leaf max-limit {
-      type uint64;
-      description
-        "Maximum number of entries available for the resource. The value
-        is the theoretical maximum resource utilization possible.";
-    }
-
-    leaf high-watermark {
-      type uint64;
-      description
-        "A watermark of highest number of entries used for this resource.";
-    }
-
-    leaf last-high-watermark {
-      type oc-types:timeticks64;
-      description
-        "The timestamp when the high-watermark was last updated. The value
-        is the timestamp in nanoseconds relative to the Unix Epoch
-        (Jan 1, 1970 00:00:00 UTC).";
-    }
-
-    leaf used-threshold-upper-exceeded {
-      type boolean;
-      description
-        "This value is set to true when the used percentage value
-        (used / (used + free) * 100) has crossed the used-threshold-upper for this
-        resource and false when the used percentage value has crossed the configured
-        used-threshold-upper-clear value for this resource.";
-    }
-  }
 
   grouping component-power-management {
     description

--- a/release/models/platform/openconfig-platform-linecard.yang
+++ b/release/models/platform/openconfig-platform-linecard.yang
@@ -22,7 +22,13 @@ module openconfig-platform-linecard {
     "This module defines data related to LINECARD components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2023-02-10" {
+    description
+      "Refactoring platform utilization.";
+    reference "1.1.0";
+  }
 
   revision "2022-07-28" {
     description
@@ -115,7 +121,6 @@ module openconfig-platform-linecard {
         uses linecard-config;
         uses linecard-state;
       }
-      uses oc-platform:platform-utilization-top;
     }
   }
 

--- a/release/models/platform/openconfig-platform-utilization.yang
+++ b/release/models/platform/openconfig-platform-utilization.yang
@@ -1,0 +1,181 @@
+module openconfig-platform-utilization {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/platform/utilization";
+
+  prefix "oc-platform-resource";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-platform-linecard { prefix oc-linecard; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This modules contains configurational and operational data for
+    resource utilization of components within the platform module.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2023-02-10" {
+    description
+      "Refactor resource utilization.";
+    reference "0.1.0";
+  }
+
+  grouping resource-utilization-threshold-common {
+    description
+      "Common threshold configuration model for resource utilization.";
+
+    leaf used-threshold-upper {
+      type oc-types:percentage;
+      description
+        "The used percentage value (used / (used + free) * 100) that
+        when crossed will set used-threshold-upper-exceeded to 'true'.";
+    }
+
+    leaf used-threshold-upper-clear {
+      type oc-types:percentage;
+      description
+        "The used percentage value (used / (used + free) * 100) that when
+        crossed will set used-threshold-upper-exceeded to 'false'.";
+    }
+  }
+
+  grouping resource-utilization-config {
+    description
+      "Configuration data for resource utilization.";
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the component.";
+    }
+
+    uses resource-utilization-threshold-common;
+  }
+
+  grouping resource-utilization-state {
+    description
+      "Operational state data for resource utilization.";
+
+    leaf used {
+      type uint64;
+      description
+        "Number of entries currently in use for the resource.";
+    }
+
+    leaf committed {
+      type uint64;
+      description
+        "Number of entries currently reserved for this resource. This is only
+        relevant to tables which allocate a block of resource for a given
+        feature.";
+    }
+
+    leaf free {
+      type uint64;
+      description
+        "Number of entries available to use.";
+    }
+
+    leaf max-limit {
+      type uint64;
+      description
+        "Maximum number of entries available for the resource. The value
+        is the theoretical maximum resource utilization possible.";
+    }
+
+    leaf high-watermark {
+      type uint64;
+      description
+        "A watermark of highest number of entries used for this resource.";
+    }
+
+    leaf last-high-watermark {
+      type oc-types:timeticks64;
+      description
+        "The timestamp when the high-watermark was last updated. The value
+        is the timestamp in nanoseconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf used-threshold-upper-exceeded {
+      type boolean;
+      description
+        "This value is set to true when the used percentage value
+        (used / (used + free) * 100) has crossed the used-threshold-upper for this
+        resource and false when the used percentage value has crossed the configured
+        used-threshold-upper-clear value for this resource.";
+    }
+  }
+
+  grouping platform-resource-utilization-top {
+    description
+      "Top level of resource utilization.";
+
+    container utilization {
+      description
+        "Resource utilization of the component.";
+
+      container resources {
+        description
+          "Enclosing container for the resources in this component.";
+
+        list resource {
+          key "name";
+          description
+            "List of resources, keyed by resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container config {
+            description
+              "Configuration data for each resource.";
+
+            uses resource-utilization-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state data for each resource.";
+
+            uses resource-utilization-config;
+            uses resource-utilization-state;
+          }
+        }
+      }
+    }
+  }
+
+  augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit" {
+    description
+      "Add resource utilization to integrated-circuit components.";
+    uses platform-resource-utilization-top;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/oc-platform:chassis" {
+    description
+      "Add resource utilization to chassis component.";
+    uses platform-resource-utilization-top;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/oc-linecard:linecard" {
+    description
+      "Add resource utilization to linecard components.";
+    uses platform-resource-utilization-top;
+  }
+}

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,13 +65,19 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.22.0";
+  oc-ext:openconfig-version "0.23.0";
+
+  revision "2023-02-10" {
+    description
+      "Refactor platform utilization.";
+    reference "0.23.0";
+  }
 
   revision "2022-12-20" {
-     description
-        "Add threshold and threshold-exceeded for resource usage.";
-      reference "0.22.0";
-   }
+    description
+      "Add threshold and threshold-exceeded for resource usage.";
+    reference "0.22.0";
+  }
 
   revision "2022-12-19" {
     description
@@ -921,8 +927,6 @@ module openconfig-platform {
         description
           "Operational state data for chassis components";
       }
-
-      uses platform-utilization-top;
     }
 
 // TODO(aashaikh): linecard container is already defined in
@@ -1077,8 +1081,6 @@ module openconfig-platform {
         description
           "Operational state data for chip components";
       }
-
-      uses platform-utilization-top;
     }
 
     container backplane {


### PR DESCRIPTION
### Change Scope
* (M) release/models/platform/openconfig-platform-common.yang
* (A) release/models/platform/openconfig-platform-utilization.yang
  * Move resource utilization into it's own yang file 
  * Update the grouping names and documentation to be more consistent
    * From `utilization (resource)` to `resource utilization`
  * Use `augment` instead of importing directly into the respective `/components/component/<component-type>` containers

* These changes are backwards compatible