### PR TITLE
Allow `ethernet` parameters to be used for LAGs.

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -24,7 +24,14 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.12.2";
+  oc-ext:openconfig-version "2.13.0";
+
+  revision "2023-03-10" {
+    description
+      "Allow Ethernet configuration parameters to be
+      used for aggregate (LAG) interfaces.";
+    reference "2.13.0";
+  }
 
   revision "2022-04-20" {
     description
@@ -669,9 +676,12 @@ module openconfig-if-ethernet {
     interfaces model";
 
     uses ethernet-top {
-      when "oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
-      description "Additional interface configuration parameters when
-      the interface type is Ethernet";
+      when "oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd' or " +
+           "oc-if:config/oc-if:type = 'ianaift:ieee8023adLag'" {
+      description
+        "Additional interface configuration parameters when
+        the interface type is Ethernet, or the interface is an aggregate
+        interface.";
       }
     }
   }


### PR DESCRIPTION
```
 * (M) release/models/interfaces/openconfig-if-ethernet.yang
   - Allow configuration and state parameters to be used for both
     Ethernet single interfaces, and aggregate LAGs. Previously this
     prevented LAG ports from being used for switching and/or having
     parameters such as MAC addresses configured on them.
```

### Change Scope

* Currently, the `when` clause that is used in the interfaces model for
  the `ethernet` container prevents the use of thes leaves for aggregate
  interfaces. This change allows the container for LAG interfaces. This
  ensures that parameters such as the `switched-vlan` and Ethernet-specific
  config can be set for these interfaces.

### Platform Implementations

 * Cisco IOS XR: [doc](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k-r6-5/interfaces/configuration/guide/b-interfaces-hardware-component-cg-asr9000-65x/b-interfaces-hardware-component-cg-asr9000-65x_chapter_01000.html) - search `mac-address`.
 * Arista EOS: [doc](https://www.arista.com/assets/data/docs/Manuals/EOS-4.17.2F-Manual.pdf) - search `mac-address`.
 * Nokia SRLinux: [doc](https://yang.srlinux.dev/release/v22.3.2/tree.html) - see `/interface/ethernet/mac-address`.
