### PR TITLE
Add bytes-sampled field to sflow sampling model

### DIFF
--- a/release/models/sampling/openconfig-sampling-sflow.yang
+++ b/release/models/sampling/openconfig-sampling-sflow.yang
@@ -167,6 +167,13 @@ module openconfig-sampling-sflow {
         "The total number of packets sampled and sent to the
         collector.";
     }
+
+    leaf bytes-sampled {
+      type oc-yang:counter64;
+      description
+        "The approximate estimate of bytes sampled and sent
+        to the collector.";
+    }
   }
 
   grouping sflow-collectors-top {


### PR DESCRIPTION
### Change Scope

* release/models/sampling/openconfig-sampling-sflow.yang
  * Added a new field bytes-sampled to indicate an approximate estimate of the total bytes sampled.

