### PR TITLE
Skip yanglint in CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -130,7 +130,7 @@ steps:
   dir: '/go/src/github.com/openconfig/pattern-regex-tests'
   waitFor: ['regexp clone']
   id: 'regexp dep'
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/regexp/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -156,7 +156,7 @@ steps:
   args: ['cp', 'gs://openconfig/yanglint.deb', '/workspace/yanglint.deb']
   waitFor: ['validator prep']
   id: 'yanglint prep2'
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/yanglint/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -194,7 +194,7 @@ steps:
   id: 'misc-checks'
 
 ############### OC-PYANG ###############
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', '/go/src/github.com/openconfig/models-ci/validators/oc-pyang/test.sh']
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -223,7 +223,7 @@ steps:
   - 'GOPATH=/go'
   waitFor: ['go path creation']
   id: 'goyang-ygot prep'
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/goyang-ygot/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -241,7 +241,7 @@ steps:
   id: 'goyang-ygot'
 
 ############### PYANG ###############
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', '/go/src/github.com/openconfig/models-ci/validators/pyang/test.sh']
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -259,7 +259,7 @@ steps:
   id: 'pyang'
 
 ############### PYANGBIND ###############
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', '/go/src/github.com/openconfig/models-ci/validators/pyangbind/test.sh']
   secretEnv: ['GITHUB_ACCESS_TOKEN']
@@ -277,7 +277,7 @@ steps:
   id: 'pyangbind'
 
 ############### COMPATIBILITY REPORT ###############
-- name: 'gcr.io/$PROJECT_ID/models-ci-image'
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', '/go/src/github.com/openconfig/models-ci/validators/compat_report.sh']
   secretEnv: ['GITHUB_ACCESS_TOKEN']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -87,9 +87,9 @@ steps:
     -pr-head-repo-url=$_HEAD_REPO_URL
     -commit-sha=$COMMIT_SHA
     -pr-number=$_PR_NUMBER
-    -skipped-validators=confd
+    -skipped-validators=confd,yanglint
     -extra-pyang-versions=2.2.1
-    -compat-report=yanglint
+    #-compat-report=yanglint
     -branch=$BRANCH_NAME
   secretEnv: ['GITHUB_ACCESS_TOKEN']
   env:


### PR DESCRIPTION
Looks like yanglint is way too out-of-date now. I'll work on getting the latest version ready so we can run it again and also create a CD for the image itself so that this doesn't happen again.