### PR TITLE
remove deviations from wifi models

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.5.0";
+  oc-ext:openconfig-version "1.6.0";
+
+  revision "2023-06-27" {
+    description
+      "Add WIFI_ACCESS_POINT";
+    reference "1.6.0";
+  }
 
   revision "2022-07-28" {
     description
@@ -343,6 +349,13 @@ module openconfig-platform-types {
       "A special purpose processing unit, typically for traffic
       switching/forwarding (e.g., switching ASIC, NPU, forwarding
       chip, etc.)";
+  }
+
+  identity WIFI_ACCESS_POINT {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "A device that attaches to a an Ethernet network and creates a wireless
+       local area network";
   }
 
   identity OPERATING_SYSTEM {

--- a/release/models/wifi/openconfig-access-points.yang
+++ b/release/models/wifi/openconfig-access-points.yang
@@ -27,7 +27,13 @@ module openconfig-access-points {
     "This module defines the top level WiFi Configurations for a list of
     Access Points.";
 
-  oc-ext:openconfig-version "1.1.1";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2023-06-26" {
+    description
+      "Update description for hostname";
+    reference "1.2.0";
+  }
 
   revision "2023-05-26" {
     description
@@ -168,7 +174,9 @@ module openconfig-access-points {
         "ap-manager:config/ap-manager:hostname";
       }
       description
-        "Access Point FQDN.";
+        "Access Point FQDN.  This leaf is only valid when the type of the
+         component is WIFI_ACCESS_POINT should be used instead of
+         /oc-sys:system/oc-sys:state/oc-sys:hostname.";
     }
   }
 

--- a/release/models/wifi/openconfig-access-points.yang
+++ b/release/models/wifi/openconfig-access-points.yang
@@ -175,7 +175,7 @@ module openconfig-access-points {
       }
       description
         "Access Point FQDN.  This leaf is only valid when the type of the
-         component is WIFI_ACCESS_POINT should be used instead of
+         component is WIFI_ACCESS_POINT, and should be used instead of
          /oc-sys:system/oc-sys:state/oc-sys:hostname.";
     }
   }

--- a/release/models/wifi/openconfig-access-points.yang
+++ b/release/models/wifi/openconfig-access-points.yang
@@ -219,12 +219,4 @@ module openconfig-access-points {
   }
   uses access-points-top;
 
-  // hostname is set using openconfig-wifi-aps model.
-  deviation /oc-sys:system/oc-sys:config/oc-sys:hostname {
-    deviate not-supported;
-  }
-
-  deviation /oc-sys:system/oc-sys:state/oc-sys:hostname {
-    deviate not-supported;
-  }
 }

--- a/release/models/wifi/openconfig-ap-interfaces.yang
+++ b/release/models/wifi/openconfig-ap-interfaces.yang
@@ -32,7 +32,13 @@ module openconfig-ap-interfaces {
     "This module defines the configuration and state data for
     non-radio interfaces on WiFi Access Points.";
 
-  oc-ext:openconfig-version "1.0.1";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2023-06-26" {
+    description
+      "Remove deviation for unnumbered interfaces";
+    reference "1.2.0";
+  }
 
   revision "2023-05-26" {
     description

--- a/release/models/wifi/openconfig-ap-interfaces.yang
+++ b/release/models/wifi/openconfig-ap-interfaces.yang
@@ -216,35 +216,4 @@ module openconfig-ap-interfaces {
 
     uses oc-tun:tunnel-top;
   }
-  // Deviation statements
-  // Unnumbered interfaces not supported on Access Points.
-  deviation "/oc-access-points:access-points/" +
-    "oc-access-points:access-point/" +
-    "oc-ap-if:interfaces/oc-ap-if:interface/" +
-    "oc-ap-if:subinterfaces/oc-ap-if:subinterface/oc-ap-if:ipv4/" +
-    "oc-ap-if:unnumbered" {
-    deviate not-supported;
-  }
-
-  deviation "/oc-access-points:access-points/" +
-    "oc-access-points:access-point/" +
-    "oc-ap-if:interfaces/oc-ap-if:interface/" +
-    "oc-ap-if:subinterfaces/oc-ap-if:subinterface/oc-ap-if:ipv6/" +
-    "oc-ap-if:unnumbered" {
-    deviate not-supported;
-  }
-
-  deviation "/oc-access-points:access-points/" +
-    "oc-access-points:access-point/" +
-    "oc-ap-if:interfaces/oc-ap-if:interface/" +
-    "oc-ap-if:tunnel/oc-ap-if:ipv4/oc-ap-if:unnumbered" {
-    deviate not-supported;
-  }
-
-  deviation "/oc-access-points:access-points/" +
-    "oc-access-points:access-point/" +
-    "oc-ap-if:interfaces/oc-ap-if:interface/" +
-    "oc-ap-if:tunnel/oc-ap-if:ipv6/oc-ap-if:unnumbered" {
-    deviate not-supported;
-  }
 }


### PR DESCRIPTION
Fixes #882 

### Change Scope

* Removing deviations from wifi model as it was determined not appropriate to add deviations within the OC models themselves.

