### PR TITLE
Clarify `unhealthy-count` of healthz.

### DIFF
--- a/release/models/platform/openconfig-platform-healthz.yang
+++ b/release/models/platform/openconfig-platform-healthz.yang
@@ -30,7 +30,13 @@ module openconfig-platform-healthz {
      further diagnostic and debugging informaton from a network
      device.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2023-04-11" {
+    description
+      "Clarification for healthz state transition and unhealthy-count leaf";
+    reference "0.1.1";
+  }
 
   revision "2023-01-23" {
     description
@@ -38,11 +44,6 @@ module openconfig-platform-healthz {
     reference "0.1.0";
   }
 
-  revision "2023-04-11" {
-    description
-      "Clarification for healthz state transition and unhealthy-count leaf";
-    reference "0.1.1";
-  }
 
   grouping platform-health-top {
     description

--- a/release/models/platform/openconfig-platform-healthz.yang
+++ b/release/models/platform/openconfig-platform-healthz.yang
@@ -38,6 +38,12 @@ module openconfig-platform-healthz {
     reference "0.1.0";
   }
 
+  revision "2023-04-11" {
+    description
+      "Clarification for healthz state transition and unhealthy-count leaf";
+    reference "0.1.1";
+  }
+
   grouping platform-health-top {
     description
       "Grouping containing health-related parameters.";

--- a/release/models/platform/openconfig-platform-healthz.yang
+++ b/release/models/platform/openconfig-platform-healthz.yang
@@ -114,7 +114,7 @@ module openconfig-platform-healthz {
       description
         "The number of status checks that have determined this component
         to be in an unhealthy state. This counter should be incremented
-        when the component transitions from the HEALTHY to UNHEALTHY
+        when the component transitions from the HEALTHY to any other
         state such that the value reflects the number of times the
         component has become unhealthy.";
       oc-ext:telemetry-on-change;


### PR DESCRIPTION
### Change Scope

* Clarify that `unhealthy-count` is incremented whenever component changes state from HEALTHY to any other state.
* Backwards compatible

This is to address #851