### PR TITLE
Add config leafs for bgp dynamic-neighbor-prefixes

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,14 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,14 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-07" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description
@@ -297,6 +304,24 @@ submodule openconfig-bgp-global {
         configured.  The configuration parameters used for the dynamic
         neighbor are those specified within the referenced peer
         group.";
+    }
+
+    leaf include-router-id {
+      type boolean;
+      default false;
+      description
+        "This value controls whether the router ID will be used to
+        identify BGP peers. A BGP peer by default is identified by
+        the network instance and peer address.
+        When this is set to true, the router ID will be included in
+        the identification of the BGP peer which will help to uniquely
+        identify dynamic peers.";
+    }
+
+    leaf remote-as {
+      type oc-inet:as-number;
+      description
+        "Neighbor's Autonomous System number."
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -28,7 +28,7 @@ submodule openconfig-bgp-global {
 
   oc-ext:openconfig-version "9.3.0";
 
-  revision "2023-03-07" {
+  revision "2023-03-27" {
     description
       "Added extra configuration parameters relating to an individual prefix
       from which dynamic neighbors are accepted";

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -321,7 +321,7 @@ submodule openconfig-bgp-global {
     leaf remote-as {
       type oc-inet:as-number;
       description
-        "Neighbor's Autonomous System number."
+        "Neighbor's Autonomous System number.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,14 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,14 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,14 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.2.0";
+  oc-ext:openconfig-version "9.3.0";
+
+  revision "2023-03-27" {
+    description
+      "Added extra configuration parameters relating to an individual prefix
+      from which dynamic neighbors are accepted";
+    reference "9.3.0";
+  }
 
   revision "2022-12-12" {
     description


### PR DESCRIPTION
Adding extra configuration parameters to /network-instances/network-instance/protocols/protocol/bgp/global/dynamic-neighbor-prefixes/dynamic-neighbor-prefix/[config|state]

### Change Scope

* Adding leaf include-router-id to help uniquely identify dynamic BGP peers.
* Adding leaf remote-as to specify BGP neighbor's Autonomous System number.
* This change is backwards compatible.
