### PR TITLE
fixing type of set-metric-type field

### DIFF
--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -26,7 +26,13 @@ module openconfig-isis-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-02-27" {
+    description
+      "Fixing type for set-metric-type leaf";
+    reference "0.5.1";
+  }
 
   revision "2020-02-04" {
     description

--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -177,7 +177,7 @@ module openconfig-isis-policy {
     }
 
     leaf set-metric-type {
-      type isis-types:level-number;
+      type isis-types:metric-style;
       description
         "Set the type of metric that is to be specified when the
         set metric leaf is specified";


### PR DESCRIPTION
### Change Scope

* [Please briefly describe the change that is being made to the models.]
* [Please indicate whether this change is backwards compatible.]

Changing the type of the set-metric-type leaf in IS-IS (previously incorrect).
Change is not backwards compatible, however, the field changed would be unuseable in previous versions

### Platform Implementations

Relevant to any implementation of IS-IS
