### PR TITLE
Add breaking change check

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@5ef41fc
+        go install github.com/openconfig/models-ci/openconfig-ci@c880ed2
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Install go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.x'
 
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.20'
+
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -43,7 +43,7 @@ jobs:
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
-        openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
+        openconfig-ci diff --github-comment --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
 
         openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -48,6 +48,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
+        openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
         echo "$EOF" >> "$GITHUB_ENV"
         #body: "${{ env.leafchanges }}"
 

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -35,5 +35,5 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@diff-cli
+        go install github.com/openconfig/models-ci@fca2350
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@65fa792
+        go install github.com/openconfig/models-ci/openconfig-ci@312f8d6
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check
@@ -68,5 +68,5 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           -----------List of all YANG node changes-----------
-          ${{ env.leafchanges }}
+          "${{ env.leafchanges }}"
         edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@742647c
+        go install github.com/openconfig/models-ci/openconfig-ci@46f4f97
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install models-ci CLI
       run: |
-        go install github.com/openconfig/models-ci@94a63b5
+        go install github.com/openconfig/models-ci@15b19a4
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       run: |
@@ -40,6 +40,4 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        echo "-----------------------------"
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
-        echo "-----------------------------"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Make sure all backward-incompatible changes are covered by version changes.
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
-        readonly BASE="$(git merge-base origin/main "${HEAD}")"
+        readonly BASE="$(git merge-base origin/master "${HEAD}")"
 
         BASEREPODIR=public_base
         git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -55,5 +55,6 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: "${{ env.leafchanges }}"
+              #body: "${{ env.leafchanges }}"
+            body: "Just a test"
           })

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -41,6 +41,8 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
+        echo "yang-changes-title='## List of all YANG node changes'" >> "$GITHUB_ENV"
+
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         openconfig-ci diff --github-comment --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
@@ -55,7 +57,7 @@ jobs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
-        body-includes: -----------List of all YANG node changes-----------
+        body-includes: ${{ env.yang-changes-title }}
 
     - name: Create or update comment
       if: always()
@@ -64,6 +66,6 @@ jobs:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          \#\# -----------List of all YANG node changes-----------
+          ${{ env.yang-changes-title }}
           ${{ env.leafchanges }}
         edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -1,4 +1,4 @@
-name: OpenConfig YANG Diff
+name: Breaking Changes
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Backward Incompatibility Check
+    name: major version update check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -26,10 +26,13 @@ jobs:
         readonly BASE="$(git merge-base origin/master "${HEAD}")"
 
         BASEREPODIR=public_base
-        git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}"
-        cd "${BASEREPODIR}"
+        #git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}"
+        #cd "${BASEREPODIR}"
+        mkdir "${BASEREPODIR}"
         git checkout "${BASE}"
-        cd ..
+        cp release/models third_party "${BASEREPODIR}" 
+        git checkout "${HEAD}"
+        #cd ..
         oldroot="${BASEREPODIR}"
         newroot=.
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,9 +22,10 @@ jobs:
 
     - name: Install models-ci CLI
       run: |
-        go install github.com/openconfig/models-ci@15b19a4
+        go install github.com/openconfig/models-ci/openconfig-ci@65fa792
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
+      id: check
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
         readonly BASE="$(git merge-base origin/master "${HEAD}")"
@@ -42,19 +43,28 @@ jobs:
 
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
+        #echo "-----------List of all YANG node changes-----------" >> "$GITHUB_OUTPUT"
+        #models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_OUTPUT"
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
         #body: "${{ env.leafchanges }}"
 
-    - name: Post comment listing YANG leaf changes
-      uses: actions/github-script@v6
+    - name: Find Comment
+      uses: peter-evans/find-comment@v2
+      id: fc
       with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "Just a test"
-          })
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: -----------List of all YANG node changes-----------
+
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v3
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          -----------List of all YANG node changes-----------
+          ${{ env.leafchanges }}
+        edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -39,5 +39,5 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@fca2350
+        go install github.com/openconfig/models-ci@94a63b5
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -30,7 +30,7 @@ jobs:
         #cd "${BASEREPODIR}"
         mkdir "${BASEREPODIR}"
         git checkout "${BASE}"
-        cp release/models third_party "${BASEREPODIR}" 
+        cp -r release/models third_party "${BASEREPODIR}" 
         git checkout "${HEAD}"
         #cd ..
         oldroot="${BASEREPODIR}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -45,13 +45,13 @@ jobs:
         leafchanges=$(models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}")
 		echo "{leafchanges}={${leafchanges}}" >> "$GITHUB_ENV"
 
-      - name: Post comment listing YANG leaf changes
-		uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "${{ env.leafchanges }}"
-            })
+	- name: Post comment listing YANG leaf changes
+	  uses: actions/github-script@v6
+	  with:
+		script: |
+		  github.rest.issues.createComment({
+			issue_number: context.issue.number,
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			body: "${{ env.leafchanges }}"
+		  })

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@312f8d6
+        go install github.com/openconfig/models-ci/openconfig-ci@742647c
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check
@@ -41,13 +41,10 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        #echo "-----------List of all YANG node changes-----------" >> "$GITHUB_OUTPUT"
-        #openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_OUTPUT"
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
-        #body: "${{ env.leafchanges }}"
 
         openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
@@ -68,5 +65,5 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           -----------List of all YANG node changes-----------
-          "${{ env.leafchanges }}"
+          ${{ env.leafchanges }}
         edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -41,7 +41,7 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        echo "yang-changes-title='## List of all YANG node changes'" >> "$GITHUB_ENV"
+        echo "yang-changes-title=## List of all YANG node changes" >> "$GITHUB_ENV"
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -28,7 +28,7 @@ jobs:
         BASEREPODIR=public_base
         #git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}"
         #cd "${BASEREPODIR}"
-        mkdir "${BASEREPODIR}"
+        mkdir -p "${BASEREPODIR}/release"
         git checkout "${BASE}"
         cp -r release/models "${BASEREPODIR}/release" 
         cp -r third_party "${BASEREPODIR}" 

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
         readonly BASE="$(git merge-base origin/main "${HEAD}")"
-        echo "HEAD is $HEAD"
-        echo "BASE is $BASE"
 
         BASEREPODIR=public_base
         git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -41,16 +41,15 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
-
         #echo "-----------List of all YANG node changes-----------" >> "$GITHUB_OUTPUT"
         #openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_OUTPUT"
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
-        openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
         echo "$EOF" >> "$GITHUB_ENV"
         #body: "${{ env.leafchanges }}"
+
+        openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
     - name: Find Comment
       if: always()

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -39,31 +39,4 @@ jobs:
         oldroot="${BASEREPODIR}"
         newroot=.
 
-        echo "yang-changes-title=## List of all YANG node changes" >> "$GITHUB_ENV"
-
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
-        openconfig-ci diff --github-comment --oldp "${oldroot}/third_party" --oldroot "${oldroot}/release/models" --newp "${newroot}/third_party" --newroot "${newroot}/release/models" >> "$GITHUB_ENV"
-        echo "$EOF" >> "$GITHUB_ENV"
-
         openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldroot "${oldroot}/release/models" --newp "${newroot}/third_party" --newroot "${newroot}/release/models"
-
-    - name: Find Comment
-      if: always()
-      uses: peter-evans/find-comment@v2
-      id: fc
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: ${{ env.yang-changes-title }}
-
-    - name: Create or update comment
-      if: always()
-      uses: peter-evans/create-or-update-comment@v3
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          ${{ env.yang-changes-title }}
-          ${{ env.leafchanges }}
-        edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -17,6 +17,8 @@ jobs:
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
         readonly BASE="$(git merge-base origin/main "${HEAD}")"
+        echo $HEAD
+        echo $BASE
 
         BASEREPODIR=public_base
         git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -20,6 +20,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install models-ci
+      run: |
+        go install github.com/openconfig/models-ci@94a63b5
+
     - name: Make sure all backward-incompatible changes are covered by version changes.
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
@@ -36,8 +40,4 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@94a63b5
-
-    - name: Make sure all backward-incompatible changes are covered by version changes.
-      run: |
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -42,3 +42,4 @@ jobs:
 
         echo "-----------------------------"
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
+        echo "-----------------------------"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -30,7 +30,8 @@ jobs:
         #cd "${BASEREPODIR}"
         mkdir "${BASEREPODIR}"
         git checkout "${BASE}"
-        cp -r release/models third_party "${BASEREPODIR}" 
+        cp -r release/models "${BASEREPODIR}/release" 
+        cp -r third_party "${BASEREPODIR}" 
         git checkout "${HEAD}"
         #cd ..
         oldroot="${BASEREPODIR}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -19,7 +19,7 @@ jobs:
         readonly BASE="$(git merge-base origin/main "${HEAD}")"
 
         BASEREPODIR=public_base
-        git clone "git@github.com:public.git" "${BASEREPODIR}" --branch "${BASE}"
+        git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"
         oldroot="${BASEREPODIR}"
         newroot=.
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -17,8 +17,8 @@ jobs:
       run: |
         readonly HEAD=${{ github.event.pull_request.head.sha }}
         readonly BASE="$(git merge-base origin/main "${HEAD}")"
-        echo $HEAD
-        echo $BASE
+        echo "HEAD is $HEAD"
+        echo "BASE is $BASE"
 
         BASEREPODIR=public_base
         git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -26,18 +26,15 @@ jobs:
         readonly BASE="$(git merge-base origin/master "${HEAD}")"
 
         BASEREPODIR=public_base
-        #git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}"
-        #cd "${BASEREPODIR}"
         mkdir -p "${BASEREPODIR}/release"
         git checkout "${BASE}"
         cp -r release/models "${BASEREPODIR}/release" 
         cp -r third_party "${BASEREPODIR}" 
         git checkout "${HEAD}"
-        #cd ..
         oldroot="${BASEREPODIR}"
         newroot=.
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@94a63b5
+        go install github.com/openconfig/models-ci@94a63b5 > /dev/null
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -41,3 +41,17 @@ jobs:
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
+
+        leafchanges=$(models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}")
+		echo "{leafchanges}={${leafchanges}}" >> "$GITHUB_ENV"
+
+      - name: Post comment listing YANG leaf changes
+		uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "${{ env.leafchanges }}"
+            })

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -43,15 +43,15 @@ jobs:
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
         leafchanges=$(models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}")
-		echo "{leafchanges}={${leafchanges}}" >> "$GITHUB_ENV"
+        echo "{leafchanges}={${leafchanges}}" >> "$GITHUB_ENV"
 
-	- name: Post comment listing YANG leaf changes
-	  uses: actions/github-script@v6
-	  with:
-		script: |
-		  github.rest.issues.createComment({
-			issue_number: context.issue.number,
-			owner: context.repo.owner,
-			repo: context.repo.repo,
-			body: "${{ env.leafchanges }}"
-		  })
+    - name: Post comment listing YANG leaf changes
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "${{ env.leafchanges }}"
+          })

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -1,0 +1,29 @@
+name: OpenConfig YANG Diff
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Backward Incompatibility Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Make sure all backward-incompatible changes are covered by version changes.
+      run: |
+        readonly HEAD=${{ github.event.pull_request.head.sha }}
+        readonly BASE="$(git merge-base origin/main "${HEAD}")"
+
+        BASEREPODIR=public_base
+        git clone "git@github.com:public.git" "${BASEREPODIR}" --branch "${BASE}"
+        oldroot="${BASEREPODIR}"
+        newroot=.
+        oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
+        newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
+
+        go install github.com/openconfig/models-ci@diff-cli
+        models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@2401790
+        go install github.com/openconfig/models-ci/openconfig-ci@88da8da
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check
@@ -38,17 +38,15 @@ jobs:
         git checkout "${HEAD}"
         oldroot="${BASEREPODIR}"
         newroot=.
-        oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
-        newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
         echo "yang-changes-title=## List of all YANG node changes" >> "$GITHUB_ENV"
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
-        openconfig-ci diff --github-comment --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
+        openconfig-ci diff --github-comment --oldp "${oldroot}/third_party" --oldroot "${oldroot}/release/models" --newp "${newroot}/third_party" --newroot "${newroot}/release/models" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
 
-        openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
+        openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldroot "${oldroot}/release/models" --newp "${newroot}/third_party" --newroot "${newroot}/release/models"
 
     - name: Find Comment
       if: always()

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Backward Incompatibility Check
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
     - name: Install go
@@ -20,7 +21,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install models-ci CLI
+    - name: Install openconfig-ci CLI
       run: |
         go install github.com/openconfig/models-ci/openconfig-ci@65fa792
 
@@ -41,13 +42,13 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
+        openconfig-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
         #echo "-----------List of all YANG node changes-----------" >> "$GITHUB_OUTPUT"
-        #models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_OUTPUT"
+        #openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_OUTPUT"
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
-        models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
+        openconfig-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
         #body: "${{ env.leafchanges }}"
 

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@88da8da
+        go install github.com/openconfig/models-ci/openconfig-ci@5ef41fc
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -36,5 +36,5 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@94a63b5 > /dev/null
+        go install github.com/openconfig/models-ci@94a63b5 &> /dev/null
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -42,8 +42,10 @@ jobs:
 
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"
 
-        leafchanges=$(models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}")
-        echo "{leafchanges}={${leafchanges}}" >> "$GITHUB_ENV"
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
+        models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
+        echo "$EOF" >> "$GITHUB_ENV"
 
     - name: Post comment listing YANG leaf changes
       uses: actions/github-script@v6

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -8,7 +8,6 @@ jobs:
   build:
     name: Backward Incompatibility Check
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
     - name: Install go
@@ -53,6 +52,7 @@ jobs:
         #body: "${{ env.leafchanges }}"
 
     - name: Find Comment
+      if: always()
       uses: peter-evans/find-comment@v2
       id: fc
       with:
@@ -61,6 +61,7 @@ jobs:
         body-includes: -----------List of all YANG node changes-----------
 
     - name: Create or update comment
+      if: always()
       uses: peter-evans/create-or-update-comment@v3
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -26,7 +26,10 @@ jobs:
         readonly BASE="$(git merge-base origin/master "${HEAD}")"
 
         BASEREPODIR=public_base
-        git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}" --branch "${BASE}"
+        git clone "https://github.com/openconfig/public.git" "${BASEREPODIR}"
+        cd "${BASEREPODIR}"
+        git checkout "${BASE}"
+        cd ..
         oldroot="${BASEREPODIR}"
         newroot=.
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -20,7 +20,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install models-ci
+    - name: Install models-ci CLI
       run: |
         go install github.com/openconfig/models-ci@94a63b5
 
@@ -40,4 +40,5 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
+        echo "-----------------------------"
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -46,6 +46,7 @@ jobs:
         echo "leafchanges<<$EOF" >> "$GITHUB_ENV"
         models-ci diff --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}" >> "$GITHUB_ENV"
         echo "$EOF" >> "$GITHUB_ENV"
+        #body: "${{ env.leafchanges }}"
 
     - name: Post comment listing YANG leaf changes
       uses: actions/github-script@v6
@@ -55,6 +56,5 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-              #body: "${{ env.leafchanges }}"
             body: "Just a test"
           })

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -36,5 +36,8 @@ jobs:
         oldfiles=$(find "${oldroot}"/release/models -name '*.yang' | tr '\n' ',')
         newfiles=$(find "${newroot}"/release/models -name '*.yang' | tr '\n' ',')
 
-        go install github.com/openconfig/models-ci@94a63b5 &> /dev/null
+        go install github.com/openconfig/models-ci@94a63b5
+
+    - name: Make sure all backward-incompatible changes are covered by version changes.
+      run: |
         models-ci diff --disallowed-incompats --oldp "${oldroot}/third_party" --oldfiles "${oldfiles}" --newp "${newroot}/third_party" --newfiles "${newfiles}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -64,6 +64,6 @@ jobs:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          -----------List of all YANG node changes-----------
+          \#\# -----------List of all YANG node changes-----------
           ${{ env.leafchanges }}
         edit-mode: replace

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install openconfig-ci CLI
       run: |
-        go install github.com/openconfig/models-ci/openconfig-ci@46f4f97
+        go install github.com/openconfig/models-ci/openconfig-ci@2401790
 
     - name: Make sure all backward-incompatible changes are covered by version changes.
       id: check

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,6 +53,7 @@ steps:
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
     branch=$(git tag -l 'v11.*' | sort -V | tail -1)
+    branch=fix-ygot
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,6 @@ steps:
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
     branch=$(git tag -l 'v11.*' | sort -V | tail -1)
-    branch=fix-ygot
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,6 @@ steps:
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
     branch=$(git tag -l 'v11.*' | sort -V | tail -1)
-    branch=c880ed2
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
     #branch=$(git tag -l 'v10.*' | sort -V | tail -1)
-    branch=fail-at-generator-pull
+    branch=c880ed2
     git checkout $branch
   volumes:
   - name: 'ssh'
@@ -110,7 +110,8 @@ steps:
     git clone git@github.com:openconfig/pattern-regex-tests.git /go/src/github.com/openconfig/pattern-regex-tests
     cd /go/src/github.com/openconfig/pattern-regex-tests
     # Modify the major version to update regexp version.
-    branch=$(git tag -l 'v2.0*' | sort -V | tail -1)
+    #branch=$(git tag -l 'v2.0*' | sort -V | tail -1)
+    branch=use-common-workflow
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,8 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    branch=$(git tag -l 'v10.*' | sort -V | tail -1)
+    #branch=$(git tag -l 'v10.*' | sort -V | tail -1)
+    branch=fail-at-generator-pull
     git checkout $branch
   volumes:
   - name: 'ssh'
@@ -213,16 +214,6 @@ steps:
   id: 'oc-pyang'
 
 ############### GOYANG/YGOT ###############
-- name: 'golang'
-  entrypoint: 'go'
-  args: ['install', 'github.com/openconfig/ygot/generator@latest']
-  volumes:
-  - name: 'gopath'
-    path: /go
-  env:
-  - 'GOPATH=/go'
-  waitFor: ['go path creation']
-  id: 'goyang-ygot prep'
 - name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
   args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/goyang-ygot/test.sh"]
@@ -237,7 +228,7 @@ steps:
   - 'COMMIT_SHA=$COMMIT_SHA'
   - '_REPO_SLUG=$_REPO_SLUG'
   - 'BRANCH_NAME=$BRANCH_NAME'
-  waitFor: ['validator prep', 'goyang-ygot prep', 'oc-pyang']
+  waitFor: ['validator prep', 'go path creation', 'oc-pyang']
   id: 'goyang-ygot'
 
 ############### PYANG ###############

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    #branch=$(git tag -l 'v10.*' | sort -V | tail -1)
+    branch=$(git tag -l 'v11.*' | sort -V | tail -1)
     branch=c880ed2
     git checkout $branch
   volumes:
@@ -110,8 +110,7 @@ steps:
     git clone git@github.com:openconfig/pattern-regex-tests.git /go/src/github.com/openconfig/pattern-regex-tests
     cd /go/src/github.com/openconfig/pattern-regex-tests
     # Modify the major version to update regexp version.
-    #branch=$(git tag -l 'v2.0*' | sort -V | tail -1)
-    branch=use-common-workflow
+    branch=$(git tag -l 'v2.0*' | sort -V | tail -1)
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.4.3";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "2.0.0";
+    reference "1.4.3";
   }
 
   revision "2023-01-29" {
@@ -284,9 +284,7 @@ module openconfig-acl {
 
 
     leaf forwarding-action {
-      type identityref {
-        base FORWARDING_ACTION;
-      }
+      type string;
       mandatory true;
       description
         "Specifies the forwarding action.  One forwarding action

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.4.3";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "1.3.3";
+    reference "1.4.3";
   }
 
   revision "2023-01-29" {
@@ -284,25 +284,23 @@ module openconfig-acl {
 
 
     leaf forwarding-action {
-      type identityref {
-        base FORWARDING_ACTION;
-      }
+      type binary;
       mandatory true;
       description
         "Specifies the forwarding action.  One forwarding action
         must be specified for each ACL entry";
     }
 
-    leaf log-action {
-      type identityref {
-        base LOG_ACTION;
-      }
-      default LOG_NONE;
-      description
-        "Specifies the log action and destination for
-        matched packets.  The default is not to log the
-        packet.";
-    }
+    //leaf log-action {
+    //  type identityref {
+    //    base LOG_ACTION;
+    //  }
+    //  default LOG_NONE;
+    //  description
+    //    "Specifies the log action and destination for
+    //    matched packets.  The default is not to log the
+    //    packet.";
+    //}
 
 
   }

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.4";
+  oc-ext:openconfig-version "1.3.3";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "1.3.4";
+    reference "1.3.3";
   }
 
   revision "2023-01-29" {
@@ -293,16 +293,16 @@ module openconfig-acl {
         must be specified for each ACL entry";
     }
 
-    //leaf log-action {
-    //  type identityref {
-    //    base LOG_ACTION;
-    //  }
-    //  default LOG_NONE;
-    //  description
-    //    "Specifies the log action and destination for
-    //    matched packets.  The default is not to log the
-    //    packet.";
-    //}
+    leaf log-action {
+      type identityref {
+        base LOG_ACTION;
+      }
+      default LOG_NONE;
+      description
+        "Specifies the log action and destination for
+        matched packets.  The default is not to log the
+        packet.";
+    }
 
 
   }

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "1.3.4";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "2.0.0";
+    reference "1.3.4";
   }
 
   revision "2023-01-29" {

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.4";
+  oc-ext:openconfig-version "2.0.0";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "1.3.4";
+    reference "2.0.0";
   }
 
   revision "2023-01-29" {

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.4.3";
+  oc-ext:openconfig-version "1.3.3";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "1.4.3";
+    reference "1.3.3";
   }
 
   revision "2023-01-29" {
@@ -284,23 +284,25 @@ module openconfig-acl {
 
 
     leaf forwarding-action {
-      type binary;
+      type identityref {
+        base FORWARDING_ACTION;
+      }
       mandatory true;
       description
         "Specifies the forwarding action.  One forwarding action
         must be specified for each ACL entry";
     }
 
-    //leaf log-action {
-    //  type identityref {
-    //    base LOG_ACTION;
-    //  }
-    //  default LOG_NONE;
-    //  description
-    //    "Specifies the log action and destination for
-    //    matched packets.  The default is not to log the
-    //    packet.";
-    //}
+    leaf log-action {
+      type identityref {
+        base LOG_ACTION;
+      }
+      default LOG_NONE;
+      description
+        "Specifies the log action and destination for
+        matched packets.  The default is not to log the
+        packet.";
+    }
 
 
   }

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -284,7 +284,7 @@ module openconfig-acl {
 
 
     leaf forwarding-action {
-      type string;
+      type binary;
       mandatory true;
       description
         "Specifies the forwarding action.  One forwarding action

--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,12 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.3.4";
 
   revision "2023-02-06" {
     description
       "Add clarifying comments on use of interface-ref.";
-    reference "1.3.3";
+    reference "1.3.4";
   }
 
   revision "2023-01-29" {
@@ -293,16 +293,16 @@ module openconfig-acl {
         must be specified for each ACL entry";
     }
 
-    leaf log-action {
-      type identityref {
-        base LOG_ACTION;
-      }
-      default LOG_NONE;
-      description
-        "Specifies the log action and destination for
-        matched packets.  The default is not to log the
-        packet.";
-    }
+    //leaf log-action {
+    //  type identityref {
+    //    base LOG_ACTION;
+    //  }
+    //  default LOG_NONE;
+    //  description
+    //    "Specifies the log action and destination for
+    //    matched packets.  The default is not to log the
+    //    packet.";
+    //}
 
 
   }


### PR DESCRIPTION
The check fails if there is a backward-incompatible change that isn't accompanied by a major version update (if not at v0).
This check is **not** exhaustive, currently it checks for the following:
* leaf deletion
* leaf type change

There are other types of backward-incompatible changes not caught, e.g.
* string pattern/number range restrictions becoming more restrictive.

Note: The "breaking"/"non-breaking" labels are still "dumb", i.e. they're determined by whether there are any major YANG version updates.