### PR TITLE
Add support for utilization thresholds config per resource

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,14 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.22.0";
+  oc-ext:openconfig-version "0.23.0";
+
+  revision "2023-02-13" {
+    description
+      "Refactor resource utilization threshold config into a separate grouping.
+      Update 'utilization resource' to 'resource utilization'.";
+    reference "0.23.0";
+  }
 
   revision "2022-12-20" {
     description
@@ -80,13 +87,13 @@ submodule openconfig-platform-common {
 
   // grouping statements
 
-  grouping platform-utilization-top {
+  grouping platform-resource-utilization-top {
     description
-      "Top level of utilization.";
+      "Top level grouping of platform resource utilization.";
 
     container utilization {
       description
-        "Utilization of the component.";
+        "Resource utilization of the component.";
 
       container resources {
         description
@@ -109,7 +116,7 @@ submodule openconfig-platform-common {
             description
               "Configuration data for each resource.";
 
-            uses platform-utilization-resource-config;
+            uses platform-resource-utilization-config;
           }
 
           container state {
@@ -117,24 +124,17 @@ submodule openconfig-platform-common {
             description
               "Operational state data for each resource.";
 
-            uses platform-utilization-resource-config;
-            uses platform-utilization-resource-state;
+            uses platform-resource-utilization-config;
+            uses platform-resource-utilization-state;
           }
         }
       }
     }
   }
 
-  grouping platform-utilization-resource-config {
+  grouping resource-utilization-threshold-common {
     description
-      "Configuration data for utilization resource.";
-
-    leaf name {
-      type string;
-      description
-        "Resource name within the component.";
-    }
-
+      "Common threshold configuration model for resource utilization.";
     leaf used-threshold-upper {
       type oc-types:percentage;
       description
@@ -150,9 +150,22 @@ submodule openconfig-platform-common {
     }
   }
 
-  grouping platform-utilization-resource-state {
+  grouping platform-resource-utilization-config {
     description
-      "Operational state data for utilization resource.";
+      "Configuration data for resource utilization.";
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the component.";
+    }
+
+    uses resource-utilization-threshold-common;
+  }
+
+  grouping platform-resource-utilization-state {
+    description
+      "Operational state data for resource utilization.";
 
     leaf used {
       type uint64;

--- a/release/models/platform/openconfig-platform-linecard.yang
+++ b/release/models/platform/openconfig-platform-linecard.yang
@@ -22,7 +22,13 @@ module openconfig-platform-linecard {
     "This module defines data related to LINECARD components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2023-02-13" {
+    description
+      "Renamed platform-utilization-top to platform-resource-utilization-top.";
+    reference "1.1.0";
+  }
 
   revision "2022-07-28" {
     description
@@ -115,7 +121,7 @@ module openconfig-platform-linecard {
         uses linecard-config;
         uses linecard-state;
       }
-      uses oc-platform:platform-utilization-top;
+      uses oc-platform:platform-resource-utilization-top;
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,14 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.22.0";
+  oc-ext:openconfig-version "0.23.0";
+
+  revision "2023-02-13" {
+    description
+      "Refactor resource utilization threshold config into a separate grouping.
+      Update 'utilization resource' to 'resource utilization'.";
+    reference "0.23.0";
+  }
 
   revision "2022-12-20" {
      description
@@ -922,7 +929,7 @@ module openconfig-platform {
           "Operational state data for chassis components";
       }
 
-      uses platform-utilization-top;
+      uses platform-resource-utilization-top;
     }
 
 // TODO(aashaikh): linecard container is already defined in
@@ -1078,7 +1085,7 @@ module openconfig-platform {
           "Operational state data for chip components";
       }
 
-      uses platform-utilization-top;
+      uses platform-resource-utilization-top;
     }
 
     container backplane {

--- a/release/models/system/.spec.yml
+++ b/release/models/system/.spec.yml
@@ -5,6 +5,7 @@
     - yang/system/openconfig-system.yang
     - yang/system/openconfig-system-terminal.yang
     - yang/system/openconfig-system-logging.yang
+    - yang/system/openconfig-system-utilization.yang
     - yang/system/openconfig-procmon.yang
     - yang/system/openconfig-aaa.yang
     - yang/system/openconfig-aaa-tacacs.yang
@@ -14,6 +15,7 @@
     - yang/openflow/openconfig-openflow.yang
   build:
     - yang/system/openconfig-system.yang
+    - yang/system/openconfig-system-utilization.yang
   run-ci: true
 - name: openconfig-system-ext
   build:

--- a/release/models/system/openconfig-system-utilization.yang
+++ b/release/models/system/openconfig-system-utilization.yang
@@ -1,0 +1,115 @@
+module openconfig-system-utilization {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-utilization";
+  prefix "oc-sys-util";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-platform { prefix oc-platform; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state for
+    system wide resource utilization thresholds.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2023-02-13" {
+      description
+        "Add system wide utilization thresholds.";
+      reference
+        "0.1.0";
+  }
+
+  grouping system-resource-utilization-config {
+    description
+      "Configuration data for resource utilization. The configuration added here should
+      apply across all of the components that matches the respective resource.
+      /components/component/*/utilization/resources/resource/name";
+
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the system.";
+    }
+
+    uses oc-platform:resource-utilization-threshold-common;
+  }
+
+  grouping system-resource-utilization-state {
+    description
+      "State data for resource utilization.";
+
+    leaf-list active-component-list {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/oc-platform:config/oc-platform:name";
+      }
+
+      description
+        "List of references to each component which has this resource.";
+    }
+  }
+
+  grouping system-resource-utilization-top {
+    description
+      "Top level grouping for system wide configuration of resources for
+      all components.";
+
+    container "utilization" {
+      description
+        "System wide resource utilization configuration.";
+
+      container "resources" {
+        description
+          "Enclosing container for the resources in the entire system. The system
+          resource names should be aggregated from the following collections:
+
+          * /components/component/chassis/utilization/resources/resource
+          * /components/component/integrate-circuit/utilization/resources/resource
+          * /components/component/linecard/utilization/resources/resource.";
+
+        list "resource" {
+          key "name";
+          description
+            "The list of all resources across all platform components keyed by
+            resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container "config" {
+            description
+              "Configuration data for resource utilization.";
+            uses system-resource-utilization-config;
+          }
+
+          container "state" {
+            config false;
+            description
+              "Operational state data for resource utilization.";
+
+            uses system-resource-utilization-config;
+            uses system-resource-utilization-state;
+          }
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add system resource utilization.";
+    uses system-resource-utilization-top;
+  }
+}


### PR DESCRIPTION
### Change Scope

* Adding system level configuration for resource utilization thresholds. The motivation for this change is that there needs to be a way to configure per resource, rather than per component per resource. It should make sense that for whichever component is added into the switch dynamically, should already be configured with the corresponding threshold.
  * This is a follow up to #754 
* This change is backwards compatible

pyang output:
```pyang
module: openconfig-system
  +--rw system
     +--rw oc-sys-util:utilization
        +--rw oc-sys-util:resources
           +--rw oc-sys-util:resource* [name]
              +--rw oc-sys-util:name      -> ../config/name
              +--rw oc-sys-util:config
              |  +--rw oc-sys-util:name?                         string
              |  +--rw oc-sys-util:used-threshold-upper?         oc-types:percentage
              |  +--rw oc-sys-util:used-threshold-upper-clear?   oc-types:percentage
              +--ro oc-sys-util:state
                 +--ro oc-sys-util:name?                         string
                 +--ro oc-sys-util:used-threshold-upper?         oc-types:percentage
                 +--ro oc-sys-util:used-threshold-upper-clear?   oc-types:percentage
                 +--ro oc-sys-util:active-component-list*        -> /oc-platform:components/component/config/name
```

### Platform Implementations

 * Arista `hardware capacity alert table <table> [feature <feature>] threshold <threshold>`: [link to documentation](https://www.arista.com/en/um-eos/eos-logging-of-event-notifications)
