### PR TITLE
Add enabled flag for MPLS routing

### DIFF
--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,13 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-03-07" {
+    description
+      "Add enabled flag for MPLS routing";
+    reference "3.4.0";
+  }
 
   revision "2022-02-11" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -23,7 +23,13 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-03-07" {
+    description
+      "Add enabled flag for MPLS routing";
+    reference "3.4.0";
+  }
 
   revision "2022-02-11" {
     description

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,13 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-03-07" {
+    description
+      "Add enabled flag for MPLS routing";
+    reference "3.4.0";
+  }
 
   revision "2022-02-11" {
     description

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -71,7 +71,13 @@ module openconfig-mpls {
                              +-------+
     ";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-03-07" {
+    description
+      "Add enabled flag for MPLS routing";
+    reference "3.4.0";
+  }
 
   revision "2022-02-11" {
     description
@@ -531,6 +537,13 @@ module openconfig-mpls {
   grouping mpls-global-config {
     description
       "Definition of global MPLS configuration parameters";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "Enable MPLS routing.";
+    }
 
     leaf null-label {
       type identityref {


### PR DESCRIPTION
Adding an enabled leaf for /network-instances/network-instance/mpls/global/[config|state] to indicate whether MPLS routing is enabled for this network instance

### Change Scope

* Adding a new leaf in release/models/mpls/openconfig-mpls.yang
* This change is backwards compatible

