### PR TITLE
Add IPv6 RA config mode

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -950,10 +950,9 @@ module openconfig-if-ip {
       type boolean;
       default true;
       description
-        "All ipv6 router advertisement functions are disabled.  The
-        local system will not transmit router advertisement messages and
-        will not respond to router solicitation messages";
-
+        "If set to false, all ipv6 router advertisement functions are
+        disabled.  The local system will not transmit router advertisement
+        messages and will not respond to router solicitation messages";
     }
 
     leaf interval {
@@ -978,9 +977,8 @@ module openconfig-if-ip {
       type boolean;
       default false;
       description
-        "When set to true, router advertisement neighbor discovery messages
-        are not transmitted on this interface.  Responses to router
-        solicitation are transmitted.";
+        "When set to true, router advertisement neighbor discovery
+        messages are not transmitted on this interface.";
     }
 
     leaf mode {

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -946,6 +946,16 @@ module openconfig-if-ip {
     description
       "Configuration parameters for IPv6 router advertisements.";
 
+    leaf enable {
+      type boolean;
+      default true;
+      description
+        "All ipv6 router advertisement functions are disabled.  The
+        local system will not transmit router advertisement messages and
+        will not respond to router solicitation messages";
+
+    }
+
     leaf interval {
       type uint32;
       units seconds;
@@ -975,25 +985,19 @@ module openconfig-if-ip {
 
     leaf mode {
       type enumeration {
-        enum ENABLE {
+        enum ALL {
           description
-            "The system will transmit ipv6 router advertisement messages and
-            respond to route solicitation requests.";
+            "The system will transmit unsolicited router advertisement
+            messages and respond to router solicitation requests.";
         }
-        enum DISABLE {
-          description
-            "All ipv6 router advertisement functions are disabled.  The
-            local system will not transmit router advertisement messages and
-            will not respond to router solicitation messages.";
-        }
-        enum DISABLE_RA {
+        enum DISABLE_UNSOLICITED_RA {
           description
             "Unsolicted router advertisement messages are not transmitted on
             this interface.  Responses to router solicitation messages will
             be transmitted.";
         }
       }
-      default "ENABLE";
+      default "ALL";
       description
         "Mode controls which set of behaviors the local system should perform
         to support ipv6 router advertisements.";

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -48,7 +48,7 @@ module openconfig-if-ip {
 
   revision "2023-06-30" {
     description
-      "Deprecate ipv6 router advertisment config suppress leaf and add config
+      "Deprecate IPv6 router advertisment config suppress leaf and add config
       mode leaf.";
     reference "3.4.0";
   }
@@ -61,7 +61,7 @@ module openconfig-if-ip {
 
   revision "2023-02-06" {
     description
-      "Add ipv6 link-local configuration.";
+      "Add IPv6 link-local configuration.";
     reference "3.2.0";
   }
 
@@ -950,7 +950,7 @@ module openconfig-if-ip {
       type boolean;
       default true;
       description
-        "If set to false, all ipv6 router advertisement functions are
+        "If set to false, all IPv6 router advertisement functions are
         disabled.  The local system will not transmit router advertisement
         messages and will not respond to router solicitation messages";
     }
@@ -998,7 +998,7 @@ module openconfig-if-ip {
       default "ALL";
       description
         "Mode controls which set of behaviors the local system should perform
-        to support ipv6 router advertisements.";
+        to support IPv6 router advertisements.";
       reference "RFC4861: Neighbor Discovery for IP version 6 (IPv6)";
     }
 

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -1,66 +1,55 @@
 module openconfig-if-ip {
 
-yang-version "1";
+  yang-version "1";
 
-// namespace
-namespace "http://openconfig.net/yang/interfaces/ip";
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces/ip";
 
-prefix "oc-ip";
+  prefix "oc-ip";
 
-// import some basic types
-import openconfig-inet-types {
-    prefix oc-inet;
-}
-import openconfig-interfaces {
-    prefix oc-if;
-}
-import openconfig-vlan {
-    prefix oc-vlan;
-}
-import openconfig-yang-types {
-    prefix oc-yang;
-}
-import openconfig-extensions {
-    prefix oc-ext;
-}
+  // import some basic types
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-vlan { prefix oc-vlan; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-extensions { prefix oc-ext; }
 
-// meta
-organization
-  "OpenConfig working group";
+  // meta
+  organization "OpenConfig working group";
 
-contact
-  "OpenConfig working group
-   netopenconfig@googlegroups.com";
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
 
-description
-  "This model defines data for managing configuration and
-   operational state on IP (IPv4 and IPv6) interfaces.
+  description
+    "This model defines data for managing configuration and
+    operational state on IP (IPv4 and IPv6) interfaces.
 
-   This model reuses data items defined in the IETF YANG model for
-   interfaces described by RFC 7277 with an alternate structure
-   (particularly for operational state data) and with
-   additional configuration items.
+    This model reuses data items defined in the IETF YANG model for
+    interfaces described by RFC 7277 with an alternate structure
+    (particularly for operational state data) and with
+    additional configuration items.
 
-   Portions of this code were derived from IETF RFC 7277.
-   Please reproduce this note if possible.
+    Portions of this code were derived from IETF RFC 7277.
+    Please reproduce this note if possible.
 
-   IETF code is subject to the following copyright and license:
-   Copyright (c) IETF Trust and the persons identified as authors of
-   the code.
-   All rights reserved.
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
 
-   Redistribution and use in source and binary forms, with or without
-   modification, is permitted pursuant to, and subject to the license
-   terms contained in, the Simplified BSD License set forth in
-   Section 4.c of the IETF Trust's Legal Provisions Relating
-   to IETF Documents (http://trustee.ietf.org/license-info).";
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
 
-oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.4.0";
 
-revision '2023-06-30" {
+  revision "2023-06-30" {
     description
-      "add router advertisement config/mode and deprecate router advertisement
-    config/suppress leaf";
+      "Deprecate ipv6 router advertisment config suppress leaf and add config
+      mode leaf.";
     reference "3.4.0";
   }
 
@@ -84,7 +73,7 @@ revision '2023-06-30" {
 
   revision "2019-01-08" {
     description
-      "Eliminate use of the empty type.";
+      "Eliminate use of the 'empty' type.";
     reference "3.0.0";
   }
 
@@ -1010,15 +999,6 @@ revision '2023-06-30" {
         "Mode controls which set of behaviors the local system should perform
         to support ipv6 router advertisements.";
       reference "RFC4861: Neighbor Discovery for IP version 6 (IPv6)";
-    }
-
-    leaf enabled {
-      type boolean;
-      default true;
-      description
-        "When set to true, ipv6 router advertisements are supported.  When
-        set to false, all ipv6 router advertisements and responses to are
-        disabled";
     }
 
     leaf managed {

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -977,21 +977,20 @@ module openconfig-if-ip {
       type enumeration {
         enum ENABLE {
           description
-            "The system should not respond to ARP requests that
-            do not specify an IP address configured on the local
-            subinterface as the target address.";
+            "The system will transmit ipv6 router advertisement messages and
+            respond to route solicitation requests.";
         }
         enum DISABLE {
           description
             "All ipv6 router advertisement functions are disabled.  The
-            local system will not transmit neighbor discovery messages and
+            local system will not transmit router advertisement messages and
             will not respond to router solicitation messages.";
         }
         enum DISABLE_RA {
           description
-            "Router advertisement neighbor discovery messages are not
-            transmitted on this interface.  Responses to router
-            solicitation messages will be transmitted.";
+            "Unsolicted router advertisement messages are not transmitted on
+            this interface.  Responses to router solicitation messages will
+            be transmitted.";
         }
       }
       default "ENABLE";

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,7 +44,14 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision '2023-06-30" {
+    description
+      "add router advertisement config/mode and deprecate router advertisement
+    config/suppress leaf";
+    reference "3.4.0";
+  }
 
   revision "2023-04-12" {
     description
@@ -957,11 +964,50 @@ module openconfig-if-ip {
     }
 
     leaf suppress {
+      status deprecated;
       type boolean;
       default false;
       description
-        "When set to true, router advertisement neighbor discovery
-        messages are not transmitted on this interface.";
+        "When set to true, router advertisement neighbor discovery messages
+        are not transmitted on this interface.  Responses to router
+        solicitation are transmitted.";
+    }
+
+    leaf mode {
+      type enumeration {
+        enum ENABLE {
+          description
+            "The system should not respond to ARP requests that
+            do not specify an IP address configured on the local
+            subinterface as the target address.";
+        }
+        enum DISABLE {
+          description
+            "All ipv6 router advertisement functions are disabled.  The
+            local system will not transmit neighbor discovery messages and
+            will not respond to router solicitation messages.";
+        }
+        enum DISABLE_RA {
+          description
+            "Router advertisement neighbor discovery messages are not
+            transmitted on this interface.  Responses to router
+            solicitation messages will be transmitted.";
+        }
+      }
+      default "ENABLE";
+      description
+        "Mode controls which set of behaviors the local system should perform
+        to support ipv6 router advertisements.";
+      reference "RFC4861: Neighbor Discovery for IP version 6 (IPv6)";
+    }
+
+    leaf enabled {
+      type boolean;
+      default true;
+      description
+        "When set to true, ipv6 router advertisements are supported.  When
+        set to false, all ipv6 router advertisements and responses to are
+        disabled";
     }
 
     leaf managed {

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -35,20 +35,20 @@ contact
 description
   "This model defines data for managing configuration and
    operational state on IP (IPv4 and IPv6) interfaces.
-   
+
    This model reuses data items defined in the IETF YANG model for
    interfaces described by RFC 7277 with an alternate structure
    (particularly for operational state data) and with
    additional configuration items.
-   
+
    Portions of this code were derived from IETF RFC 7277.
    Please reproduce this note if possible.
-   
+
    IETF code is subject to the following copyright and license:
    Copyright (c) IETF Trust and the persons identified as authors of
    the code.
    All rights reserved.
-   
+
    Redistribution and use in source and binary forms, with or without
    modification, is permitted pursuant to, and subject to the license
    terms contained in, the Simplified BSD License set forth in

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -1,52 +1,63 @@
 module openconfig-if-ip {
 
-  yang-version "1";
+yang-version "1";
 
-  // namespace
-  namespace "http://openconfig.net/yang/interfaces/ip";
+// namespace
+namespace "http://openconfig.net/yang/interfaces/ip";
 
-  prefix "oc-ip";
+prefix "oc-ip";
 
-  // import some basic types
-  import openconfig-inet-types { prefix oc-inet; }
-  import openconfig-interfaces { prefix oc-if; }
-  import openconfig-vlan { prefix oc-vlan; }
-  import openconfig-yang-types { prefix oc-yang; }
-  import openconfig-extensions { prefix oc-ext; }
+// import some basic types
+import openconfig-inet-types {
+    prefix oc-inet;
+}
+import openconfig-interfaces {
+    prefix oc-if;
+}
+import openconfig-vlan {
+    prefix oc-vlan;
+}
+import openconfig-yang-types {
+    prefix oc-yang;
+}
+import openconfig-extensions {
+    prefix oc-ext;
+}
 
-  // meta
-  organization "OpenConfig working group";
+// meta
+organization
+  "OpenConfig working group";
 
-  contact
-    "OpenConfig working group
-    netopenconfig@googlegroups.com";
+contact
+  "OpenConfig working group
+   netopenconfig@googlegroups.com";
 
-  description
-    "This model defines data for managing configuration and
-    operational state on IP (IPv4 and IPv6) interfaces.
+description
+  "This model defines data for managing configuration and
+   operational state on IP (IPv4 and IPv6) interfaces.
+   
+   This model reuses data items defined in the IETF YANG model for
+   interfaces described by RFC 7277 with an alternate structure
+   (particularly for operational state data) and with
+   additional configuration items.
+   
+   Portions of this code were derived from IETF RFC 7277.
+   Please reproduce this note if possible.
+   
+   IETF code is subject to the following copyright and license:
+   Copyright (c) IETF Trust and the persons identified as authors of
+   the code.
+   All rights reserved.
+   
+   Redistribution and use in source and binary forms, with or without
+   modification, is permitted pursuant to, and subject to the license
+   terms contained in, the Simplified BSD License set forth in
+   Section 4.c of the IETF Trust's Legal Provisions Relating
+   to IETF Documents (http://trustee.ietf.org/license-info).";
 
-    This model reuses data items defined in the IETF YANG model for
-    interfaces described by RFC 7277 with an alternate structure
-    (particularly for operational state data) and with
-    additional configuration items.
+oc-ext:openconfig-version "3.4.0";
 
-    Portions of this code were derived from IETF RFC 7277.
-    Please reproduce this note if possible.
-
-    IETF code is subject to the following copyright and license:
-    Copyright (c) IETF Trust and the persons identified as authors of
-    the code.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, is permitted pursuant to, and subject to the license
-    terms contained in, the Simplified BSD License set forth in
-    Section 4.c of the IETF Trust's Legal Provisions Relating
-    to IETF Documents (http://trustee.ietf.org/license-info).";
-
-  oc-ext:openconfig-version "3.4.0";
-
-  revision '2023-06-30" {
+revision '2023-06-30" {
     description
       "add router advertisement config/mode and deprecate router advertisement
     config/suppress leaf";

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -84,7 +84,7 @@ revision '2023-06-30" {
 
   revision "2019-01-08" {
     description
-      "Eliminate use of the 'empty' type.";
+      "Eliminate use of the empty type.";
     reference "3.0.0";
   }
 

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -952,7 +952,7 @@ module openconfig-if-ip {
       description
         "If set to false, all IPv6 router advertisement functions are
         disabled.  The local system will not transmit router advertisement
-        messages and will not respond to router solicitation messages";
+        messages and will not respond to router solicitation messages.";
     }
 
     leaf interval {


### PR DESCRIPTION
### Change Scope
Introduce a new leaf to set one of three different modes for IPv6 router advertisements.  

Deprecate the ipv6 router advertisement config "suppress" leaf since common operational requirements involve setting one of three different values.

This change is backwards compatible.

### Platform Implementations

 * [Arista EOS](https://www.arista.com/en/um-eos/eos-ipv6#xx1143369) implements `ipv6 nd ra disabled` and `ipv6 nd ra disabled all`
 
 * [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/ios_xr_sw/iosxr_r3-7/addr_serv/command/reference/ir37ntsk.html#wp1182427) implements `ipv6 nd ra suppress` and `ipv6 nd ra suppress all`

 * [JunOS](https://www.juniper.net/documentation/us/en/software/junos/neighbor-discovery/topics/topic-map/ipv6-neighbor-discovery.html) uses router-advertisement to enable or disable on a per interface basis.  It is disabled by default.  JunOS uses [solicit-router-advertisement-unicast](https://www.juniper.net/documentation/us/en/software/junos/neighbor-discovery/topics/ref/statement/solicit-router-advertisement-unicast.html) to enable/disable support for solicitation.

* [Nokia SRLinux](https://documentation.nokia.com/cgi-bin/dbaccessfilename.cgi/3HE17569AAAA01_V1_SR%20Linux%20R21.6%20Configuration%20Basics.pdf) can enable and disable ipv6 router advertisements.  It is not appear that solicitation is configurable.
