### PR TITLE
#836 fixing description of neighbor RSSI

### DIFF
--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -27,6 +27,12 @@ module openconfig-wifi-phy {
 
   oc-ext:openconfig-version "1.2.0";
 
+  revision "2023-04-25" {
+    description
+      "Update description for neighbor RSSI to specify as a negative numberr";
+    reference "1.2.1";
+  }
+
   revision "2022-09-16" {
     description
       "Adds obss-rx and clarifies language on rx-dot11-channel-utilization.";
@@ -384,7 +390,7 @@ module openconfig-wifi-phy {
     leaf rssi {
       type int8;
       description
-       "The RSSI of this neighboring BSSID.";
+       "The RSSI of this neighboring BSSID, expressed as a negative number";
     }
 
     leaf channel {

--- a/release/models/wifi/openconfig-wifi-phy.yang
+++ b/release/models/wifi/openconfig-wifi-phy.yang
@@ -25,7 +25,7 @@ module openconfig-wifi-phy {
   description
     "Model for managing PHY layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.2.1";
 
   revision "2023-04-25" {
     description


### PR DESCRIPTION
### Change Scope

* Updating description of the wifi-phy neighbor RSSI state leaf to be more descriptive and match other references to RSSI to include "represented as a negative number."
* This update is backwards compatible, clarifying description update only.

