### PR TITLE
Add the `telemetry-atomic` extension to BGP policy statements

### DIFF
--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -77,7 +77,16 @@ module openconfig-routing-policy {
     the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-05-02" {
+    description
+      "Add the telemetry-atomic extension to the BGP policy statements
+      container to reflect that policies are configured as a whole rather than
+      as individual statements. This change also enables scalar-based telemetry
+      to support the ordering of this 'ordered-by user' list.";
+    reference "3.4.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -1022,8 +1031,14 @@ module openconfig-routing-policy {
       "Top-level grouping for the policy statements list";
 
     container statements {
+      oc-ext:telemetry-atomic;
       description
-        "Enclosing container for policy statements";
+        "Enclosing container for policy statements.
+
+        Note: in order to support scalar-based telemetry, policy statements are
+        treated as a whole instead of individually. Per the telemetry-atomic
+        extension, this means both configuration and telemetry must be sent in
+        whole and never as single policy statements.";
 
       list statement {
         key "name";

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -1038,7 +1038,10 @@ module openconfig-routing-policy {
         Note: in order to support scalar-based telemetry, policy statements are
         treated as a whole instead of individually. Per the telemetry-atomic
         extension, this means both configuration and telemetry must be sent in
-        whole and never as single policy statements.";
+        whole and never as single policy statements. When scalar values are
+        provided, it is expected that when examining the streamed paths in
+        order, that the ordering of every new path key reflects the order in
+        the configuration.";
 
       list statement {
         key "name";


### PR DESCRIPTION
### Change Scope
      Add the telemetry-atomic extension to the BGP policy statements
      container to reflect that policies are configured as a whole rather than
      as individual statements. This change also enables scalar-based telemetry
      to support the ordering of this 'ordered-by user' list.

This change is backwards-incompatible for configuration and telemetry below the `telemetry-atomic` node, and for any telemetry on BGP policy statements on the server side.

This change fixes an ordering issue when configuring or streaming telemetry using scalar TypedValue types in gNMI. The issue is that it is currently not possible to indicate policy statement ordering when data is not streamed together as part of a single SubscribeResponse.

When clients and implementors provide scalar values in gNMI for this container, it is expected that when examining the streamed paths in order, that the ordering of every new path key reflects the order in the configuration.