### PR TITLE
Update string type keys to use interface-id type

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,13 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.2.5";
+  oc-ext:openconfig-version "0.2.6";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.2.6";
+  }
 
   revision "2023-02-06" {
     description
@@ -194,7 +200,7 @@ module openconfig-bfd {
       "Top-level per-interface configuration parameters for BFD.";
 
     leaf id {
-      type string;
+      type oc-if:interface-id;
       description
         "A unique identifier for the interface.";
     }

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.1.0";
+  oc-ext:openconfig-version "4.1.1";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "4.1.1";
+  }
 
   revision "2023-07-12" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.1.0";
+  oc-ext:openconfig-version "4.1.1";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "4.1.1";
+  }
 
   revision "2023-07-12" {
     description
@@ -1097,7 +1103,7 @@ module openconfig-network-instance {
       with the network instance";
 
     leaf id {
-      type string;
+      type oc-if:interface-id;
       description
         "A unique identifier for this interface - this is expressed
         as a free-text string";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,7 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description
@@ -110,7 +116,7 @@ submodule openconfig-ospfv2-area-interface {
       "Configuration parameters for an OSPF interface";
 
     leaf id {
-      type string;
+      type oc-if:interface-id;
       description
         "An operator-specified string utilised to uniquely
         reference this interface";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,7 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,7 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,7 +23,13 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,7 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,7 +34,13 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.4.2";
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
 
   revision "2023-07-05" {
     description

--- a/release/models/segment-routing/openconfig-segment-routing.yang
+++ b/release/models/segment-routing/openconfig-segment-routing.yang
@@ -36,7 +36,13 @@ module openconfig-segment-routing {
       - SR SID advertisements - instantiated within the relevant IGP.
       - SR-specific counters - instantied within the relevant dataplane.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.1";
+  }
 
   revision "2023-05-24" {
     description
@@ -449,7 +455,7 @@ module openconfig-segment-routing {
       "MPLS-specific Segment Routing configuration for an interface";
 
     leaf interface-id {
-      type string;
+      type oc-if:interface-id;
       description
         "A unique identifier for the interface.";
     }


### PR DESCRIPTION
### Change Scope
- Fix certain keys that were typed to `string` when that should be `interface-id` type.
- The goal is to make these `interface-ref` and `interface-id` usage to be more consistent
- This change is backwards compatible
    - `interface-id` underlying type is `string` so there shouldn't be any issues

Paths updated:
* /bfd/interfaces/interface/id
* /network-instances/network-instance/mpls/signaling-protocols/segment-routing/interfaces/interface/interface-id
* /network-instances/network-instance/interfaces/interface/id
* /network-instances/network-instance/protocols/protocol/ospfv2/areas/area/interfaces/interface/id
