### PR TITLE
Add missing state container to control-plane ACL.

### DIFF
--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -255,6 +255,7 @@ module openconfig-system-controlplane {
           }
 
           container state {
+            config false;
             description
               "Operational state parameters relating to the ACL to be applied.";
             uses system-controlplane-common-acl-config;

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -45,15 +45,20 @@ module openconfig-system-controlplane {
        The specified control-plane ACL is applied to traffic received by the
        control-plane of the system.";
 
-    oc-ext:openconfig-version "0.1.0";
+    oc-ext:openconfig-version "0.2.0";
     oc-ext:catalog-organization "openconfig";
     oc-ext:origin "openconfig";
 
+    revision "2023-03-03" {
+      description
+        "Add missing state container to ACL.";
+      reference "0.2.0";
+    }
+
     revision "2021-08-02" {
-        description
-          "Initial revision.";
-        reference
-          "0.1.0";
+      description
+        "Initial revision.";
+      reference "0.1.0";
     }
 
     grouping system-controlplane-top {
@@ -246,6 +251,12 @@ module openconfig-system-controlplane {
             description
               "Configuration parameters relating to the ACL to be applied.";
 
+            uses system-controlplane-common-acl-config;
+          }
+
+          container state {
+            description
+              "Operational state parameters relating to the ACL to be applied.";
             uses system-controlplane-common-acl-config;
           }
 


### PR DESCRIPTION
```
 * (M) release/models/system/openconfig-system-controlplane.yang
   - Add a missing `state` container to system control plane model.
```

### Change Scope

* Fixing a bug in the `/system/control-plane` model.
