### PR TITLE
Clarify transport/state/remote-port vs. config/neighbor-port

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
 
   revision "2023-04-01" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
 
   revision "2023-04-01" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
 
   revision "2023-04-01" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -26,7 +26,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
 
   revision "2023-04-01" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -203,7 +203,8 @@ submodule openconfig-bgp-neighbor {
         type oc-inet:port-number;
         default 179;
         description
-          "Destination TCP port number of the BGP peer";
+          "Destination TCP port number of the BGP peer when initiating a
+          session from the local router";
     }
 
     leaf enabled {
@@ -480,10 +481,11 @@ submodule openconfig-bgp-neighbor {
     leaf remote-port {
       type oc-inet:port-number;
       description
-        "Remote port being used by the peer for the TCP session
-        supporting the BGP session.  This may be the same value
-        as the configured neighbor-port or another TCP port if
-        the peer initiated the TCP session.";
+        "The source TCP port being used by the peer for the TCP session
+        supporting the BGP session.  This is expected to be the same value
+        as the configured neighbor-port if the local device initiated the
+        connection or a different TCP port if the peer initiated the TCP
+        session.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -197,7 +197,7 @@ submodule openconfig-bgp-neighbor {
         type oc-inet:port-number;
         default 179;
         description
-          "Port number of the BGP peer";
+          "Destination TCP port number of the BGP peer";
     }
 
     leaf enabled {
@@ -475,7 +475,9 @@ submodule openconfig-bgp-neighbor {
       type oc-inet:port-number;
       description
         "Remote port being used by the peer for the TCP session
-        supporting the BGP session";
+        supporting the BGP session.  This may be the same value
+        as the configured neighbor-port or another TCP port if
+        the peer initiated the TCP session.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,8 +30,14 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
 
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+  
   revision "2023-04-01" {
     description
       "Add support for BGP large communities [rfc8092] in

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -34,7 +34,7 @@ submodule openconfig-bgp-neighbor {
 
   revision "2023-06-27" {
     description
-      "Clarify bgp remote-port description";
+      "Clarify bgp neighbor-port, remote-port and local-port descriptions";
     reference "9.4.1";
   }
 
@@ -467,7 +467,7 @@ submodule openconfig-bgp-neighbor {
     leaf local-port {
       type oc-inet:port-number;
       description
-        "Local TCP port being used for the TCP session supporting
+        "Local, source TCP port being used for the TCP session supporting
         the BGP session";
     }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -37,7 +37,7 @@ submodule openconfig-bgp-neighbor {
       "Clarify bgp remote-port description";
     reference "9.4.1";
   }
-  
+
   revision "2023-04-01" {
     description
       "Add support for BGP large communities [rfc8092] in

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
 
   revision "2023-04-01" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,8 +68,14 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.4.0";
+  oc-ext:openconfig-version "9.4.1";
 
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+  
   revision "2023-04-01" {
     description
       "Add support for BGP large communities [rfc8092] in

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -75,7 +75,7 @@ module openconfig-bgp {
       "Clarify bgp remote-port description";
     reference "9.4.1";
   }
-  
+
   revision "2023-04-01" {
     description
       "Add support for BGP large communities [rfc8092] in


### PR DESCRIPTION
This is a description only clarification on the purpose of 
`/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/neighbor-port`
versus
`/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/transport/state/remote-port`

state/neighbor-port contains the value of the local device's configured (config/neighbor-port) destination TCP port of a bgp neighbor.

transport/state/remote-port shows the source TCP port of a remote peer which is currently connected.  This could be a dynamic or statically configured peer.  The value might be the same as state/neighbor-port if the local device created the connection.    But if the connection was created by the neighbor, the TCP port will be an ephemeral TCP port number.
