### PR TITLE
add control plane queue config and state

### DIFF
--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -204,28 +204,44 @@ module openconfig-system-controlplane {
               }
             }
 
-            container queue {
+            container queues {
               description
                 "Configuration and operational state relating to the QoS
-                queues that are used for control-plane traffic.  The
+                queues that are used for control plane traffic.  The
                 control-plane container is treated like an interface.";
-
-              container config {
+              
+              list queue {
+                key "name";
+                
                 description
-                  "Configuration parameters relating to the queues used
-                  for control-plane traffic.";
+                "Top-level container for the queue associated with 
+                control plane traffic";
 
-                uses system-control-plane-queue-config;
-              }
+                leaf name {
+                  type leafref {
+                    path "../state/name";
+                  }
+                  description
+                    "Reference to the name of the queue
+                    for control plane traffic.";
+                }
 
-              container state {
-                config false;
-                description
-                  "Operational state parameters relating to the queues
-                  used for control-plane traffic.";
+                container state {
+                  config false;
+                  description
+                    "Operational state parameters relating to the queues
+                    used for control-plane traffic.";
 
-                uses system-control-plane-queue-config;
-                uses system-control-plane-queue-state;
+                  leaf name {
+                    type string;
+                    description
+                      "Reference to the queue associated with control plane 
+                      traffic.  These queues are expected to be implicitly
+                      created by the system.";
+                  }
+
+                  uses oc-qos:qos-interface-queue-state;
+                }
               }
             }
           }
@@ -242,26 +258,20 @@ module openconfig-system-controlplane {
       }
     }
 
-    grouping system-control-plane-queue-config {
-      description
-        "Configuration data for queues associated with the
-        interface, this is re-used across input/output queues.";
-
-      leaf name {
-        type string;
-        description
-          "Reference to the queue associated with the control plane.
-          A queue may be explicitly configured, or implicitly created
-          by the system based on default queues that are instantiated
-          by a hardware component, or are assumed to be default on
-          the system.";
-      }
-    }
-
   grouping system-control-plane-queue-state {
     description
       "Operational state data for the queue associated with the
       control plane";
+
+    leaf name {
+      type string;
+      description
+        "Reference to the queue associated with the control plane.
+        A queue may be explicitly configured, or implicitly created
+        by the system based on default queues that are instantiated
+        by a hardware component, or are assumed to be default on
+        the system.";
+    }
 
     leaf max-queue-len {
       type oc-yang:counter64;

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -4,18 +4,11 @@ module openconfig-system-controlplane {
     namespace "http://openconfig.net/yang/system-controlplane";
     prefix "oc-sys-copp";
 
-    import openconfig-extensions {
-        prefix oc-ext;
-    }
-    import openconfig-system {
-        prefix oc-sys;
-    }
-    import openconfig-acl {
-        prefix oc-acl;
-    }
-    import openconfig-qos {
-        prefix oc-qos;
-    }
+    import openconfig-extensions { prefix oc-ext; }
+    import openconfig-system { prefix oc-sys; }
+    import openconfig-acl { prefix oc-acl; }
+    import openconfig-qos { prefix oc-qos; }
+    import openconfig-yang-types { prefix oc-yang; }
 
     organization
       "OpenConfig working group";
@@ -31,9 +24,13 @@ module openconfig-system-controlplane {
           a QoS classifier.
         - schedule traffic that has been forwarded towards the control-plane,
           to allow for policies such as rate limits to be applied.
+        - queue traffic ingress or egress from the control plane, allowing
+          packets to be queued separately based on a QoS classifier.
+
        The configured policies apply generically to all control-planes that
        exist within the system, and should be mapped to the internal interfaces
        via which packets are forwarded to control-plane modules.
+
        When a packet is received at an input interface - it is classified into a
        forwarding group which drains to a specific queue. If this input mapping
        is sufficient, the CPU-facing interface uses the specified scheduler
@@ -42,12 +39,20 @@ module openconfig-system-controlplane {
        an alternate classifier that is used to reclassify traffic into
        a new set of forwarding-groups (and hence queues) that can subsequently
        be scheduled by the specified scheduler.
+
        The specified control-plane ACL is applied to traffic received by the
        control-plane of the system.";
 
-    oc-ext:openconfig-version "0.2.0";
+    oc-ext:openconfig-version "0.3.0";
     oc-ext:catalog-organization "openconfig";
     oc-ext:origin "openconfig";
+
+    revision "2023-03-03" {
+        description
+          "Add queues to control plane.";
+        reference
+          "0.3.0";
+    }
 
     revision "2023-03-03" {
       description
@@ -198,6 +203,32 @@ module openconfig-system-controlplane {
                 }
               }
             }
+
+            container control-plane-queue {
+              description
+                "Configuration and operational state relating to the QoS
+                queues that are used for control-plane traffic.  The
+                control-plane-traffic container is treated like an
+                interface.";
+
+              container config {
+                description
+                  "Configuration parameters relating to the queues used
+                  for control-plane traffic.";
+
+                uses system-control-plane-queue-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the queues
+                  used for control-plane traffic.";
+
+                uses system-control-plane-queue-config;
+                uses system-control-plane-queue-state;
+              }
+            }
           }
         }
 
@@ -211,6 +242,66 @@ module openconfig-system-controlplane {
         }
       }
     }
+
+    grouping system-control-plane-queue-config {
+      description
+        "Configuration data for queues associated with the
+        interface, this is re-used across input/output queues.";
+
+      leaf name {
+        type string;
+        description
+          "Reference to the queue associated with the control plane.
+          A queue may be explicitly configured, or implicitly created
+          by the system based on default queues that are instantiated
+          by a hardware component, or are assumed to be default on
+          the system.";
+      }
+    }
+
+  grouping system-control-plane-queue-state {
+    description
+      "Operational state data for the queue associated with the
+      control plane";
+
+    leaf max-queue-len {
+      type oc-yang:counter64;
+      units bytes;
+      description
+        "Maximum observed queue length";
+    }
+
+    leaf avg-queue-len {
+      type oc-yang:counter64;
+      units bytes;
+      description
+        "Average observed queue length";
+    }
+
+    leaf transmit-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets transmitted by this queue";
+    }
+
+    leaf transmit-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets trasmitted by this queue";
+    }
+
+    leaf dropped-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets dropped by the queue due to overrun";
+    }
+
+    leaf dropped-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets dropped by the queue due to overrun";
+    }
+  }
 
     grouping system-controlplane-acl-common-top {
       description

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -209,12 +209,12 @@ module openconfig-system-controlplane {
                 "Configuration and operational state relating to the QoS
                 queues that are used for control plane traffic.  The
                 control-plane container is treated like an interface.";
-              
+
               list queue {
                 key "name";
-                
+
                 description
-                "Top-level container for the queue associated with 
+                "Top-level container for the queue associated with
                 control plane traffic";
 
                 leaf name {
@@ -238,7 +238,7 @@ module openconfig-system-controlplane {
                       "oc-qos:config/oc-qos:name";
                     }
                     description
-                      "Reference to the queue associated with control plane 
+                      "Reference to the queue associated with control plane
                       traffic.  These queues are expected to be implicitly
                       created by the system.";
                   }

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -8,7 +8,6 @@ module openconfig-system-controlplane {
     import openconfig-system { prefix oc-sys; }
     import openconfig-acl { prefix oc-acl; }
     import openconfig-qos { prefix oc-qos; }
-    import openconfig-yang-types { prefix oc-yang; }
 
     organization
       "OpenConfig working group";
@@ -211,6 +210,7 @@ module openconfig-system-controlplane {
                 control-plane container is treated like an interface.";
 
               list queue {
+                config false;
                 key "name";
 
                 description
@@ -218,6 +218,7 @@ module openconfig-system-controlplane {
                 control plane traffic";
 
                 leaf name {
+                  config false;
                   type leafref {
                     path "../state/name";
                   }
@@ -232,16 +233,17 @@ module openconfig-system-controlplane {
                     "Operational state parameters relating to the queues
                     used for control-plane traffic.";
 
-                  leaf name {
-                    type leafref {
-                      path "/oc-qos:qos/oc-qos:queues/oc-qos:queue/" +
-                      "oc-qos:state/oc-qos:name";
+                    leaf name {
+                      config false;
+                      type leafref {
+                        path "/oc-qos:qos/oc-qos:queues/oc-qos:queue/" +
+                        "oc-qos:state/oc-qos:name";
+                      }
+                      description
+                        "Reference to the queue associated with control plane
+                        traffic.  These queues are expected to be implicitly
+                        created by the system.";
                     }
-                    description
-                      "Reference to the queue associated with control plane
-                      traffic.  These queues are expected to be implicitly
-                      created by the system.";
-                  }
 
                   uses oc-qos:qos-interface-queue-state;
                 }

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -204,12 +204,11 @@ module openconfig-system-controlplane {
               }
             }
 
-            container control-plane-queue {
+            container queue {
               description
                 "Configuration and operational state relating to the QoS
                 queues that are used for control-plane traffic.  The
-                control-plane-traffic container is treated like an
-                interface.";
+                control-plane container is treated like an interface.";
 
               container config {
                 description

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -233,7 +233,10 @@ module openconfig-system-controlplane {
                     used for control-plane traffic.";
 
                   leaf name {
-                    type string;
+                    type leafref {
+                      path "/oc-qos:qos/oc-qos:queues/oc-qos:queue/" +
+                      "oc-qos:config/oc-qos:name";
+                    }
                     description
                       "Reference to the queue associated with control plane 
                       traffic.  These queues are expected to be implicitly
@@ -257,60 +260,6 @@ module openconfig-system-controlplane {
         }
       }
     }
-
-  grouping system-control-plane-queue-state {
-    description
-      "Operational state data for the queue associated with the
-      control plane";
-
-    leaf name {
-      type string;
-      description
-        "Reference to the queue associated with the control plane.
-        A queue may be explicitly configured, or implicitly created
-        by the system based on default queues that are instantiated
-        by a hardware component, or are assumed to be default on
-        the system.";
-    }
-
-    leaf max-queue-len {
-      type oc-yang:counter64;
-      units bytes;
-      description
-        "Maximum observed queue length";
-    }
-
-    leaf avg-queue-len {
-      type oc-yang:counter64;
-      units bytes;
-      description
-        "Average observed queue length";
-    }
-
-    leaf transmit-pkts {
-      type oc-yang:counter64;
-      description
-        "Number of packets transmitted by this queue";
-    }
-
-    leaf transmit-octets {
-      type oc-yang:counter64;
-      description
-        "Number of octets trasmitted by this queue";
-    }
-
-    leaf dropped-pkts {
-      type oc-yang:counter64;
-      description
-        "Number of packets dropped by the queue due to overrun";
-    }
-
-    leaf dropped-octets {
-      type oc-yang:counter64;
-      description
-        "Number of octets dropped by the queue due to overrun";
-    }
-  }
 
     grouping system-controlplane-acl-common-top {
       description

--- a/release/models/system/openconfig-system-controlplane.yang
+++ b/release/models/system/openconfig-system-controlplane.yang
@@ -235,7 +235,7 @@ module openconfig-system-controlplane {
                   leaf name {
                     type leafref {
                       path "/oc-qos:qos/oc-qos:queues/oc-qos:queue/" +
-                      "oc-qos:config/oc-qos:name";
+                      "oc-qos:state/oc-qos:name";
                     }
                     description
                       "Reference to the queue associated with control plane


### PR DESCRIPTION
### Change Scope

* Add queue config and state to control plane traffic
* This change is backwards compatible

The intent of these queues is expose their existence and statistics.  In the referenced implementations the traffic classes and queues (if any) for control plane traffic offer no configuration that I could find.  These queues are 'system defined' queues which have system defined classifiers, queues and schedulers.  This is compliant with the QoS model as it explicitly permits systems to expose default queue names and their associated statistics.  Future PR's could add configurability of these queues if there is an operational need and implementation.
 
(Note: Control plane policers are typically configurable and are intended to be covered by the traffic scheduler paths which are already defined for control-plane-traffic).    

### Platform Implementations

 *  [Cisco XR OS Control Plane Queue](https://content.cisco.com/chapter.sjs?uri=/searchable/chapter/content/en/us/td/docs/ios-xml/ios/qos_plcshp/configuration/15-mt/qos-plcshp-15-mt-book/qos-plcshp-cpp.html.xml#GUID-F05A63BE-DC5E-4D0B-9B61-FA8B78F5ECAB) thresholding feature defines queues as part of it's control plane traffic features
 * [Arista EOS CoPP policy](https://www.arista.com/en/um-eos/eos-traffic-management#xx1152216) defines queues depending on the hardware platform supported.  
 * [JunOS](https://www.juniper.net/documentation/us/en/software/junos/security-services/topics/topic-map/configuring-ddos-protection.html) supports control plane traffic policing which likely maps to the policers already defined.  It is not clear if JunOS also has queues for control plane traffic.

### Tree view

```
     +--rw oc-sys-copp:control-plane-traffic
     |  +--rw oc-sys-copp:ingress
        |     +--rw oc-sys-copp:queues
        |        +--ro oc-sys-copp:queue* [name]
        |           +--ro oc-sys-copp:name     -> ../state/name
        |           +--ro oc-sys-copp:state
        |              +--ro oc-sys-copp:name?              -> /oc-qos:qos/queues/queue/state/name
        |              +--ro oc-sys-copp:max-queue-len?     oc-yang:counter64
        |              +--ro oc-sys-copp:avg-queue-len?     oc-yang:counter64
        |              +--ro oc-sys-copp:transmit-pkts?     oc-yang:counter64
        |              +--ro oc-sys-copp:transmit-octets?   oc-yang:counter64
        |              +--ro oc-sys-copp:dropped-pkts?      oc-yang:counter64
        |              +--ro oc-sys-copp:dropped-octets?    oc-yang:counter64
```