### PR TITLE
Set metric type leaf

### DIFF
--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -28,6 +28,12 @@ module openconfig-isis-policy {
 
   oc-ext:openconfig-version "0.6.0";
 
+  revision "2023-04-28" {
+    description
+      "Adding set metric-type leaf";
+    reference "0.6.0";
+  }
+
   revision "2023-02-27" {
     description
       "Fixing type for set-metric-type leaf";
@@ -143,6 +149,12 @@ module openconfig-isis-policy {
         be used in the case that import or export policies refer
         to an IS-IS instance that has multiple levels configured
         within it";
+    }
+
+    leaf set-metric-type {
+      type isis-types:metric-type;
+      description
+        "Set the type of the route to redistribute to INTERNAL or EXTERNAL";
     }
   }
 

--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -26,7 +26,13 @@ module openconfig-isis-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2023-04-28" {
+    description
+      "Adding set metric-type leaf";
+    reference "0.7.0";
+  }
 
   revision "2023-04-28" {
     description

--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -34,12 +34,6 @@ module openconfig-isis-policy {
     reference "0.7.0";
   }
 
-  revision "2023-04-28" {
-    description
-      "Adding set metric-type leaf";
-    reference "0.6.0";
-  }
-
   revision "2023-02-27" {
     description
       "Fixing type for set-metric-type leaf";


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]

Add policy match conditions internal, external and both to IS-IS

### Change Scope

* Additional feature to IS-IS policy allowing filtering by a routes destination type
* Change is backwards compatible

### Platform Implementations

 * Implementation A: [link to documentation](https://extremeportal.force.com/ExtrArticleDetail?an=000096278) 
```
route-map "ISIS_to_OSPF" 10
permit
enable
match metric-type-isis internal
exit
```
The above provisioning code shows a metric-type option is available under the equivalent of match-conditions.

 * Implementation B: [link to documentation](https://www.ciscopress.com/articles/article.asp?p=2273507&seqNum=6) 
 ```
Router(config-router)#redistribute ospf 1 match internal external 1 external 2
```
Redistributes routes learned from OSPF process ID 1. The keywords match internal external 1 and external 2 instruct EIGRP to only redistribute internal, external type 1 and type 2 OSPF routes.

The above demonstrates the proposed change follows known standards. 
