### PR TITLE
Clarify the default of global AF enabled leaf for ipv4-unicast

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -193,8 +193,11 @@ submodule openconfig-bgp-common-multiprotocol {
       type boolean;
       default false;
       description
-        "This leaf indicates whether the AFI-SAFI is
-        enabled for all neighbors or groups";
+        "This leaf indicates whether the AFI-SAFI is enabled for all
+        neighbors or groups.  For historical reasons AF_IPV4 must be 
+        enabled by default and all other AF are disabled by default.  This
+        supports implementations of BGP RFC4271 which only defined
+        IPv4 and is always enabled when BGP is configured.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -195,7 +195,6 @@ submodule openconfig-bgp-common-multiprotocol {
       description
         "This leaf indicates whether the AFI-SAFI is enabled for all
         neighbors or groups.";
-        supports implementations of BGP RFC4271 which only defined
         IPv4 and is always enabled when BGP is configured.";
     }
   }

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -195,7 +195,6 @@ submodule openconfig-bgp-common-multiprotocol {
       description
         "This leaf indicates whether the AFI-SAFI is enabled for all
         neighbors or groups.";
-        enabled by default and all other AF are disabled by default.  This
         supports implementations of BGP RFC4271 which only defined
         IPv4 and is always enabled when BGP is configured.";
     }

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -178,9 +178,30 @@ submodule openconfig-bgp-common-multiprotocol {
     }
   }
 
+  grouping bgp-common-mp-global-afi-safi-config {
+    description
+      "Configuration parameters used for all BGP global AFI-SAFIs";
+
+    leaf afi-safi-name {
+      type identityref {
+        base oc-bgp-types:AFI_SAFI_TYPE;
+      }
+      description "AFI,SAFI";
+    }
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether the AFI-SAFI is
+        enabled for all neighbors or groups";
+    }
+  }
+
   grouping bgp-common-mp-afi-safi-config {
     description
-      "Configuration parameters used for all BGP AFI-SAFIs";
+      "Configuration parameters used for all BGP neighbors
+      or groups AFI-SAFIs";
 
     leaf afi-safi-name {
       type identityref {

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -194,7 +194,7 @@ submodule openconfig-bgp-common-multiprotocol {
       default false;
       description
         "This leaf indicates whether the AFI-SAFI is enabled for all
-        neighbors or groups.  For historical reasons AF_IPV4 must be 
+        neighbors or groups.";
         enabled by default and all other AF are disabled by default.  This
         supports implementations of BGP RFC4271 which only defined
         IPv4 and is always enabled when BGP is configured.";

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -29,7 +29,7 @@ submodule openconfig-bgp-common-multiprotocol {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -195,7 +195,6 @@ submodule openconfig-bgp-common-multiprotocol {
       description
         "This leaf indicates whether the AFI-SAFI is enabled for all
         neighbors or groups.";
-        IPv4 and is always enabled when BGP is configured.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description
@@ -194,7 +200,10 @@ submodule openconfig-bgp-common-multiprotocol {
       default false;
       description
         "This leaf indicates whether the AFI-SAFI is enabled for all
-        neighbors or groups.";
+        neighbors or groups. For historical reasons AF_IPV4 must be
+        enabled by default and all other AF are disabled by default.
+        This supports implementations of BGP RFC4271 which only defined
+        IPv4 and is always enabled when BGP is configured.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model.";
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description
@@ -184,7 +191,6 @@ submodule openconfig-bgp-common-multiprotocol {
 
     leaf enabled {
       type boolean;
-      default false;
       description
         "This leaf indicates whether the AFI-SAFI is
         enabled for the neighbor or group";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -26,7 +26,7 @@ submodule openconfig-bgp-common-structure {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -26,7 +26,7 @@ submodule openconfig-bgp-common-structure {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,14 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -29,7 +29,7 @@ submodule openconfig-bgp-common {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -29,7 +29,7 @@ submodule openconfig-bgp-common {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -31,7 +31,7 @@ submodule openconfig-bgp-global {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -344,13 +344,13 @@ submodule openconfig-bgp-global {
       container config {
         description
           "Configuration parameters for the AFI-SAFI";
-        uses bgp-common-mp-afi-safi-config;
+        uses bgp-common-mp-global-afi-safi-config;
       }
       container state {
         config false;
         description
           "State information relating to the AFI-SAFI";
-        uses bgp-common-mp-afi-safi-config;
+        uses bgp-common-mp-global-afi-safi-config;
         uses bgp-common-state;
       }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -31,7 +31,7 @@ submodule openconfig-bgp-global {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,14 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -35,7 +35,7 @@ submodule openconfig-bgp-neighbor {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -35,7 +35,7 @@ submodule openconfig-bgp-neighbor {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,14 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -30,7 +30,7 @@ submodule openconfig-bgp-peer-group {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,14 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.1.0";
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -30,7 +30,7 @@ submodule openconfig-bgp-peer-group {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -73,7 +73,7 @@ module openconfig-bgp {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model.";
+      at neighbor/peer-group to support BGP inheritance model.";
     reference "9.2.0";
   }
 

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,13 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.2.1";
+
+  revision "2023-02-22" {
+    description
+      "Clarify the default of global AF enabled leaf for ipv4-unicast.";
+    reference "9.2.1";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -58,15 +58,15 @@ module openconfig-bgp {
         +-> neighbor
           +-> [ neighbor config ]
           +-> [ optional pointer to peer-group ]
-          +-> AFI / SAFI [ per-AFI overrides ]";
+          +-> AFI / SAFI [ per-AFI overrides ]
 
-   Most BGP features can be configured at multiple levels in the BGP
-   configuration level hierarchy. The common inheritance model allows
-   the more specific configuration (e.g. neighbor) to inherit from or
-   override the less specific configuration (e.g. global).
-   Leaf present at one level overrides leafs present at higher levels,
-   whereas leaf not present inherits its value from the leaf present
-   at the next higher level in the hierarchy.
+    Most BGP features can be configured at multiple levels in the BGP
+    configuration level hierarchy. The common inheritance model allows
+    the more specific configuration (e.g. neighbor) to inherit from or
+    override the less specific configuration (e.g. global).
+    Leaf present at one level overrides leafs present at higher levels,
+    whereas leaf not present inherits its value from the leaf present
+    at the next higher level in the hierarchy.";
 
   oc-ext:openconfig-version "9.2.0";
 

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -64,9 +64,9 @@ module openconfig-bgp {
    configuration level hierarchy. The common inheritance model allows
    the more specific configuration (e.g. neighbor) to inherit from or
    override the less specific configuration (e.g. global).
-   Leaf set at a lower level overrides leaf values at higher levels,
-   whereas leaf unset inherits from the leaf at the next applicable
-   higher level in the hierarchy.
+   Leaf present at one level overrides leafs present at higher levels,
+   whereas leaf not present inherits its value from the leaf present
+   at the next higher level in the hierarchy.
 
   oc-ext:openconfig-version "9.2.0";
 

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -60,7 +60,22 @@ module openconfig-bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  oc-ext:openconfig-version "9.1.0";
+   Most BGP features can be configured at multiple levels in the BGP
+   configuration level hierarchy. The common inheritance model allows
+   the more specific configuration (e.g. neighbor) to inherit from or
+   override the less specific configuration (e.g. global).
+   Leaf set at a lower level overrides leaf values at higher levels,
+   whereas leaf unset inherits from the leaf at the next applicable
+   higher level in the hierarchy.
+
+  oc-ext:openconfig-version "9.2.0";
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      to support BGP inheritance model."
+    reference "9.2.0";
+  }
 
   revision "2022-05-21" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -73,7 +73,7 @@ module openconfig-bgp {
   revision "2022-12-12" {
     description
       "Removed the default of enabled leaf of AFI-SAFI
-      to support BGP inheritance model."
+      to support BGP inheritance model.";
     reference "9.2.0";
   }
 


### PR DESCRIPTION
This change clarifies that BGP global AF `enabled` leaf for `ipv4-unicast` afi-safi is enabled by default. This is the followup PR to https://github.com/openconfig/public/pull/774 More context can be found over there.

`ipv4-unicast` is the only afi-safi supported in BGP protocl ([RFC4271](https://www.rfc-editor.org/rfc/rfc4271)). Other afi-safis are supported later in the context of MP-BGP ([RFC4760](https://www.rfc-editor.org/rfc/rfc4760)). Since `ipv4-unicast` is an inextricable component of the BGP protocol itself, it's enabled by default in most implementations today. 

There is not a reasonable way to indicate this condition in our model using a `when` statement, so this change proposes to clarify that `ipv4-unicast` is enabled by default in the the description of the global AF `enable` leaf.