### PR TITLE
Revert "Add multicast counters to ip interface, remove physical counters from subinterface"

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,14 +44,7 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.5.0";
-
-  revision "2023-07-14" {
-    description
-      "Move counters which apply to both interfaces and subinterfaces to
-      a common grouping.  Deprecate physical counters from subinterface";
-    reference "3.5.0";
-  }
+  oc-ext:openconfig-version "3.4.0";
 
   revision "2023-06-30" {
     description
@@ -237,6 +230,42 @@ module openconfig-if-ip {
         "Packet and byte counters for IP transmission and
         reception for the address family.";
 
+
+      leaf in-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of IP packets received for the specified
+          address family, including those received in error";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf in-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets received in input IP packets
+          for the specified address family, including those received
+          in error.";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf in-error-pkts {
+        // TODO: this counter combines several error conditions --
+        // could consider breaking them out to separate leaf nodes
+        type oc-yang:counter64;
+        description
+          "Number of IP packets discarded due to errors for the
+          specified address family, including errors in the IP
+          header, no route found to the IP destination, invalid
+          address, unknown protocol, etc.";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
       leaf in-forwarded-pkts {
         type oc-yang:counter64;
         description
@@ -257,6 +286,57 @@ module openconfig-if-ip {
           not their final IP destination and for which the
           device attempted to find a route to forward them to that
           final destination.";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf in-discarded-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of input IP packets for the
+          specified address family, for which no problems were
+          encountered to prevent their continued processing, but
+          were discarded (e.g., for lack of buffer space).";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf out-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of IP packets for the
+          specified address family that the device supplied
+          to the lower layers for transmission.  This includes
+          packets generated locally and those forwarded by the
+          device.";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf out-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets in IP packets for the
+          specified address family that the device
+          supplied to the lower layers for transmission.  This
+          includes packets generated locally and those forwarded by
+          the device.";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
+
+      leaf out-error-pkts {
+        // TODO: this counter combines several error conditions --
+        // could consider breaking them out to separate leaf nodes
+        type oc-yang:counter64;
+        description
+          "Number of IP packets for the specified address family
+          locally generated and discarded due to errors, including
+          no route found to the IP destination.";
         reference
           "RFC 4293 - Management Information Base for the
           Internet Protocol (IP)";
@@ -283,8 +363,23 @@ module openconfig-if-ip {
           "RFC 4293 - Management Information Base for the
           Internet Protocol (IP)";
       }
+
+      leaf out-discarded-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of output IP packets for the
+          specified address family for which no problem was
+          encountered to prevent their transmission to their
+          destination, but were discarded (e.g., for lack of
+          buffer space).";
+        reference
+          "RFC 4293 - Management Information Base for the
+          Internet Protocol (IP)";
+      }
     }
+
   }
+
 
 
   grouping ipv4-global-config {

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,16 +51,9 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.0.2";
 
-  revision "2023-07-14" {
-    description
-      "Move counters which apply to both interfaces and subinterfaces to
-      a common grouping.  Deprecate physical counters from subinterface";
-    reference "3.5.0";
-  }
-
-  revision "2023-02-06" {
+revision "2023-02-06" {
     description
       "Add further specification to interface-ref type to
        clarify that the interface and subinterface leaves
@@ -644,365 +637,298 @@ module openconfig-interfaces {
     }
   }
 
-grouping interface-common-counters-state {
-    description
-      "Operational state representing interface counters and statistics
-      applicable to (physical) interfaces and (logical) subinterfaces.";
-
-    leaf in-octets {
-      type oc-yang:counter64;
-      description
-        "The total number of octets received on the interface,
-        including framing characters.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCInOctets.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-pkts {
-      type oc-yang:counter64;
-      description
-        "The total number of packets received on the interface,
-        including all unicast, multicast, broadcast and bad packets
-        etc.";
-      reference
-        "RFC 2819: Remote Network Monitoring Management Information Base.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-unicast-pkts {
-      type oc-yang:counter64;
-      description
-        "The number of packets, delivered by this sub-layer to a
-        higher (sub-)layer, that were not addressed to a
-        multicast or broadcast address at this sub-layer.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-broadcast-pkts {
-      type oc-yang:counter64;
-      description
-        "The number of packets, delivered by this sub-layer to a
-        higher (sub-)layer, that were addressed to a broadcast
-        address at this sub-layer.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCInBroadcastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-multicast-pkts {
-      type oc-yang:counter64;
-      description
-        "The number of packets, delivered by this sub-layer to a
-        higher (sub-)layer, that were addressed to a multicast
-        address at this sub-layer.  For a MAC-layer protocol,
-        this includes both Group and Functional addresses.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCInMulticastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-errors {
-      type oc-yang:counter64;
-      description
-        "For packet-oriented interfaces, the number of inbound
-        packets that contained errors preventing them from being
-        deliverable to a higher-layer protocol.  For character-
-        oriented or fixed-length interfaces, the number of
-        inbound transmission units that contained errors
-        preventing them from being deliverable to a higher-layer
-        protocol.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifInErrors.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf in-discards {
-      type oc-yang:counter64;
-      description
-        "The number of inbound packets that were chosen to be
-        discarded even though no errors had been detected to
-        prevent their being deliverable to a higher-layer
-        protocol.  One possible reason for discarding such a
-        packet could be to free up buffer space.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-
-
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifInDiscards.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-octets {
-      type oc-yang:counter64;
-      description
-        "The total number of octets transmitted out of the
-        interface, including framing characters.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCOutOctets.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-pkts {
-      type oc-yang:counter64;
-      description
-        "The total number of packets transmitted out of the
-        interface, including all unicast, multicast, broadcast,
-        and bad packets etc.";
-      reference
-        "RFC 2819: Remote Network Monitoring Management Information Base.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-unicast-pkts {
-      type oc-yang:counter64;
-      description
-        "The total number of packets that higher-level protocols
-        requested be transmitted, and that were not addressed
-        to a multicast or broadcast address at this sub-layer,
-        including those that were discarded or not sent.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-broadcast-pkts {
-      type oc-yang:counter64;
-      description
-        "The total number of packets that higher-level protocols
-        requested be transmitted, and that were addressed to a
-        broadcast address at this sub-layer, including those
-        that were discarded or not sent.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCOutBroadcastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-multicast-pkts {
-      type oc-yang:counter64;
-      description
-        "The total number of packets that higher-level protocols
-        requested be transmitted, and that were addressed to a
-        multicast address at this sub-layer, including those
-        that were discarded or not sent.  For a MAC-layer
-        protocol, this includes both Group and Functional
-        addresses.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifHCOutMulticastPkts.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-discards {
-      type oc-yang:counter64;
-      description
-        "The number of outbound packets that were chosen to be
-        discarded even though no errors had been detected to
-        prevent their being transmitted.  One possible reason
-        for discarding such a packet could be to free up buffer
-        space.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifOutDiscards.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf out-errors {
-      type oc-yang:counter64;
-      description
-        "For packet-oriented interfaces, the number of outbound
-        packets that could not be transmitted because of errors.
-        For character-oriented or fixed-length interfaces, the
-        number of outbound transmission units that could not be
-        transmitted because of errors.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifOutErrors.
-        RFC 4293: Management Information Base for the
-        Internet Protocol (IP).";
-    }
-
-    leaf last-clear {
-      type oc-types:timeticks64;
-      description
-        "Timestamp of the last time the interface counters were
-        cleared.
-
-        The value is the timestamp in nanoseconds relative to
-        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
-      oc-ext:telemetry-on-change;
-    }
-  }
 
   grouping interface-counters-state {
     description
       "Operational state representing interface counters
       and statistics.";
 
-    oc-ext:operational;
-
-    leaf in-unknown-protos {
-      type oc-yang:counter64;
-      description
-        "For packet-oriented interfaces, the number of packets
-        received via the interface that were discarded because
-        of an unknown or unsupported protocol.  For
-        character-oriented or fixed-length interfaces that
-        support protocol multiplexing, the number of
-        transmission units received via the interface that were
-        discarded because of an unknown or unsupported protocol.
-        For any interface that does not support protocol
-        multiplexing, this counter is not present.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
-    }
-
-    leaf in-fcs-errors {
-      type oc-yang:counter64;
-      description
-        "Number of received packets which had errors in the
-        frame check sequence (FCS), i.e., framing errors.
-
-        Discontinuities in the value of this counter can occur
-        when the device is re-initialization as indicated by the
-        value of 'last-clear'.";
-    }
-
-    leaf carrier-transitions {
-      type oc-yang:counter64;
-      description
-        "Number of times the interface state has transitioned
-        between up and down since the time the device restarted
-        or the last-clear time, whichever is most recent.";
-      oc-ext:telemetry-on-change;
-    }
-  }
-
-  grouping subinterfaces-counters-state {
-    description
-      "Operational state representing counters unique to subinterfaces";
+      //TODO: we may need to break this list of counters into those
+      //that would appear for physical vs. subinterface or logical
+      //interfaces.  For now, just replicating the full stats
+      //grouping to both interface and subinterface.
 
     oc-ext:operational;
-    leaf in-unknown-protos {
-      type oc-yang:counter64;
-      status deprecated;
+
+    container counters {
       description
-        "For packet-oriented interfaces, the number of packets
-        received via the interface that were discarded because
-        of an unknown or unsupported protocol.  For
-        character-oriented or fixed-length interfaces that
-        support protocol multiplexing, the number of
-        transmission units received via the interface that were
-        discarded because of an unknown or unsupported protocol.
-        For any interface that does not support protocol
-        multiplexing, this counter is not present.
+        "A collection of interface-related statistics objects.";
 
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+      leaf in-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets received on the interface,
+          including framing characters.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+      }
+
+      leaf in-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of packets received on the interface,
+          including all unicast, multicast, broadcast and bad packets
+          etc.";
+        reference
+          "RFC 2819: Remote Network Monitoring Management Information
+          Base";
+      }
+
+      leaf in-unicast-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were not addressed to a
+          multicast or broadcast address at this sub-layer.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+      }
+
+      leaf in-broadcast-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were addressed to a broadcast
+          address at this sub-layer.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCInBroadcastPkts";
+      }
+
+      leaf in-multicast-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were addressed to a multicast
+          address at this sub-layer.  For a MAC-layer protocol,
+          this includes both Group and Functional addresses.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCInMulticastPkts";
+      }
+
+      leaf in-discards {
+        type oc-yang:counter64;
+        description
+          "The number of inbound packets that were chosen to be
+          discarded even though no errors had been detected to
+          prevent their being deliverable to a higher-layer
+          protocol.  One possible reason for discarding such a
+          packet could be to free up buffer space.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+
+
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+      }
+
+      leaf in-errors {
+        type oc-yang:counter64;
+        description
+          "For packet-oriented interfaces, the number of inbound
+          packets that contained errors preventing them from being
+          deliverable to a higher-layer protocol.  For character-
+          oriented or fixed-length interfaces, the number of
+          inbound transmission units that contained errors
+          preventing them from being deliverable to a higher-layer
+          protocol.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInErrors";
+      }
+
+      leaf in-unknown-protos {
+        type oc-yang:counter64;
+        description
+          "For packet-oriented interfaces, the number of packets
+          received via the interface that were discarded because
+          of an unknown or unsupported protocol.  For
+          character-oriented or fixed-length interfaces that
+          support protocol multiplexing, the number of
+          transmission units received via the interface that were
+          discarded because of an unknown or unsupported protocol.
+          For any interface that does not support protocol
+          multiplexing, this counter is not present.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+      }
+
+      leaf in-fcs-errors {
+        type oc-yang:counter64;
+        description
+          "Number of received packets which had errors in the
+          frame check sequence (FCS), i.e., framing errors.
+
+          Discontinuities in the value of this counter can occur
+          when the device is re-initialization as indicated by the
+          value of 'last-clear'.";
+      }
+
+      leaf out-octets {
+        type oc-yang:counter64;
+        description
+          "The total number of octets transmitted out of the
+          interface, including framing characters.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+      }
+
+      leaf out-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of packets transmitted out of the
+          interface, including all unicast, multicast, broadcast,
+          and bad packets etc.";
+        reference
+          "RFC 2819: Remote Network Monitoring Management Information
+          Base";
+      }
+
+      leaf out-unicast-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of packets that higher-level protocols
+          requested be transmitted, and that were not addressed
+          to a multicast or broadcast address at this sub-layer,
+          including those that were discarded or not sent.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+      }
+
+      leaf out-broadcast-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of packets that higher-level protocols
+          requested be transmitted, and that were addressed to a
+          broadcast address at this sub-layer, including those
+          that were discarded or not sent.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCOutBroadcastPkts";
+      }
+
+
+      leaf out-multicast-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of packets that higher-level protocols
+          requested be transmitted, and that were addressed to a
+          multicast address at this sub-layer, including those
+          that were discarded or not sent.  For a MAC-layer
+          protocol, this includes both Group and Functional
+          addresses.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCOutMulticastPkts";
+      }
+
+      leaf out-discards {
+        type oc-yang:counter64;
+        description
+          "The number of outbound packets that were chosen to be
+          discarded even though no errors had been detected to
+          prevent their being transmitted.  One possible reason
+          for discarding such a packet could be to free up buffer
+          space.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+      }
+
+      leaf out-errors {
+        type oc-yang:counter64;
+        description
+          "For packet-oriented interfaces, the number of outbound
+          packets that could not be transmitted because of errors.
+          For character-oriented or fixed-length interfaces, the
+          number of outbound transmission units that could not be
+          transmitted because of errors.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'last-clear'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+      }
+
+      leaf carrier-transitions {
+        type oc-yang:counter64;
+        description
+          "Number of times the interface state has transitioned
+          between up and down since the time the device restarted
+          or the last-clear time, whichever is most recent.";
+        oc-ext:telemetry-on-change;
+      }
+
+      leaf last-clear {
+        type oc-types:timeticks64;
+        description
+          "Timestamp of the last time the interface counters were
+          cleared.
+
+          The value is the timestamp in nanoseconds relative to
+          the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+        oc-ext:telemetry-on-change;
+      }
     }
-
-    leaf in-fcs-errors {
-      type oc-yang:counter64;
-      status deprecated;
-      description
-        "Number of received packets which had errors in the
-        frame check sequence (FCS), i.e., framing errors.
-
-        Discontinuities in the value of this counter can occur
-        when the device is re-initialization as indicated by the
-        value of 'last-clear'.";
-    }
-
-    leaf carrier-transitions {
-      type oc-yang:counter64;
-      status deprecated;
-      description
-        "Number of times the interface state has transitioned
-        between up and down since the time the device restarted
-        or the last-clear time, whichever is most recent.";
-      oc-ext:telemetry-on-change;
-    }
-
   }
 
   // data definition statements
@@ -1094,15 +1020,7 @@ grouping interface-common-counters-state {
     }
 
     uses interface-common-state;
-
-    container counters {
-      description
-        "A collection of interface specific statistics entitites which are
-        not common to subinterfaces.";
-
-      uses interface-common-counters-state;
-      uses subinterfaces-counters-state;
-     }
+    uses interface-counters-state;
   }
 
   grouping subinterfaces-top {
@@ -1201,15 +1119,7 @@ grouping interface-common-counters-state {
 
           uses interface-phys-config;
           uses interface-common-state;
-
-          container counters {
-            description
-              "A collection of interface specific statistics entitites which are
-              not common to subinterfaces.";
-
-            uses interface-common-counters-state;
-            uses interface-counters-state;
-          }
+          uses interface-counters-state;
         }
 
         uses interface-phys-holdtime-top;


### PR DESCRIPTION
Reverts openconfig/public#905

#905 unintentionally removed counters from IP subinterfaces.    A new PR will be introduced to fix this.

FYI, this breaking change was detected by the following [featureprofiles CI check](https://github.com/openconfig/featureprofiles/actions/runs/5695540733/job/15439270834?pr=1946).  We will look into exposing public model breaking changes via checks like this.  
