### PR TITLE
Configure BFD min interval, multipleir when activated in protocols

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -215,43 +215,7 @@ module openconfig-bfd {
         interface.";
     }
 
-    leaf desired-minimum-tx-interval {
-      type uint32;
-      units microseconds;
-      description
-        "The minimum interval between transmission of BFD control
-        packets that the operator desires. This value is advertised to
-        the peer, however the actual interval used is specified by
-        taking the maximum of desired-minimum-tx-interval and the
-        value of the remote required-minimum-receive interval value.
-
-        This value is specified as an integer number of microseconds.";
-    }
-
-    leaf required-minimum-receive {
-      type uint32;
-      units microseconds;
-      description
-        "The minimum interval between received BFD control packets that
-        this system should support. This value is advertised to the
-        remote peer to indicate the maximum frequency (i.e., minimum
-        inter-packet interval) between BFD control packets that is
-        acceptable to the local system.";
-    }
-
-    // rjs: Could have required-minimum-echo-receive here, but this is
-    // generally not configurable.
-
-    leaf detection-multiplier {
-      type uint8 {
-        range "1..max";
-      }
-      description
-        "The number of packets that must be missed to declare this
-        session as down. The detection interval for the BFD session
-        is calculated by multiplying the value of the negotiated
-        transmission interval by this value.";
-    }
+    uses bfd-configuration;
 
     leaf enable-per-member-link {
       type boolean;
@@ -701,8 +665,9 @@ module openconfig-bfd {
         the peer, however the actual interval used is specified by
         taking the maximum of desired-minimum-tx-interval and the
         value of the remote required-minimum-receive interval value.
-
-        This value is specified as an integer number of microseconds.";
+        This value is specified as an integer number of microseconds.
+        The value 0 is reserved and cannot be used.";
+      reference "section 4.1 of RFC 5880";
     }
 
     leaf required-minimum-receive {
@@ -714,6 +679,7 @@ module openconfig-bfd {
         remote peer to indicate the maximum frequency (i.e., minimum
         inter-packet interval) between BFD control packets that is
         acceptable to the local system.";
+      reference "section 4.1 of RFC 5880";
     }
 
     leaf detection-multiplier {
@@ -725,6 +691,7 @@ module openconfig-bfd {
         session as down. The detection interval for the BFD session
         is calculated by multiplying the value of the negotiated
         transmission interval by this value.";
+      reference "section 4.1 of RFC 5880";
     }
 
   }

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -773,7 +773,7 @@ module openconfig-bfd {
 
         uses enable-bfd-config;
         uses bfd-configuration;
-        
+
       }
 
       container state {

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -33,7 +33,7 @@ module openconfig-bfd {
       "Add configuration of min interval, multiplier when
       BFD is enabled at protocol level";
     reference "0.3.0";
- } 
+ }
 
   revision "2023-08-09" {
     description

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,14 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.2.4";
+  oc-ext:openconfig-version "0.3.0";
+  
+  revision "2023-04-13" {
+    description
+      "Add configuration of min interval, multiplier when
+      BFD is enabled at protocol level";
+    reference "0.3.0";
+  }
 
   revision "2022-06-28" {
     description
@@ -682,6 +689,46 @@ module openconfig-bfd {
     }
   }
 
+  grouping bfd-configuration {
+    description
+       "Configuration parameters of BFD when it is enabled in protocols.";
+    leaf desired-minimum-tx-interval {
+      type uint32;
+      units microseconds;
+      description
+        "The minimum interval between transmission of BFD control
+        packets that the operator desires. This value is advertised to
+        the peer, however the actual interval used is specified by
+        taking the maximum of desired-minimum-tx-interval and the
+        value of the remote required-minimum-receive interval value.
+
+        This value is specified as an integer number of microseconds.";
+    }
+
+    leaf required-minimum-receive {
+      type uint32;
+      units microseconds;
+      description
+        "The minimum interval between received BFD control packets that
+        this system should support. This value is advertised to the
+        remote peer to indicate the maximum frequency (i.e., minimum
+        inter-packet interval) between BFD control packets that is
+        acceptable to the local system.";
+    }
+
+    leaf detection-multiplier {
+      type uint8 {
+        range "1..max";
+      }
+      description
+        "The number of packets that must be missed to declare this
+        session as down. The detection interval for the BFD session
+        is calculated by multiplying the value of the negotiated
+        transmission interval by this value.";
+    }
+
+  }
+  
   grouping enable-bfd-state {
     description
       "Operational state parameters relating to enabling BFD.";
@@ -725,6 +772,8 @@ module openconfig-bfd {
           "Configuration parameters relating to enabling BFD.";
 
         uses enable-bfd-config;
+        uses bfd-configuration;
+        
       }
 
       container state {
@@ -733,6 +782,7 @@ module openconfig-bfd {
           "Operational state parameters relating to enabing BFD.";
 
         uses enable-bfd-config;
+        uses bfd-configuration;
         //uses enable-bfd-state;
       }
     }

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -27,7 +27,7 @@ module openconfig-bfd {
     configuration and operational state.";
 
   oc-ext:openconfig-version "0.3.0";
-  
+
   revision "2023-04-13" {
     description
       "Add configuration of min interval, multiplier when
@@ -728,7 +728,7 @@ module openconfig-bfd {
     }
 
   }
-  
+
   grouping enable-bfd-state {
     description
       "Operational state parameters relating to enabling BFD.";


### PR DESCRIPTION
### Change Scope
Min-tx-interval, required-minimum-receive and multiplier added for the case when BFD is activated at a protocol

### Platform Implementations

 * Cisco: [DOC](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-2/interfaces/command/reference/b_interfaces_cr42xr12k_chapter_010.html)
 * Juniper [DOC](https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/topic-map/bfd-for-bgp-session.html)
 * Huawei: [DOC](https://support.huawei.com/enterprise/en/doc/EDOC1000178171/14038c9c/example-for-configuring-bfd-for-bgp )
 
### Examples  
Cisco
```
neighbor 10.10.10.2
     remote-as 65000
     bfd fast-detect
     bfd multiplier 3
     bfd minimum-interval 100
```
Juniper
```
neighbor 12.12.12.12 {
    description DESCRIPTION;
    import RP_BGP_IMPORT;
    authentication-key KEY;
    export RP_BGP_EXPORT;
    peer-as 65028;
    bfd-liveness-detection {
        minimum-interval 200
        multiplier 4
    }
}
```
Huawei
```
peer 10.10.10.10 as-number 65000
   peer 10.10.10.10 description DESCRIPTION
   peer 10.10.10.10 password PASSWORD
   peer 10.10.10.10 bfd min-tx-interval 200 min-rx-interval 200
   peer 10.10.10.10 bfd enable
```
