### PR TITLE
Add `gre` and `mpls` containers under next-hops aft entry state. Add `ttl` and `tos` under gre, mpls and ip-in-ip aft entry state for telemetry.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -419,7 +419,7 @@ submodule openconfig-aft-common {
       "Outer header fields of encapsulation applied on a next-hop";
 
     leaf ttl {
-      type uint32;
+      type uint8;
       description
         "This leaf reflects the configured TTL value that is used in the outer
          header during packet encapsulation. When this leaf is not set, the TTL
@@ -428,7 +428,7 @@ submodule openconfig-aft-common {
     }
 
     leaf tos {
-      type uint16;
+      type uint8;
       description
         "This leaf reflects the configured TOS value that is used in the outer
          header during packet encapsulation. When this leaf is not set, the TOS

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,14 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description
@@ -359,6 +366,18 @@ submodule openconfig-aft-common {
          specified network-instance.";
     }
 
+    leaf ttl {
+      type uint32;
+      description
+        "TTL used when forwarding a packet to the specified next-hop.";
+    }
+
+    leaf tos {
+      type uint16;
+      description
+        "TOS used when forwarding a packet to the specified next-hop.";
+    }
+
     uses aft-common-install-protocol;
   }
 
@@ -577,6 +596,15 @@ submodule openconfig-aft-common {
         identifier. If the identifier of the next-hop-group
         is changed, all AFT entries that reference it must
         also be updated.";
+    }
+
+    leaf next-hop-group-name {
+      type string;
+      description
+       "Where applicable, this leaf is a unique identifier string for the
+        next-hop-group. This leaf's type is able to accommodate more
+        permutations of identifiers that vendors may have and want to
+        expose.";
     }
 
     leaf programmed-id {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -421,19 +421,19 @@ submodule openconfig-aft-common {
     leaf ttl {
       type uint8;
       description
-        "This leaf reflects the configured TTL value that is used in the outer
-         header during packet encapsulation. When this leaf is not set, the TTL
-         value of the inner packet is copied over as the outer packet's TTL
-         value during encapsulation.";
+        "This leaf reflects the configured/default TTL value that is used in the
+         outer header during packet encapsulation. When this leaf is not set,
+         the TTL value of the inner packet is copied over as the outer packet's
+         TTL value during encapsulation.";
     }
 
     leaf tos {
       type uint8;
       description
-        "This leaf reflects the configured TOS value that is used in the outer
-         header during packet encapsulation. When this leaf is not set, the TOS
-         value of the inner packet is copied over as the outer packet's TOS
-         value during encapsulation.";
+        "This leaf reflects the configured/default TOS value that is used in the
+         outer header during packet encapsulation. When this leaf is not set,
+         the TOS value of the inner packet is copied over as the outer packet's
+         TOS value during encapsulation.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,8 +27,9 @@ submodule openconfig-aft-common {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state for telemetry";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 
@@ -211,6 +212,33 @@ submodule openconfig-aft-common {
             description
               "State parameters relating to IP-in-IP encapsulation.";
             uses aft-common-entry-nexthop-ipip-state;
+            uses aft-common-entry-nexthop-encap-outer-header-state;
+          }
+        }
+
+        container gre {
+          description
+            "When specified, the packet has an GRE header applied to it before
+             forwarding to the specified next-hop.";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to GRE encapsulation.";
+            uses aft-common-entry-nexthop-encap-outer-header-state;
+          }
+        }
+
+        container mpls {
+          description
+            "When specified, the packet has an MPLS header applied to it before
+             forwarding to the specified next-hop.";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to MPLS encapsulation.";
+            uses aft-common-entry-nexthop-encap-outer-header-state;
           }
         }
 
@@ -366,20 +394,6 @@ submodule openconfig-aft-common {
          specified network-instance.";
     }
 
-    leaf ttl {
-      type uint32;
-      description
-        "The TTL value used by the hardware pipeline while forwarding
-         a packet to the specified next-hop.";
-    }
-
-    leaf tos {
-      type uint16;
-      description
-        "The TOS value used by the hardware pipeline while forwarding
-         a packet to the specified next-hop.";
-    }
-
     uses aft-common-install-protocol;
   }
 
@@ -397,6 +411,29 @@ submodule openconfig-aft-common {
       type oc-inet:ip-address;
       description
         "Destination IP address to use for the encapsulated packet.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-encap-outer-header-state {
+    description
+      "Outer header fields of encapsulation applied on a next-hop";
+
+    leaf ttl {
+      type uint32;
+      description
+        "This leaf reflects the configured TTL value that is used in the outer
+         header during packet encapsulation. When this leaf is not set, the TTL
+         value of the inner packet is copied over as the outer packet's TTL
+         value during encapsulation.";
+    }
+
+    leaf tos {
+      type uint16;
+      description
+        "This leaf reflects the configured TOS value that is used in the outer
+         header during packet encapsulation. When this leaf is not set, the TOS
+         value of the inner packet is copied over as the outer packet's TOS
+         value during encapsulation.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -28,7 +28,7 @@ submodule openconfig-aft-common {
   revision "2023-05-25" {
     description
       "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+       Add ttl and tos in NH AFT entry state for telemetry";
     reference "2.4.0";
   }
 
@@ -369,13 +369,15 @@ submodule openconfig-aft-common {
     leaf ttl {
       type uint32;
       description
-        "TTL used when forwarding a packet to the specified next-hop.";
+        "The TTL value used by the hardware pipeline while forwarding
+         a packet to the specified next-hop.";
     }
 
     leaf tos {
       type uint16;
       description
-        "TOS used when forwarding a packet to the specified next-hop.";
+        "The TOS value used by the hardware pipeline while forwarding
+         a packet to the specified next-hop.";
     }
 
     uses aft-common-install-protocol;
@@ -602,9 +604,8 @@ submodule openconfig-aft-common {
       type string;
       description
        "Where applicable, this leaf is a unique identifier string for the
-        next-hop-group. This leaf's type is able to accommodate more
-        permutations of identifiers that vendors may have and want to
-        expose.";
+        next-hop-group. It is an arbitrary name for the group, that is
+        supported by vendors and is exposed for telemetry.";
     }
 
     leaf programmed-id {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,8 +27,8 @@ submodule openconfig-aft-common {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state for telemetry";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state for telemetry";
     reference "2.4.0";
   }
 
@@ -606,6 +606,14 @@ submodule openconfig-aft-common {
        "Where applicable, this leaf is a unique identifier string for the
         next-hop-group. It is an arbitrary name for the group, that is
         supported by vendors and is exposed for telemetry.";
+    }
+
+    leaf auto-size {
+      type boolean;
+      description
+       "Where applicable, this leaf is a indicator of the
+        next-hop-group size being automatically determined or is it
+        configured to a fixed size.";
     }
 
     leaf programmed-id {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -637,22 +637,6 @@ submodule openconfig-aft-common {
         also be updated.";
     }
 
-    leaf next-hop-group-name {
-      type string;
-      description
-       "Where applicable, this leaf is a unique identifier string for the
-        next-hop-group. It is an arbitrary name for the group, that is
-        supported by vendors and is exposed for telemetry.";
-    }
-
-    leaf auto-size {
-      type boolean;
-      description
-       "Where applicable, this leaf is a indicator of the
-        next-hop-group size being automatically determined or is it
-        configured to a fixed size.";
-    }
-
     leaf programmed-id {
       type uint64;
       description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -24,8 +24,8 @@ submodule openconfig-aft-ethernet {
 
   revision "2023-05-25" {
      description
-       "Add next-hop-group-name in NHG AFT entry state and
-        Add ttl and tos in NH AFT entry state";
+       "Add next-hop-group-name and auto-size in NHG AFT entry state
+        and Add ttl and tos in NH AFT entry state";
      reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,14 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+     description
+       "Add next-hop-group-name in NHG AFT entry state and
+        Add ttl and tos in NH AFT entry state";
+     reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -24,8 +24,9 @@ submodule openconfig-aft-ethernet {
 
   revision "2023-05-25" {
      description
-       "Add next-hop-group-name and auto-size in NHG AFT entry state
-        and Add ttl and tos in NH AFT entry state";
+       "Add gre and mpls containers under next-hops aft entry state.
+        Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+        for telemetry.";
      reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,14 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+     description
+       "Add next-hop-group-name in NHG AFT entry state and
+        Add ttl and tos in NH AFT entry state";
+     reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -24,8 +24,9 @@ submodule openconfig-aft-ipv4 {
 
   revision "2023-05-25" {
      description
-       "Add next-hop-group-name and auto-size in NHG AFT entry state
-        and Add ttl and tos in NH AFT entry state";
+       "Add gre and mpls containers under next-hops aft entry state.
+        Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+        for telemetry.";
      reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -24,8 +24,8 @@ submodule openconfig-aft-ipv4 {
 
   revision "2023-05-25" {
      description
-       "Add next-hop-group-name in NHG AFT entry state and
-        Add ttl and tos in NH AFT entry state";
+       "Add next-hop-group-name and auto-size in NHG AFT entry state
+        and Add ttl and tos in NH AFT entry state";
      reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -24,8 +24,9 @@ submodule openconfig-aft-ipv6 {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,14 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -24,8 +24,8 @@ submodule openconfig-aft-ipv6 {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -25,8 +25,8 @@ submodule openconfig-aft-mpls {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,14 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -25,8 +25,9 @@ submodule openconfig-aft-mpls {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -32,8 +32,8 @@ submodule openconfig-aft-pf {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -32,8 +32,9 @@ submodule openconfig-aft-pf {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,14 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,14 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -20,8 +20,9 @@ submodule openconfig-aft-state-synced {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -20,8 +20,8 @@ submodule openconfig-aft-state-synced {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,14 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2023-05-25" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state and
+       Add ttl and tos in NH AFT entry state";
+    reference "2.4.0";
+  }
 
   revision "2023-04-19" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -46,8 +46,9 @@ module openconfig-aft {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name and auto-size in NHG AFT entry state
-       and Add ttl and tos in NH AFT entry state";
+      "Add gre and mpls containers under next-hops aft entry state.
+       Add ttl and tos under gre, mpls and ip-in-ip aft entry state
+       for telemetry.";
     reference "2.4.0";
   }
 

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -46,8 +46,8 @@ module openconfig-aft {
 
   revision "2023-05-25" {
     description
-      "Add next-hop-group-name in NHG AFT entry state and
-       Add ttl and tos in NH AFT entry state";
+      "Add next-hop-group-name and auto-size in NHG AFT entry state
+       and Add ttl and tos in NH AFT entry state";
     reference "2.4.0";
   }
 


### PR DESCRIPTION
* (M) aft/openconfig-aft-common.yang
* (M) aft/openconfig-aft-ethernet.yang
* (M) aft/openconfig-aft-ipv4.yang
* (M) aft/openconfig-aft-ipv6.yang
* (M) aft/openconfig-aft-mpls.yang
* (M) aft/openconfig-aft-pf.yang
* (M) aft/openconfig-aft-state-synced.yang
* (M) aft/openconfig-aft.yang

Change Scope
  - Add gre and mpls containers under next-hops aft entry state.
  - Add ttl and tos under gre, mpls and ip-in-ip aft entry state for telemetry.
  - This change is backwards compatible

Platform Implementations
  - Arista [documentation](https://www.arista.com/en/um-eos/eos-nexthop-groups#xx1147395)

Relevant pyang output:
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--ro afts
        |  +--ro next-hops
        |     +--ro next-hop* [index]
        |        +--ro index            -> ../state/index
        |        +--ro state
        |        |  +--ro index?                       uint64
        |        |  +--ro programmed-index?            uint64
        |        |  +--ro ip-address?                  oc-inet:ip-address
        |        |  +--ro mac-address?                 oc-yang:mac-address
        |        |  +--ro pop-top-label?               boolean
        |        |  +--ro pushed-mpls-label-stack*     oc-mplst:mpls-label
        |        |  +--ro encapsulate-header?          oc-aftt:encapsulation-header-type
        |        |  +--ro decapsulate-header?          oc-aftt:encapsulation-header-type
        |        |  +--ro origin-protocol?             identityref
        |        |  +--ro lsp-name?                    string
        |        |  +--ro counters
        |        |  |  +--ro packets-forwarded?   oc-yang:counter64
        |        |  |  +--ro octets-forwarded?    oc-yang:counter64
        |        |  +--ro vni-label?                   oc-evpn-types:evi-id
        |        |  +--ro tunnel-src-ip-address?       oc-inet:ip-address
        |        |  +--ro oc-aftni:network-instance?   oc-ni:network-instance-ref
        |        +--ro ip-in-ip
        |        |  +--ro state
        |        |     +--ro src-ip?   oc-inet:ip-address
        |        |     +--ro dst-ip?   oc-inet:ip-address
        |        |     +--ro ttl?      uint32
        |        |     +--ro tos?      uint16
        |        +--ro gre
        |        |  +--ro state
        |        |     +--ro ttl?   uint32
        |        |     +--ro tos?   uint16
        |        +--ro mpls
        |        |  +--ro state
        |        |     +--ro ttl?   uint32
        |        |     +--ro tos?   uint16
        |        +--ro interface-ref
        |           +--ro state
        |              +--ro interface?      -> /oc-if:interfaces/interface/name
        |              +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index 
```