### PR TITLE
Clarify use match-set-options=ALL with regex

### DIFF
--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -24,7 +24,14 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.2.3";
+  oc-ext:openconfig-version "3.2.4";
+
+  revision "2023-06-09" {
+    description
+      "Clarify that match-set-options-type ALL is not valid in
+      combination with bgp-community-regexp-type";
+    reference "3.2.4";
+  }
 
   revision "2022-11-08" {
     description
@@ -107,7 +114,8 @@ module openconfig-policy-types {
       }
       enum ALL {
         description "match is true if given value matches all
-        members of the defined set";
+        members of the defined set.  This type is not valid when
+        used with oc-bgp-types:bgp-community-regexp-type";
       }
       enum INVERT {
         description "match is true if given value does not match any


### PR DESCRIPTION
* (M)  openconfig-policy-types.yang

match-set-options=ALL is not supported when used  with oc-bgp-types:bgp-community-regexp-type

Resolves #875 

## Scope of Change 
There is ambiguity in the OC model as to how matches are intended to be performed.  Sorry for the long explanation below, but this hopefully clearly explains it considering OC policy match vs. what NOS are doing today.

I believe the logic issue can be explained this way:

### Match behavior for match-set-options-type=ANY
There is no issue with the ANY behavior. I present this as a case which is well understood as background for the motivation for this PR.

`match-set-options-type=ANY`  The device should compare each item in a set of values with a list of match-set criteria.  If one or more values match one or more of the elements in the match-set, then the match operation is true.   In other words, a logical "OR" operation is used both for comparing a value with each match-set and across all the values.

For example, a prefix contains two communities:  5413:1, 29636:2
and the match-set contains 5413:[01] and 5555:[12] 
`match-set-options-type=ANY` will return a match because 5413:1 matches regex 5413:[01].

###  Match behavior for match-set-options-type=ALL

`match-set-options-type=ALL` requires a logical "AND" operation to be performed.   But it's ambiguous to me exactly how OC expects this to be performed.  There are two options I can see.  
1. The device should compare each item in a list of values with the list of match criteria.  ALL of the match criteria must be true for a given value in the list for a match to be true.
2. The device should compare each item in a list of values with ALL the items in the list of match criteria.  All of the match criteria must match at least one, but not all values in the value list. 
3. The device should compare each item in the list of values with the match criteria.  ALL of the values in the list must match at least one match criteria.   

In option 1, multiple regexes aren't logical because they must have some common/overlapping criteria in order for one value to match multiple regexes.  In this case it is more simple just have just one regex with the desired match criteria.  
This is the motivation for this PR.  However, it is not clear if OC requires this match behavior. 

In option 2, using multiple regexes seems logical.  

In option 3, using multiple regexes seems logical.  

[Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-0/routing/command/reference/rr40crs1book_chapter8.html#wp897883513) supports behavior like option 2, but only for community ranges, not for regex.   

[JunOS's policy match implementation for regex](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-configuring-as-path-regular-expressions-to-use-as-routing-policy-match-conditions.html) specifies that  ANY / OR is implemented when regex is in place.  A match-set-options ALL is not supported when using regex.

[Arista EOS ip extcommunity-list regexp](https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1116761) allows defining a list of regular expressions.  In [a comment below](https://github.com/openconfig/public/pull/891#issuecomment-1634379245), Arista indicates they support option 2 behavior.

[Nokia SR Linux supports policy match using a community set with multiple regex entries](https://documentation.nokia.com/srlinux/22-3/SR_Linux_Book_Files/Data_Model_Reference/srl_nokia-routing-policy_0.html#d4593) but it is not clear what the match behavior is from the documention.   Below @hellt describes that currently ALL is not implemented, but if they did implement it, it would follow option 3.

