### PR TITLE
Update openconfig-network-instance-policy.yang

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -30,7 +30,7 @@ module openconfig-network-instance-policy {
   revision "2023-07-25" {
     description
       "Expand description of
-       match-protocol-instance/protocol-name";
+       match-protocol-instance/protocol-name.";
     reference "0.1.2";
   }
 

--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -64,10 +64,11 @@ module openconfig-network-instance-policy {
         type string;
         description
           "The name of the protocol instance to match
-          on in the local network instance. The string must match
-          one of /openconfig-network-instance:network-instances/
-          network-instance/protocols/protocol/identifier in the
-          local network instance.";
+          on in the local network instance. The string
+          must match one of /network-instances/
+          network-instance/protocols/
+          protocol/identifier in the local network
+          instance.";
       }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -25,9 +25,16 @@ module openconfig-network-instance-policy {
     actions) for the network instance model.  These statements are
     generally added to the routing policy model.";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.1.2";
 
-  revision "2018-11-21" {
+  revision "2023-07-25" {
+    description
+      "Expand description of
+       match-protocol-instance/protocol-name";
+    reference "0.1.2";
+  }
+
+revision "2018-11-21" {
     description
       "Add OpenConfig module metadata extensions.";
     reference "0.1.1";

--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -64,7 +64,10 @@ module openconfig-network-instance-policy {
         type string;
         description
           "The name of the protocol instance to match
-          on in the local network instance";
+          on in the local network instance. The string must match 
+          one of /openconfig-network-instance:network-instances/
+          network-instance/protocols/protocol/identifier in the 
+          local network instance.";
       }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -64,9 +64,9 @@ module openconfig-network-instance-policy {
         type string;
         description
           "The name of the protocol instance to match
-          on in the local network instance. The string must match 
+          on in the local network instance. The string must match
           one of /openconfig-network-instance:network-instances/
-          network-instance/protocols/protocol/identifier in the 
+          network-instance/protocols/protocol/identifier in the
           local network instance.";
       }
   }


### PR DESCRIPTION
### Change Scope

* Expanding description of /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-protocol-instance/config/protocol-name leaf by providing bit more context of expected values and relation to other configuration elements.
* 
### Platform Implementations

N/A
