### PR TITLE
Fix openconfig-icmpv6-types module prefix

### DIFF
--- a/release/models/acl/openconfig-icmpv6-types.yang
+++ b/release/models/acl/openconfig-icmpv6-types.yang
@@ -3,7 +3,7 @@ module openconfig-icmpv6-types {
   yang-version "1";
   namespace "http://openconfig.net/yang/openconfig-icmpv6-types";
 
-  prefix "oc-icmpv4-types";
+  prefix "oc-icmpv6-types";
 
   import openconfig-extensions { prefix oc-ext; }
 
@@ -17,7 +17,13 @@ module openconfig-icmpv6-types {
     "OpenConfig module defining the types and coresponding subcodes for
     ICMPv6.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2023-05-02" {
+    description
+      "Fix module prefix.";
+    reference "0.1.1";
+  }
 
   revision "2023-01-26" {
     description


### PR DESCRIPTION
### Change Scope

* Fix openconfig-icmpv6-types module prefix

### Platform Implementations

 * n/a