### PR TITLE
Vty files logging

### DIFF
--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -370,6 +370,18 @@ submodule openconfig-qos-interfaces {
       description
         "Number of octets dropped by the queue due to overrun";
     }
+
+    leaf aged-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets dropped due to timeout; Timeout occurse when queue is not full yet, so packet are enqueued and not tail/WRED dropped, but there is no transmission out of queue - queue is starved by other higher priority traffic for extended period of time.";
+    }
+
+    leaf aged-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets dropped by the queue due to timeout; Timeout occurse when queue is not full yet, so packet are enqueued and not tail/WRED dropped, but there is no transmission out of queue - queue is starved by other higher priority traffic for extended period of time.";
+    }
   }
 
   grouping qos-interface-queue-top {

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,13 +25,7 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.10.0";
-
-  revision "2023-07-13" {
-    description
-      "Add support for aged-packet, aged-byte conters";
-    reference "0.10.0";
-  }
+  oc-ext:openconfig-version "0.9.1";
 
   revision "2023-04-25" {
     description
@@ -368,25 +362,13 @@ submodule openconfig-qos-interfaces {
     leaf dropped-pkts {
       type oc-yang:counter64;
       description
-        "Number of packets dropped by the queue due to overrun, that is tail-drop or WRED drop";
+        "Number of packets dropped by the queue due to overrun";
     }
 
     leaf dropped-octets {
       type oc-yang:counter64;
       description
-        "Number of octets dropped by the queue due to overrun, that is tail-drop or WRED drop";
-    }
-
-    leaf aged-pkts {
-      type oc-yang:counter64;
-      description
-        "Number of packets dropped due to timeout; Timeout occurse when queue is not full yet, so packet are enqueued and not tail/WRED dropped, but there is no transmission out of queue - queue is starved by other higher priority traffic for extended period of time.";
-    }
-
-    leaf aged-octets {
-      type oc-yang:counter64;
-      description
-        "Number of octets dropped by the queue due to timeout; Timeout occurse when queue is not full yet, so packet are enqueued and not tail/WRED dropped, but there is no transmission out of queue - queue is starved by other higher priority traffic for extended period of time.";
+        "Number of octets dropped by the queue due to overrun";
     }
   }
 

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -368,13 +368,13 @@ submodule openconfig-qos-interfaces {
     leaf dropped-pkts {
       type oc-yang:counter64;
       description
-        "Number of packets dropped by the queue due to overrun";
+        "Number of packets dropped by the queue due to overrun, that is tail-drop or WRED drop";
     }
 
     leaf dropped-octets {
       type oc-yang:counter64;
       description
-        "Number of octets dropped by the queue due to overrun";
+        "Number of octets dropped by the queue due to overrun, that is tail-drop or WRED drop";
     }
 
     leaf aged-pkts {

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.9.1";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2023-07-13" {
+    description
+      "Add support for aged-packet, aged-byte conters";
+    reference "0.10.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -442,7 +442,8 @@ revision "2023-07-20" {
 
     container remote-servers {
       description
-        "Enclosing container for the list of remote log servers";
+        "Enclosing container for the list of remote log 
+         servers";
 
       list remote-server {
         key "host";
@@ -488,7 +489,9 @@ revision "2023-07-20" {
         length 0..255;
       }
       description
-        "A name used for the file.  It is expected that an implementation may append timestamp, serial-number or other identifier to the filename.";
+        "A name used for the file.  It is expected that an
+        implementation may append timestamp, serial-number or
+        other identifier to the filename.";
     }
 
     leaf path {
@@ -496,23 +499,31 @@ revision "2023-07-20" {
         length 0..255;
       }
       description
-        "The fully specified path of the folder where the logfile is stored.  The path is implementation specific
+        "The fully specified path of the folder where the 
+        logfile is stored.  The path is implementation specific
         and may include attributes such as a drive identifier.";
     }
 
-    leaf count {
+    leaf rotate {
       type uint32;
-      default 1;
+      default 0;
       description
-        "Used for logfile rotation.   When the max-size limit is reached the active file is rotated.  Log files are rotated the number of times defined by this leaf.  The default value of 1 indicates that there will be one rotation file and one active file.  A 0 value indicates old versions are removed rather than rotated.";
+        "Used for logfile rotation.
+         Log files are rotated the number of times defined by
+         this leaf.
+         The default value of 1 indicates that there will be one
+         rotation file and one active file.  A 0 value indicates 
+         old versions are removed rather than rotated.";
     }
 
     leaf max-size {
       type uint32;
       default 1000;
       description
-        "Maximum size in Bytes, logfile may grow to. When logfile reach this size it triggers log rotation.
-        The log file need to be save, closed, and new file open or future log storage.
+        "Used for logfile rotation.
+        Maximum size in Bytes, logfile may grow to. When logfile
+        reach this size it triggers log rotation. The log file need to
+        be save, closed, and new file open or future log storage.
         If needed oldest logfile of same prefix shall be deleted to";
     }
 
@@ -520,11 +531,13 @@ revision "2023-07-20" {
       type uint32;
       default 1440;
       description
-        "Maximum time, in minutes, the logfile can be open. When expires, 
+        "Used for logfile rotation.
+        Maximum time, in minutes, the logfile can be open. When expires, 
         it triggers log rotation.
         Actions are same ans when log file reaches its max-size. 
-        it need to be closed, save, and new file open or future log storage. 
-        If needed oldest logfile of same prefix shall be deleted to ";
+        it need to be closed, save, and new file open or future log 
+        storage. If needed oldest logfile of same prefix shall be
+        deleted to ";
     }
   }
 
@@ -536,7 +549,8 @@ revision "2023-07-20" {
         length 0..511;
       }
       description
-        "the currently active/open filename prepended by folder path and including suffix appended to filename-prefix by system";
+        "the currently active/open filename prepended by folder path
+        and including suffix appended to filename-prefix by system";
     }
   }
 

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -589,7 +589,7 @@ module openconfig-system-logging {
 
       uses logging-console-top;
       uses logging-remote-top;
-      uses loffing-files-top;
+      uses logging-files-top;
 
     }
   }

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -542,8 +542,7 @@ revision "2023-07-20" {
         "Enclosing container for the list of log files";
 
       list file {
-        key "filename-prefix";
-        key "path";
+        key "path filename-prefix";
         description
           "List of logfiles";
 

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -511,14 +511,20 @@ revision "2023-07-20" {
       type uint32;
       default 1000;
       description
-        "Maximum size logfile may grow to. When logfile reach this size it need to be closed, save, and new file open or future log storage. If needed oldest logfile of same prefix shall be deleted to";
+        "Maximum size in Bytes, logfile may grow to. When logfile reach this size it triggers log rotation.
+        The log file need to be save, closed, and new file open or future log storage.
+        If needed oldest logfile of same prefix shall be deleted to";
     }
 
     leaf max-open-time {
       type uint32;
       default 1440;
       description
-        "Maximum time, in minutes, the logfile can be open. When expires, it need to be closed, save, and new file open or future log storage. If needed oldest logfile of same prefix shall be deleted to ";
+        "Maximum time, in minutes, the logfile can be open. When expires, 
+        it triggers log rotation.
+        Actions are same ans when log file reaches its max-size. 
+        it need to be closed, save, and new file open or future log storage. 
+        If needed oldest logfile of same prefix shall be deleted to ";
     }
   }
 
@@ -566,17 +572,13 @@ revision "2023-07-20" {
         container config {
           description
             "Configuration data for logfile";
-
           uses logging-file-config;
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for logfile servers";
-
           uses logging-file-config;
           uses logging-file-state;
         }
@@ -602,16 +604,12 @@ revision "2023-07-20" {
       }
 
       container state {
-
         config false;
-
         description
           "Operational state data for console logging";
-
         uses logging-console-config;
         uses logging-console-state;
       }
-
       uses logging-selectors-top;
     }
   }

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -442,7 +442,7 @@ revision "2023-07-20" {
 
     container remote-servers {
       description
-        "Enclosing container for the list of remote log 
+        "Enclosing container for the list of remote log
          servers";
 
       list remote-server {
@@ -499,7 +499,7 @@ revision "2023-07-20" {
         length 0..255;
       }
       description
-        "The fully specified path of the folder where the 
+        "The fully specified path of the folder where the
         logfile is stored.  The path is implementation specific
         and may include attributes such as a drive identifier.";
     }
@@ -512,7 +512,7 @@ revision "2023-07-20" {
          Log files are rotated the number of times defined by
          this leaf.
          The default value of 1 indicates that there will be one
-         rotation file and one active file.  A 0 value indicates 
+         rotation file and one active file.  A 0 value indicates
          old versions are removed rather than rotated.";
     }
 
@@ -532,10 +532,10 @@ revision "2023-07-20" {
       default 1440;
       description
         "Used for logfile rotation.
-        Maximum time, in minutes, the logfile can be open. When expires, 
+        Maximum time, in minutes, the logfile can be open. When expires,
         it triggers log rotation.
-        Actions are same ans when log file reaches its max-size. 
-        it need to be closed, save, and new file open or future log 
+        Actions are same ans when log file reaches its max-size.
+        it need to be closed, save, and new file open or future log
         storage. If needed oldest logfile of same prefix shall be
         deleted to ";
     }

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -23,7 +23,7 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
 
 revision "2023-07-20" {
     description

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -23,12 +23,12 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.5.1";
+  oc-ext:openconfig-version "0.6.0";
 
 revision "2023-07-20" {
     description
       "adding VTY and local files as logging destinations";
-    reference "0.5.1";
+    reference "0.6.0";
   }
 
   revision "2023-05-04" {
@@ -488,7 +488,7 @@ revision "2023-07-20" {
         length 0..255;
       }
       description
-        "filename prefix. It is expected that implementation may append to it timestamp, serial-number or other type of identifier";
+        "A name used for the file.  It is expected that an implementation may append timestamp, serial-number or other identifier to the filename.";
     }
 
     leaf path {
@@ -496,14 +496,15 @@ revision "2023-07-20" {
         length 0..255;
       }
       description
-        "path to the folder where logfile is stored. May include drive identifier is implementation requires";
+        "The fully specified path of the folder where the logfile is stored.  The path is implementation specific
+        and may include attributes such as a drive identifier.";
     }
 
     leaf count {
       type uint32;
       default 1;
       description
-        "Used for logfile rotation. maximum number of files of given filename-prefix stored. Default value: 1. ";
+        "Used for logfile rotation.   When the max-size limit is reached the active file is rotated.  Log files are rotated the number of times defined by this leaf.  The default value of 1 indicates that there will be one rotation file and one active file.  A 0 value indicates old versions are removed rather than rotated.";
     }
 
     leaf max-size {

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -473,6 +473,112 @@ module openconfig-system-logging {
     }
   }
 
+  grouping logging-file-config {
+    description
+      "Configuration data for logfile";
+
+    leaf filename-prefix {
+      type string {
+        length 0..255;
+      }
+      description
+        "filename prefix. It is expected that implementation may append to it timestamp, serial-number or other type of identifier";
+    }
+
+    leaf path {
+      type string {
+        length 0..255;
+      }
+      description
+        "path to the folder where logfile is stored. May include drive identifier is implementation requires";
+    }
+
+    leaf count {
+      type uint32;
+      default 1;
+      description
+        "Used for logfile rotation. maximum number of files of given filename-prefix stored. Default value: 1. ";
+    }
+
+    leaf max-size {
+      type uint32;
+      default 1000;
+      description
+        "Maximum size logfile may grow to. When logfile reach this size it need to be closed, save, and new file open or future log storage. If needed oldest logfile of same prefix shall be deleted to";
+    }
+
+    leaf max-open-time {
+      type uint32;
+      default 1440;
+      description
+        "Maximum time, in minutes, the logfile can be open. When expires, it need to be closed, save, and new file open or future log storage. If needed oldest logfile of same prefix shall be deleted to ";
+    }
+  }
+
+  grouping logging-file-state {
+    description
+      "Operational state data for logfile";
+    leaf open-logfile {
+      type string{
+        length 0..511;
+      }
+      description
+        "the currently active/open filename prepended by folder path and including suffix appended to filename-prefix by system";
+    }
+  }
+
+  grouping logging-files-top {
+    description
+      "Top-level grouping for local log files";
+
+    container files {
+      description
+        "Enclosing container for the list of log files";
+
+      list file {
+        key "filename-prefix";
+        key "path";
+        description
+          "List of logfiles";
+
+        leaf filename-prefix {
+          type leafref {
+            path "../config/filename-prefix";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        leaf path {
+          type leafref {
+            path "../config/path";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        container config {
+          description
+            "Configuration data for logfile";
+
+          uses logging-file-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for logfile servers";
+
+          uses logging-file-config;
+          uses logging-file-state;
+        }
+        uses logging-selectors-top;
+      }
+    }
+  }
+
   grouping logging-top {
     description
       "Top-level grouping for logging data";
@@ -483,6 +589,8 @@ module openconfig-system-logging {
 
       uses logging-console-top;
       uses logging-remote-top;
+      uses loffing-files-top;
+
     }
   }
   // data definition statements

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -25,6 +25,12 @@ module openconfig-system-logging {
 
   oc-ext:openconfig-version "0.5.0";
 
+revision "2023-07-20" {
+    description
+      "adding VTY and local files as logging destinations";
+    reference "0.5.1";
+  }
+
   revision "2023-05-04" {
     description
       "removing LOG_DESTINATION_TYPE identities";
@@ -354,12 +360,12 @@ module openconfig-system-logging {
 
   grouping logging-console-config {
     description
-      "Configuration data for console logging";
+      "Configuration data for console and vty logging";
   }
 
   grouping logging-console-state {
     description
-      "Operational state data for console logging";
+      "Operational state data for console and vty logging";
   }
 
   grouping logging-console-top {
@@ -579,6 +585,37 @@ module openconfig-system-logging {
     }
   }
 
+  grouping logging-vty-top {
+    description
+      "Top-level grouping for vty logging data";
+
+    container vty {
+      description
+        "Top-level container for data related to vty-based
+        logging (active sessions of ssh, telnet, etc )";
+
+      container config {
+        description
+          "Configuration data for vty logging";
+
+        uses logging-console-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for console logging";
+
+        uses logging-console-config;
+        uses logging-console-state;
+      }
+
+      uses logging-selectors-top;
+    }
+  }
+
   grouping logging-top {
     description
       "Top-level grouping for logging data";
@@ -590,6 +627,7 @@ module openconfig-system-logging {
       uses logging-console-top;
       uses logging-remote-top;
       uses logging-files-top;
+      uses logging-vty-top;
 
     }
   }


### PR DESCRIPTION
### Change Scope

This change adds local files and vty as destination of logging.
For local files, retention of logfiles is added as well.

### Platform Implementations

 * Juniper: [logging to local file](https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/ref/statement/file-edit-system-syslog.html) 
 * Juniper [logging to vty]()
 * Cisco XR [logging to vty](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-monitoring/73x/b-system-monitoring-cg-cisco8k-73x/implementing_system_logging.html#concept_myy_hk4_43b)
* Cisco XR [logging to local file](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-monitoring/73x/b-system-monitoring-cg-cisco8k-73x/implementing_system_logging.html#concept_gt2_l34_43b)
* Nokia SR-Linux [logging to file](https://infocenter.nokia.com/public/SRLINUX200R6A/topic/com.srlinux.configbasics/html/configb-logging.html?resultof=%22%73%79%73%6c%6f%67%22%20)

## Tree view
```
pyang -f tree -p release/models/*/*  

[... snip ...]

module: openconfig-system
  +--rw system
[... snip ...]
     +--rw logging
[... snip ...]
     |  +--rw files
     |  |  +--rw file* [path filename-prefix]
     |  |     +--rw filename-prefix    -> ../config/filename-prefix
     |  |     +--rw path               -> ../config/path
     |  |     +--rw config
     |  |     |  +--rw filename-prefix?   string
     |  |     |  +--rw path?              string
     |  |     |  +--rw rotate?            uint32
     |  |     |  +--rw max-size?          uint32
     |  |     |  +--rw max-open-time?     uint32
     |  |     +--ro state
     |  |     |  +--ro filename-prefix?   string
     |  |     |  +--ro path?              string
     |  |     |  +--ro rotate?            uint32
     |  |     |  +--ro max-size?          uint32
     |  |     |  +--ro max-open-time?     uint32
     |  |     |  +--ro open-logfile?      string
     |  |     +--rw selectors
     |  |        +--rw selector* [facility severity]
     |  |           +--rw facility    -> ../config/facility
     |  |           +--rw severity    -> ../config/severity
     |  |           +--rw config
     |  |           |  +--rw facility?   identityref
     |  |           |  +--rw severity?   syslog-severity
     |  |           +--ro state
     |  |              +--ro facility?   identityref
     |  |              +--ro severity?   syslog-severity
     |  +--rw vty
     |     +--rw config
     |     +--ro state
     |     +--rw selectors
     |        +--rw selector* [facility severity]
     |           +--rw facility    -> ../config/facility
     |           +--rw severity    -> ../config/severity
     |           +--rw config
     |           |  +--rw facility?   identityref
     |           |  +--rw severity?   syslog-severity
     |           +--ro state
     |              +--ro facility?   identityref
     |              +--ro severity?   syslog-severity
```

The change is not breaking