### PR TITLE
Add support for weighted ECMP in ISIS

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.4.1";
+
+  oc-ext:openconfig-version "1.4.2";
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.4.2";
+  }
 
   revision "2023-03-20" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -35,12 +35,12 @@ submodule openconfig-isis-lsp {
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
 
-  oc-ext:openconfig-version "1.4.2";
+  oc-ext:openconfig-version "1.5.0";
 
   revision "2023-03-27" {
     description
       "Add weighted ecmp.";
-    reference "1.4.2";
+    reference "1.5.0";
   }
 
   revision "2023-03-20" {

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.4.1";
+  oc-ext:openconfig-version "1.4.2";
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.4.2";
+  }
 
   revision "2023-03-20" {
     description
@@ -41,7 +47,6 @@ submodule openconfig-isis-routing {
     description
       "Per-level global enabled configuration removed, since it duplicates
       the level-capability leaf.";
-
     reference "1.3.0";
   }
 

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,12 +20,12 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.4.2";
+  oc-ext:openconfig-version "1.5.0";
 
   revision "2023-03-27" {
     description
       "Add weighted ecmp.";
-    reference "1.4.2";
+    reference "1.5.0";
   }
 
   revision "2023-03-20" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,12 +54,12 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.4.2";
+  oc-ext:openconfig-version "1.5.0";
 
   revision "2023-03-27" {
     description
       "Add weighted ecmp.";
-    reference "1.4.2";
+    reference "1.5.0";
   }
 
   revision "2023-03-20" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -863,11 +863,11 @@ module openconfig-isis {
         }
         type enumeration {
           enum "auto" {
-              description "Load-balancing weight is based on the bandwidth of 
+              description "Load-balancing weight is based on the bandwidth of
               the parent interface (port or LAG)";
           }
           enum "none" {
-              description "The interface should not participate in weighted 
+              description "The interface should not participate in weighted
               ECMP";
           }
         }
@@ -1337,10 +1337,14 @@ module openconfig-isis {
         "This container defines ISIS interface weighted ECMP options";
 
       container config {
+        description
+          "Configuration parameters relating to weighted ecmp";
         uses isis-interface-weighted-ecmp-config;
       }
 
       container state {
+        description
+          "This container defines state information for weighted ecmp";
         uses isis-interface-weighted-ecmp-config;
       }
     }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.4.1";
+  oc-ext:openconfig-version "1.4.2";
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.4.2";
+  }
 
   revision "2023-03-20" {
     description
@@ -275,6 +281,16 @@ module openconfig-isis {
       type uint8;
       description
         "ISIS max-paths count.";
+    }
+
+    leaf weighted-ecmp {
+      type boolean;
+      default "false";
+      description
+        "When set to true, all eligible multipath IS-IS routes associated with
+        the instance are programmed to use weighted ECMP. An IS-IS route is
+        eligible for weighted ECMP if all the next-hop interfaces in the
+        multipath set have a load-balancing-weight other than 'none'.";
     }
 
     leaf poi-tlv {
@@ -833,6 +849,33 @@ module openconfig-isis {
     }
   }
 
+  grouping isis-interface-weighted-ecmp-config {
+    description
+      "This grouping defines ISIS weighted ECMP configuration";
+
+    leaf load-balancing-weight {
+      description
+        "The load-balancing weight of the interface, which applies when
+        weighted ECMP is enabled and the interface is part of a multipath set.";
+      type union {
+        type uint32 {
+          range "1..4294967295";
+        }
+        type enumeration {
+          enum "auto" {
+              description "Load-balancing weight is based on the bandwidth of 
+              the parent interface (port or LAG)";
+          }
+          enum "none" {
+              description "The interface should not participate in weighted 
+              ECMP";
+          }
+        }
+      }
+      default "auto";
+    }
+  }
+
   grouping isis-transport-config {
     description
       "This grouping defines configuration parameters relating to the
@@ -1286,6 +1329,19 @@ module openconfig-isis {
           "This container defines state information for ISIS interface timers.";
 
         uses isis-interface-timers-config;
+      }
+    }
+
+    container weighted-ecmp {
+      description
+        "This container defines ISIS interface weighted ECMP options";
+
+      container config {
+        uses isis-interface-weighted-ecmp-config;
+      }
+
+      container state {
+        uses isis-interface-weighted-ecmp-config;
       }
     }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -1343,6 +1343,7 @@ module openconfig-isis {
       }
 
       container state {
+        config false;
         description
           "This container defines state information for weighted ecmp";
         uses isis-interface-weighted-ecmp-config;


### PR DESCRIPTION
This code is a Contribution to the OpenConfig Public project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.

### Change Scope

* This PR adds configuration and state support for enabling weighted ECMP load-balancing in an ISIS instance and controlling the load-balancing behavior of specific interfaces
* This change is backwards compatible

### Platform Implementations

 * Implementation A: https://www.juniper.net/documentation/us/en/software/junos/is-is/topics/concept/wecmp-for-one-hop-isis-neighbors-overview.html
 * Implementation B: https://infocenter.nokia.com/public/7750SR227R1A/index.jsp?topic=%2Fcom.nokia.Router_Configuration_Guide%2Fweighted_load-b-ai9exj5xrd.html

