### PR TITLE
Update openconfig-mpls-te.yang

### DIFF
--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,13 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.3.2";
+  oc-ext:openconfig-version "3.3.3";
+
+  revision "2023-07-25" {
+    description
+      "Added record-record-enabled to MPLS p2p tunnel config";
+    reference "3.3.3";
+  }
 
   revision "2023-04-28" {
     description

--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,12 +21,12 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.3.3";
+  oc-ext:openconfig-version "3.4.0";
 
   revision "2023-07-25" {
     description
       "Added record-route-enabled to MPLS p2p tunnel config";
-    reference "3.3.3";
+    reference "3.4.0";
   }
 
   revision "2023-04-28" {

--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -25,7 +25,7 @@ submodule openconfig-mpls-igp {
 
   revision "2023-07-25" {
     description
-      "Added record-record-enabled to MPLS p2p tunnel config";
+      "Added record-route-enabled to MPLS p2p tunnel config";
     reference "3.3.3";
   }
 

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -23,12 +23,12 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.3.3";
+  oc-ext:openconfig-version "3.4.0";
 
   revision "2023-07-25" {
     description
       "Added record-route-enabled to MPLS p2p tunnel config";
-    reference "3.3.3";
+    reference "3.4.0";
   }
 
   revision "2023-04-28" {

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -23,7 +23,13 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.3.2";
+  oc-ext:openconfig-version "3.3.3";
+
+  revision "2023-07-25" {
+    description
+      "Added record-record-enabled to MPLS p2p tunnel config";
+    reference "3.3.3";
+  }
 
   revision "2023-04-28" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -27,7 +27,7 @@ submodule openconfig-mpls-static {
 
   revision "2023-07-25" {
     description
-      "Added record-record-enabled to MPLS p2p tunnel config";
+      "Added record-route-enabled to MPLS p2p tunnel config";
     reference "3.3.3";
   }
 

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -804,6 +804,11 @@ submodule openconfig-mpls-te {
       description
         "P2P tunnel destination address";
     }
+    leaf record-record-enabled {
+      type Boolean;
+      description
+        "Enables recording a path on an LSP using the record route object (RRO)";
+    }
   }
 
   grouping p2p-path-state {

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -34,7 +34,7 @@ submodule openconfig-mpls-te {
 
   revision "2023-07-25" {
     description
-      "Added record-record-enabled to MPLS p2p tunnel config";
+      "Added record-route-enabled to MPLS p2p tunnel config";
     reference "3.3.3";
   }
 
@@ -810,7 +810,7 @@ submodule openconfig-mpls-te {
       description
         "P2P tunnel destination address";
     }
-    leaf record-record-enabled {
+    leaf record-route-enabled {
       type boolean;
       description
         "Enables recording a path on an LSP using the record route object (RRO)";

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,13 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.3.2";
+  oc-ext:openconfig-version "3.3.3";
+
+  revision "2023-07-25" {
+    description
+      "Added record-record-enabled to MPLS p2p tunnel config";
+    reference "3.3.3";
+  }
 
   revision "2023-04-28" {
     description

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,12 +30,12 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.3.3";
+  oc-ext:openconfig-version "3.4.0";
 
   revision "2023-07-25" {
     description
       "Added record-route-enabled to MPLS p2p tunnel config";
-    reference "3.3.3";
+    reference "3.4.0";
   }
 
   revision "2023-04-28" {

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -805,7 +805,7 @@ submodule openconfig-mpls-te {
         "P2P tunnel destination address";
     }
     leaf record-record-enabled {
-      type Boolean;
+      type boolean;
       description
         "Enables recording a path on an LSP using the record route object (RRO)";
     }

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -1,4 +1,4 @@
-lemodule openconfig-mpls {
+module openconfig-mpls {
 
   yang-version "1";
 

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -70,12 +70,12 @@ module openconfig-mpls {
                +------+      |ROUTING|      +-----+
                              +-------+
     ";
-  oc-ext:openconfig-version "3.3.3";
+  oc-ext:openconfig-version "3.4.0";
 
   revision "2023-07-25" {
     description
       "Added record-route-enabled to MPLS p2p tunnel config";
-    reference "3.3.3";
+    reference "3.4.0";
   }
 
   revision "2023-04-28" {

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -74,7 +74,7 @@ module openconfig-mpls {
 
   revision "2023-07-25" {
     description
-      "Added record-record-enabled to MPLS p2p tunnel config";
+      "Added record-route-route to MPLS p2p tunnel config";
     reference "3.3.3";
   }
 

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -1,4 +1,4 @@
-module openconfig-mpls {
+lemodule openconfig-mpls {
 
   yang-version "1";
 
@@ -74,7 +74,7 @@ module openconfig-mpls {
 
   revision "2023-07-25" {
     description
-      "Added record-route-route to MPLS p2p tunnel config";
+      "Added record-route-enabled to MPLS p2p tunnel config";
     reference "3.3.3";
   }
 

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -70,8 +70,13 @@ module openconfig-mpls {
                +------+      |ROUTING|      +-----+
                              +-------+
     ";
+  oc-ext:openconfig-version "3.3.3";
 
-  oc-ext:openconfig-version "3.3.2";
+  revision "2023-07-25" {
+    description
+      "Added record-record-enabled to MPLS p2p tunnel config";
+    reference "3.3.3";
+  }
 
   revision "2023-04-28" {
     description


### PR DESCRIPTION
Fixes #889

Change Scope
-------

- Added a leaf to MPLS P2P tunnels to enable/disable record-route
- This change is backwards compatible

Platform Implementation
-------

- [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/mpls/command/reference/b-mpls-cr-8k/b-mpls-te-commands.html#wp3639895934) disables RRO by default.
- [JunOS](https://www.juniper.net/documentation/us/en/software/junos/mpls/topics/ref/statement/record-edit-protocols-mpls.html) enables RRO by default.
