### PR TITLE
Fix bgp-set-med-type

### DIFF
--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -28,7 +28,13 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "6.1.0";
+  oc-ext:openconfig-version "6.1.1";
+
+  revision "2023-03-27" {
+    description
+      "Update bgp-set-med-type to allow directly setting the med value";
+    reference "6.1.1";
+  }
 
   revision "2022-05-24" {
     description
@@ -159,8 +165,8 @@ module openconfig-bgp-policy {
     type union {
       type uint32;
       type string {
-        pattern '[+-][0-9]+';
-        oc-ext:posix-pattern '^[+-][0-9]+$';
+        pattern '[+-]?[0-9]+';
+        oc-ext:posix-pattern '^[+-]?[0-9]+$';
       }
       type enumeration {
         enum IGP {

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -32,7 +32,7 @@ module openconfig-bgp-policy {
 
   revision "2023-03-27" {
     description
-      "Update bgp-set-med-type to allow directly setting the med value";
+      "Clarify bgp-set-med-type description";
     reference "6.1.1";
   }
 
@@ -165,8 +165,8 @@ module openconfig-bgp-policy {
     type union {
       type uint32;
       type string {
-        pattern '[+-]?[0-9]+';
-        oc-ext:posix-pattern '^[+-]?[0-9]+$';
+        pattern '[+-][0-9]+';
+        oc-ext:posix-pattern '^[+-][0-9]+$';
       }
       type enumeration {
         enum IGP {
@@ -178,8 +178,9 @@ module openconfig-bgp-policy {
     description
       "Type definition for specifying how the BGP MED can
       be set in BGP policy actions. The three choices are to set
-      the MED directly, increment/decrement using +/- notation,
-      and setting it to the IGP cost (predefined value).";
+      the MED directly using the uint32 type or increment/decrement
+      using +/- notation in the string type or setting it to
+      the IGP cost using the enum (predefined value).";
   }
 
   // grouping statements


### PR DESCRIPTION
Clarify the intended use of the types for `bgp-set-med-type`

This change is backwards compatible as no functionality is changed.  