### PR TITLE
Mirror /access-points/access-point/config/hostname in a state container and increment CI version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,6 @@
+substitutions:
+    _OC_PYANG_VERSION: state-container-dne
+
 steps:
 ############### GET CI REPO ###############
 # Decrypt the file containing the key
@@ -48,7 +51,8 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    branch=$(git tag -l 'v8*' | sort -V | tail -1)
+    #branch=$(git tag -l 'v8*' | sort -V | tail -1)
+    branch=ocpyang-version #FIXME: remove
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-    _OC_PYANG_VERSION: state-container-dne
+    _OC_PYANG_VERSION: master
 
 steps:
 ############### GET CI REPO ###############

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,8 +51,7 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    #branch=$(git tag -l 'v8*' | sort -V | tail -1)
-    branch=ocpyang-version #FIXME: remove
+    branch=$(git tag -l 'v9*' | sort -V | tail -1)
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -205,6 +205,7 @@ steps:
   - 'COMMIT_SHA=$COMMIT_SHA'
   - '_REPO_SLUG=$_REPO_SLUG'
   - 'BRANCH_NAME=$BRANCH_NAME'
+  - '_OC_PYANG_VERSION=$_OC_PYANG_VERSION'
   volumes:
   - name: 'gopath'
     path: /go

--- a/release/models/wifi/openconfig-access-points.yang
+++ b/release/models/wifi/openconfig-access-points.yang
@@ -27,7 +27,14 @@ module openconfig-access-points {
     "This module defines the top level WiFi Configurations for a list of
     Access Points.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2023-03-22" {
+    description
+      "Mirror /access-points/access-point/config/hostname in a state
+      container.";
+    reference "1.1.0";
+  }
 
   revision "2021-08-02" {
     description
@@ -185,6 +192,13 @@ module openconfig-access-points {
         container config {
           description
             "Config items at the global, Access Point level.";
+
+          uses access-points-common-config;
+        }
+
+        container state {
+          description
+            "State items at the global, Access Point level.";
 
           uses access-points-common-config;
         }

--- a/release/models/wifi/openconfig-access-points.yang
+++ b/release/models/wifi/openconfig-access-points.yang
@@ -197,6 +197,7 @@ module openconfig-access-points {
         }
 
         container state {
+          config false;
           description
             "State items at the global, Access Point level.";
 


### PR DESCRIPTION
Updated linter version to v9 to catch this previously-uncaught issue.