### PR TITLE
Update to support multiple next-hops per L2RIB producer

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -728,7 +728,7 @@ submodule openconfig-network-instance-l2 {
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
     }
 
-    leaf-list next-hop {
+    leaf next-hop {
       type leafref {
         path "../../../../../../next-hops/next-hop/index";
       }
@@ -740,8 +740,7 @@ submodule openconfig-network-instance-l2 {
       type leafref {
         path "../../../../../../next-hop-groups/next-hop-group/id";
       }
-      description
-        "Import Route Target (RT) in the network-instance on a PE.";
+      description "Leafref next-hop-group for the MAC-IP table entry";
     }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.1.1";
+  oc-ext:openconfig-version "4.2.0";
+
+  revision "2023-09-07" {
+    description
+      "Add L2RIB Per Producer Next-Hop Capability";
+    reference "4.2.0";
+  }
 
   revision "2023-08-09" {
     description
@@ -545,6 +551,7 @@ submodule openconfig-network-instance-l2 {
             }
           }
         }
+        uses l2ni-l2rib-common-next-hop-group-state;
         uses l2ni-l2rib-common-next-hop-state;
       }
 
@@ -606,6 +613,7 @@ submodule openconfig-network-instance-l2 {
             }
           }
         }
+        uses l2ni-l2rib-common-next-hop-group-state;
         uses l2ni-l2rib-common-next-hop-state;
       }
     }
@@ -708,7 +716,10 @@ submodule openconfig-network-instance-l2 {
 
     leaf esi {
       type oc-evpn-types:esi;
-      description "Ethernet Segment Identifier for local and remote routes";
+      description
+        "Ethernet Segment Identifier (ESI) for local and remote routes.
+         ESI is used to resolve the next-hop-group. All mac-addresses
+         learned with the same ESI should point to the same next-hop-group";
     }
 
     leaf sticky {
@@ -717,6 +728,12 @@ submodule openconfig-network-instance-l2 {
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
     }
 
+    leaf next-hop-group {
+      type leafref {
+        path "../../../../../../next-hop-groups/next-hop-group/id";
+      }
+      description "Leafref next-hop for the MAC-IP table entry";
+    }
     leaf next-hop {
       type leafref {
         path "../../../../../../next-hops/next-hop/index";
@@ -757,11 +774,115 @@ submodule openconfig-network-instance-l2 {
             type oc-evpn-types:evi-id;
             description "Next hop label representing the l2vni for the route";
           }
+          leaf esi {
+            type oc-evpn-types:esi;
+            description "Ethernet Segment Identifier (ESI)";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+          leaf resolved {
+            type boolean;
+            description
+              "Indicates if the path is eligible for forwarding as per evpn mass
+               withdraw procedures as defined in RFC 7432";
+          }
           uses oc-if:interface-ref-common;
         }
       }
     }
   }
+
+  grouping l2ni-l2rib-common-next-hop-group-state {
+    description "L2RIB Common Next Hop Group Attributes Operational State Data Grouping";
+
+    container next-hop-groups {
+      description "Surrounding container for groups of L2RIB next-hops.";
+      list next-hop-group {
+        key "id";
+        description
+          "An individual set of next-hops grouped into a common group.
+           Each entry within an L2RIB can optionally point to a
+           next-hop-group.";
+
+        leaf id {
+          type leafref {
+            path "../state/id";
+          }
+          description
+            "A reference to a unique identifier for the next-hop-group.";
+        }
+        container state {
+          description "State container for common next-hop-group attributes";
+          config false;
+          leaf id {
+            type uint64;
+            description
+              "A unique identifier for the next-hop-group. This index is not
+               expected to be consistent across reboots, or reprogramming of
+               the next-hop-group. When updating a next-hop-group, if the group
+               is removed by the system or assigned an alternate identifier, the
+               system should send telemetry notifications deleting the previous
+               identifier. If the identifier of the next-hop-group is changed,
+               all L2RIB entries that reference it must also be updated.";
+          }
+          leaf esi {
+            type oc-evpn-types:esi;
+            description "Ethernet Segment Identifier (ESI)";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+          leaf type {
+            type enumeration {
+              enum ESI {
+                description
+                  "Per ESI pathlist next-hop-group used for evpn mass withdraw procedures as defined in RFC 7432";
+              }
+              enum ESI_EVI {
+                description
+                  "Per ESI,EVI pathlist next-hop-group used for evpn aliasing procedures as defined in RFC 7432";
+              }
+              enum BASE_ECMP {
+                description
+                  "Base ECMP next-hop-group used in absence of evpn aliasing";
+              }
+            }
+            description "Type of next-hop-group";
+          }
+        }
+        container next-hops {
+          description
+            "Surrounding container for the list of next-hops within the next-hop-group.";
+          list next-hop {
+            key "index";
+            description
+              "An individual next-hop within the next-hop-group. Each next-hop is a
+               reference to an entry within the next-hop list.";
+
+            leaf index {
+              type leafref {
+                path "../state/index";
+              }
+              description
+                "A reference to the index for the next-hop within the the next-hop-group.";
+            }
+            container state {
+              description
+                "Operational state parameters related to a next-hop within the next-hop-group.";
+              config false;
+              leaf index {
+                type leafref {
+                  path "../../../../../../next-hops/next-hop/index";
+                }
+                description
+                  "A reference to the identifier for the next-hop to which the entry in the
+                   next-hop group corresponds.";
+              }
+            }
+          }
+        }
+
+      }
+    }
+  }
+
   grouping l2ni-l2rib-mac-table-producer-state {
     description "L2RIB MAC Table Operational State Data Grouping";
 

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -727,18 +727,12 @@ submodule openconfig-network-instance-l2 {
       description "MAC address is sticky and not subjected to MAC moves";
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
     }
-
-    leaf next-hop-group {
+    leaf-list next-hop-group {
       type leafref {
         path "../../../../../../next-hop-groups/next-hop-group/id";
       }
-      description "Leafref next-hop for the MAC-IP table entry";
-    }
-    leaf next-hop {
-      type leafref {
-        path "../../../../../../next-hops/next-hop/index";
-      }
-      description "Leafref next-hop for the MAC-IP table entry";
+      description
+        "Import Route Target (RT) in the network-instance on a PE.";
     }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -727,6 +727,15 @@ submodule openconfig-network-instance-l2 {
       description "MAC address is sticky and not subjected to MAC moves";
       reference "RFC7432: BGP MPLS-Based Ethernet VPN";
     }
+
+    leaf-list next-hop {
+      type leafref {
+        path "../../../../../../next-hops/next-hop/index";
+      }
+      status deprecated;
+      description "Leafref next-hop for the MAC-IP table entry";
+    }
+
     leaf-list next-hop-group {
       type leafref {
         path "../../../../../../next-hop-groups/next-hop-group/id";

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.1.1";
+  oc-ext:openconfig-version "4.2.0";
+
+  revision "2023-09-07" {
+    description
+      "Add L2RIB Per Producer Next-Hop Capability";
+    reference "4.2.0";
+  }
 
   revision "2023-08-09" {
     description


### PR DESCRIPTION
### Change Scope

* Update to the L2RIB model to support multiple next-hops per producer.  The current limitation is that only one next-hop can be supported per producer but we need to support evpn-multihoming scenarios.
* This update also `deprecates` the leaf-reference under producer directly to next-hop and adds a leaf-reference to the next-hop-group and then to next-hop.
* Change is backwards compatible

### Tree View

```yang
        |  +--ro l2rib
        |     +--ro mac-table
        |     |  +--ro entries
        |     |  |  +--ro entry* [mac-address]
        |     |  |     +--ro mac-address    -> ../state/mac-address
        |     |  |     +--ro state
        |     |  |     |  +--ro mac-address?   oc-yang:mac-address
        |     |  |     |  +--ro vlan?          -> ../../../../../../../vlans/vlan/config/vlan-id
        |     |  |     |  +--ro evi?           oc-evpn-types:evi-id
        |     |  |     |  +--ro l2-vni?        oc-evpn-types:evi-id
        |     |  |     +--ro producers
        |     |  |        +--ro producer* [producer]
        |     |  |           +--ro producer    -> ../state/producer
        |     |  |           +--ro state
        |     |  |              +--ro producer?              enumeration
        |     |  |              +--ro seq-number?            uint32
        |     |  |              +--ro mobility-state?        enumeration
        |     |  |              +--ro esi?                   oc-evpn-types:esi
        |     |  |              +--ro sticky?                boolean
        |     |  |              x--ro next-hop?              -> ../../../../../../next-hops/next-hop/index
        |     |  |              +--ro next-hop-group*        -> ../../../../../../next-hop-groups/next-hop-group/id
        |     |  |              +--ro derived-from-mac-ip?   boolean
        |     |  |              +--ro directly-received?     boolean
        |     |  +--ro next-hop-groups
        |     |  |  +--ro next-hop-group* [id]
        |     |  |     +--ro id           -> ../state/id
        |     |  |     +--ro state
        |     |  |     |  +--ro id?     uint64
        |     |  |     |  +--ro esi?    oc-evpn-types:esi
        |     |  |     |  +--ro type?   enumeration
        |     |  |     +--ro next-hops
        |     |  |        +--ro next-hop* [index]
        |     |  |           +--ro index    -> ../state/index
        |     |  |           +--ro state
        |     |  |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
        |     |  +--ro next-hops
        |     |     +--ro next-hop* [index]
        |     |        +--ro index    -> ../state/index
        |     |        +--ro state
        |     |           +--ro index?          uint64
        |     |           +--ro peer-ip?        oc-inet:ip-address
        |     |           +--ro label?          oc-evpn-types:evi-id
        |     |           +--ro esi?            oc-evpn-types:esi
        |     |           +--ro resolved?       boolean
        |     |           +--ro interface?      -> /oc-if:interfaces/interface/name
        |     |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
        |     +--ro mac-ip-table
        |        +--ro entries
        |        |  +--ro entry* [mac-address host-ip]
        |        |     +--ro mac-address    -> ../state/mac-address
        |        |     +--ro host-ip        -> ../state/host-ip
        |        |     +--ro state
        |        |     |  +--ro mac-address?   oc-yang:mac-address
        |        |     |  +--ro vlan?          -> ../../../../../../../vlans/vlan/config/vlan-id
        |        |     |  +--ro evi?           oc-evpn-types:evi-id
        |        |     |  +--ro l2-vni?        oc-evpn-types:evi-id
        |        |     |  +--ro host-ip?       oc-inet:ip-address
        |        |     |  +--ro l3-vni?        oc-evpn-types:evi-id
        |        |     +--ro producers
        |        |        +--ro producer* [producer]
        |        |           +--ro producer    -> ../state/producer
        |        |           +--ro state
        |        |              +--ro producer?         enumeration
        |        |              +--ro seq-number?       uint32
        |        |              +--ro mobility-state?   enumeration
        |        |              +--ro esi?              oc-evpn-types:esi
        |        |              +--ro sticky?           boolean
        |        |              x--ro next-hop?         -> ../../../../../../next-hops/next-hop/index
        |        |              +--ro next-hop-group*   -> ../../../../../../next-hop-groups/next-hop-group/id
        |        +--ro next-hop-groups
        |        |  +--ro next-hop-group* [id]
        |        |     +--ro id           -> ../state/id
        |        |     +--ro state
        |        |     |  +--ro id?     uint64
        |        |     |  +--ro esi?    oc-evpn-types:esi
        |        |     |  +--ro type?   enumeration
        |        |     +--ro next-hops
        |        |        +--ro next-hop* [index]
        |        |           +--ro index    -> ../state/index
        |        |           +--ro state
        |        |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
        |        +--ro next-hops
        |           +--ro next-hop* [index]
        |              +--ro index    -> ../state/index
        |              +--ro state
        |                 +--ro index?          uint64
        |                 +--ro peer-ip?        oc-inet:ip-address
        |                 +--ro label?          oc-evpn-types:evi-id
        |                 +--ro esi?            oc-evpn-types:esi
        |                 +--ro resolved?       boolean
        |                 +--ro interface?      -> /oc-if:interfaces/interface/name
        |                 +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
```

### Platform Implementations

##### Cisco IOS-XE: [link to documentation](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/mp_l2_vpns/configuration/xe-16-10/mp-l2-vpns-xe-16-10-book/evpn-multihoming.html) 

See `Next Hops(s):` Field in output below

 PE1#show l2vpn evpn mac bridge-domain 10 detail 
MAC Address:               000c.2911.6d2a
EVPN Instance:             10
Bridge Domain:             10
Ethernet Segment:          03AB.CDAB.CDAB.C100.0001	-> ESI number assigned to the MAC learnt on this EFP
Ethernet Tag ID:           0
Next Hop(s):               Port-channel1 service instance 10	-> MAC learnt locally on port-channel 1
                                   3.3.3.3
Local Address:             0.0.0.0
Label:                     17
Sequence Number:           0
MAC only present:          Yes
MAC Duplication Detection: Timer not running


##### Juniper: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/evpn-vxlan/topics/concept/evpn-bgp-multihoming-overview.html)
