### PR TITLE
Clarify routing table deletion

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.0.1";
+  oc-ext:openconfig-version "4.0.2";
+
+  revision "2023-03-15" {
+    description
+      "Clarify that tables are to be deleted by the
+      network operating system";
+    reference "4.0.2";
+  }
 
   revision "2023-02-07" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -574,9 +574,9 @@ module openconfig-network-instance {
               this list when the relevant protocol context is enabled.
               i.e., when a BGP instance is created with IPv4 and IPv6
               address families enabled, the protocol=BGP,
-              address-family=IPv4 table is created by the system.  If
-	      all BGP instances for an address family are deleted, the
-	      associated table must also be deleted.";
+              address-family=IPv4 table is created by the system. The
+	      removal of the table should not require additional or
+	      explicit configurations";
 
             leaf protocol {
               type leafref {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,6 +48,15 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
+  oc-ext:openconfig-version "4.0.2";
+
+  revision "2023-03-15" {
+    description
+      "Clarify that tables are to be deleted by the
+      network operating system";
+    reference "4.0.2";
+  }
+  
   oc-ext:openconfig-version "4.0.1";
 
   revision "2023-02-07" {
@@ -565,7 +574,9 @@ module openconfig-network-instance {
               this list when the relevant protocol context is enabled.
               i.e., when a BGP instance is created with IPv4 and IPv6
               address families enabled, the protocol=BGP,
-              address-family=IPv4 table is created by the system.";
+              address-family=IPv4 table is created by the system.  If
+	      all BGP instances for an address family are deleted, the
+	      associated table must also be deleted.";
 
             leaf protocol {
               type leafref {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -56,8 +56,6 @@ module openconfig-network-instance {
       network operating system";
     reference "4.0.2";
   }
-  
-  oc-ext:openconfig-version "4.0.1";
 
   revision "2023-02-07" {
     description
@@ -575,8 +573,8 @@ module openconfig-network-instance {
               i.e., when a BGP instance is created with IPv4 and IPv6
               address families enabled, the protocol=BGP,
               address-family=IPv4 table is created by the system. The
-	      removal of the table should not require additional or
-	      explicit configurations";
+	            removal of the table should not require additional or
+	            explicit configurations";
 
             leaf protocol {
               type leafref {


### PR DESCRIPTION

### Change Scope

* Adding clarification that network operating systems must delete routing tables for an address family if the address family is removed.   This clarification is introduced based on this featureprofiles test https://github.com/openconfig/featureprofiles/pull/1253/files#r1136470816

* This change is backwards compatible.
