### PR TITLE
Clarify IS-IS instance identifiers per #710.

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,15 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.3.0";
+  }
 
   revision "2023-01-04" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,15 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.3.0";
+  }
 
   revision "2023-01-04" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -213,7 +213,7 @@ module openconfig-isis {
       default 0;
       description
         "ISIS Instance. This leaf has been deprecated. The instance name
-        is specified within the 
+        is specified within the
         /network-instances/network-instance/protocols/protocol/config/name
         leaf (list key). If a user requires a specific instance identifier
         used in the Instance Identifier TLV to be configured the instance-id

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,15 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.3.0";
+  }
 
   revision "2023-01-04" {
     description
@@ -200,13 +208,28 @@ module openconfig-isis {
     description
       "This grouping defines global configuration options for ISIS router.";
 
-    // multi-instance
     leaf instance {
       type string;
       default 0;
       description
-        "ISIS Instance.";
+        "ISIS Instance. This leaf has been deprecated. The instance name
+        is specified within the 
+        /network-instances/network-instance/protocols/protocol/config/name
+        leaf (list key). If a user requires a specific instance identifier
+        used in the Instance Identifier TLV to be configured the instance-id
+        leaf is used.";
+      status deprecated;
     }
+
+    leaf instance-id {
+      type uint16;
+      description
+        "When specified, this leaf explicitly indicates the instance identifier
+        that is to be used for the IS-IS instance. The value should be included
+        in the Instance Identifier (IID) TLV.";
+      reference "RFC6822: IS-IS Multi-Instance";
+    }
+
 
     leaf-list net {
       type oc-isis-types:net;


### PR DESCRIPTION
```
 * (M) release/models/isis/openconfig-isis.yang
 * (M) release/models/isis/openconfig-isis-routing.yang
 * (M) release/models/isis/openconfig-isis-lsp.yang
   - Remove the `instance` leaf that was ambiguous as to whether
     this is the name of the instance, or the instance identifier.
   - Add a new uint16 instance-identifier leaf.
```

### Change Scope

* removes the `instance` leaf (deprecated) since it was of type `string`
  and causes ambiguity as to whether this is the name of the instance
  or the instance ID.
* adds a new `instance-id` leaf that explicitly specifies the instance
  identifier TLV value.

### Platform Implementations

* see #710 for discussion of support. confirmed supported in ios xr and sros.
