### PR TITLE
Add `default false` to deprecated isis global per-level enabled leaf

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.4.1";
+
+  revision "2023-03-20" {
+    description
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
+  }
 
   revision "2023-02-22" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -29,6 +29,14 @@ submodule openconfig-isis-routing {
     reference "1.4.1";
   }
 
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.4.0";
+  }
+
   revision "2023-01-25" {
     description
       "Per-level global enabled configuration removed, since it duplicates

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,14 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.4.1";
 
-  revision "2023-02-22" {
+  revision "2023-03-20" {
     description
-      "Deprecate the instance leaf, and add a new instance-id leaf
-      that indicates the value to be used in the Instance Identifier
-      TLV.";
-    reference "1.4.0";
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
   }
 
   revision "2023-01-25" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,14 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.4.1";
+
+  revision "2023-03-20" {
+    description
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
+  }
 
   revision "2023-02-22" {
     description
@@ -331,6 +338,7 @@ module openconfig-isis {
 
     leaf enabled {
       type boolean;
+      default false;
       status deprecated;
       description
         "Formerly this leaf was used to enable or disable the functionality


### PR DESCRIPTION
Add `default false` statement as a follow-up fix to https://github.com/openconfig/public/pull/794

This change is backwards-compatible