### PR TITLE
Adding total frame counts for retry calculations #786

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
 
   revision "2023-02-14" {
     description

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -28,6 +28,12 @@ module openconfig-wifi-mac {
 
   oc-ext:openconfig-version "1.2.0";
 
+  revision "2023-02-14" {
+    description
+      "Adds totals to retry metrics to calculate retry percentages.";
+    reference "1.3.0";
+  }
+
   revision "2023-01-17" {
     description
       "Splits client phy-rate leaf into rx/tx phy-rate leaves.  Marks phy-rate
@@ -861,16 +867,35 @@ module openconfig-wifi-mac {
           within this BSS.";
       }
 
+      leaf rx-total-frames {
+        type oc-yang:counter64;
+        description
+          "Total number of received frames within this BSS.";
+      }
+
       leaf rx-retries-data {
         type oc-yang:counter64;
         description
           "Number of received QoS Data frames with the Retry bit set";
       }
+
+      leaf rx-total-data {
+        type oc-yang:counter64;
+        description
+          "Number of received QoS Data frames";
+      }
+
       leaf rx-retries-subframe {
         type oc-yang:counter64;
         description
           "Aggregated MPDUs which had individual subframes that fail
           and require retransmission.";
+      }
+
+      leaf rx-total-subframe {
+        type oc-yang:counter64;
+        description
+          "Total Aggregated MPDUs received";
       }
 
       leaf rx-bytes-data {
@@ -1132,6 +1157,12 @@ module openconfig-wifi-mac {
           "Number of frames transmitted with the Retry bit set";
       }
 
+      leaf tx-total-frames {
+        type oc-yang:counter64;
+        description
+          "Number of frames transmitted";
+      }
+
       leaf tx-retries-data {
         type oc-yang:counter64;
         description
@@ -1139,11 +1170,23 @@ module openconfig-wifi-mac {
           set";
       }
 
+      leaf tx-total-data {
+        type oc-yang:counter64;
+        description
+          "Number of transmitted QoS Data frames";
+      }
+
       leaf tx-retries-subframe {
         type oc-yang:counter64;
         description
           "Aggregated MPDUs which had individual subframes that fail
           and require retransmission.";
+      }
+
+        leaf tx-total-subframe {
+        type oc-yang:counter64;
+        description
+          "Aggregated MPDUs total frames transmitted.";
       }
 
       leaf tx-bytes-data {
@@ -1195,10 +1238,22 @@ module openconfig-wifi-mac {
           "Rx retried frames from this client.";
       }
 
+      leaf rx-total {
+        type oc-yang:counter64;
+        description
+          "Rx frames from this client.";
+      }
+
       leaf tx-retries {
         type oc-yang:counter64;
         description
           "Tx retried frames to this client.";
+      }
+
+      leaf tx-total {
+        type oc-yang:counter64;
+        description
+          "Tx frames to this client.";
       }
     }
   }


### PR DESCRIPTION
### Change Scope

* Adding total frame counts for wifi-mac in order to calculate retry percentages.
* For each reference to `leaf (rx|tx)-retries.*` there is a `leaf (rx-tx)-total.*` leaf for calculation of retry rates.
* This should be backwards compatible.

From both Arista and Aruba engineering, these changes should be feasible.

### Platform Implementations
Cisco: 
https://www.cisco.com/c/en/us/td/docs/wireless/controller/9800/17-3/cmd-ref/b_wl_17_3_cr/show-commands.html#wp1035443452

Aruba: https://www.arubanetworks.com/techdocs/InstantWenger_Mobile/Advanced/Content/Instant%20User%20Guide%20-%20volumes/Client_View.htm#monitoring_737706378_1022176


Arista: see section 5.1
https://www.arista.com/assets/data/pdf/user-manual/um-books/CloudVision-CUE-User-Guide.pdf