### PR TITLE
Add IPv4 address type

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,7 +44,13 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2023-04-12" {
+    description
+      "Add ipv4 address type configuration.";
+    reference "3.3.0";
+  }
 
   revision "2023-02-06" {
     description
@@ -171,6 +177,24 @@ module openconfig-if-ip {
     }
     description
       "The origin of a neighbor entry.";
+  }
+
+  typedef ipv4-address-type {
+    type enumeration {
+      enum PRIMARY {
+        description
+          "The primary address on the interface. There can only be one primary
+          address associated on an interface.";
+      }
+      enum SECONDARY {
+        description
+          "Secondary address on an interface. There can be multiple secondary
+          addresses associated on an interface.";
+      }
+    }
+
+    description
+      "The type of an IPv4 address.";
   }
 
   // grouping statements
@@ -390,7 +414,6 @@ module openconfig-if-ip {
   }
 
   grouping ipv4-address-config {
-
     description
       "Per IPv4 adresss configuration data for the
       interface.";
@@ -407,6 +430,16 @@ module openconfig-if-ip {
       }
       description
        "The length of the subnet prefix.";
+    }
+
+    leaf type {
+      type ipv4-address-type;
+      default PRIMARY;
+      description
+        "Specifies the explicit type of the IPv4 address being assigned
+        to the interface. By default, addresses are assumed to be a primary address.
+        Where secondary addresses is to be configured, this leaf should be set
+        to SECONDARY.";
     }
   }
 
@@ -526,7 +559,7 @@ module openconfig-if-ip {
       default GLOBAL_UNICAST;
       description
         "Specifies the explicit type of the IPv6 address being assigned
-        to the subinterface. By default, addresses are assumed to be
+        to the interface. By default, addresses are assumed to be
         global unicast.  Where a link-local address is to be explicitly
         configured, this leaf should be set to LINK_LOCAL.";
     }


### PR DESCRIPTION
### Change Scope

* Add `type` to IPv4 address configuration to support PRIMARY and SECONDARY addressing for all L3 interfaces with IPv4 address support. There should only be one PRIMARY address per interface, while there could be multiple secondary IPs.
* This change is backwards compatible

### Platform Implementations

 * Arista [documentation](https://www.arista.com/en/um-eos/eos-data-plane-security#xx1144036)
   * `ip address <addr> secondary`

Relevant pyang output:
```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw subinterfaces
           +--rw subinterface* [index]
              +--rw oc-ip:ipv4
                 +--rw oc-ip:addresses
                    +--rw oc-ip:address* [ip]
                       +--rw oc-ip:ip        -> ../config/ip
                       +--rw oc-ip:config
                       |  +--rw oc-ip:ip?              oc-inet:ipv4-address
                       |  +--rw oc-ip:prefix-length?   uint8
                       |  +--rw oc-ip:type?            ipv4-address-type
                       +--ro oc-ip:state
                       |  +--ro oc-ip:ip?              oc-inet:ipv4-address
                       |  +--ro oc-ip:prefix-length?   uint8
                       |  +--ro oc-ip:type?            ipv4-address-type
                       |  +--ro oc-ip:origin?          ip-address-origin

module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-vlan:routed-vlan
           +--rw oc-ip:ipv4
              +--rw oc-ip:addresses
                 +--rw oc-ip:address* [ip]
                    +--rw oc-ip:ip        -> ../config/ip
                    +--rw oc-ip:config
                    |  +--rw oc-ip:ip?              oc-inet:ipv4-address
                    |  +--rw oc-ip:prefix-length?   uint8
                    |  +--rw oc-ip:type?            ipv4-address-type
                    +--ro oc-ip:state
                    |  +--ro oc-ip:ip?              oc-inet:ipv4-address
                    |  +--ro oc-ip:prefix-length?   uint8
                    |  +--ro oc-ip:type?            ipv4-address-type
                    |  +--ro oc-ip:origin?          ip-address-origin

module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-tun:tunnel
           +--rw oc-tun:ipv4
              +--rw oc-tun:addresses
                 +--rw oc-tun:address* [ip]
                    +--rw oc-tun:ip        -> ../config/ip
                    +--rw oc-tun:config
                    |  +--rw oc-tun:ip?              oc-inet:ipv4-address
                    |  +--rw oc-tun:prefix-length?   uint8
                    |  +--rw oc-tun:type?            ipv4-address-type
                    +--ro oc-tun:state
                       +--ro oc-tun:ip?              oc-inet:ipv4-address
                       +--ro oc-tun:prefix-length?   uint8
                       +--ro oc-tun:type?            ipv4-address-type
                       +--ro oc-tun:origin?          ip-address-origin
```
