### PR TITLE
Add hashing model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository is primarily for publishing the models, documents, and other
 material developed by the OpenConfig operators group.
 
 For information about how to contribute to OpenConfig models, please
-see [External Submissions to OpenConfig](doc/external-contributions-guide.md).
+see [External Submissions to OpenConfig](doc/contributions-guide.md).
 
 Feedback and suggestions to improve OpenConfig models is welcomed on the
 [public mailing list](https://groups.google.com/forum/?hl=en#!forum/netopenconfig),

--- a/release/models/hashing/openconfig-hashing.yang
+++ b/release/models/hashing/openconfig-hashing.yang
@@ -1,0 +1,164 @@
+module openconfig-hashing {
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/hashing";
+
+    prefix "oc-hashing";
+
+    // import some basic types
+    import openconfig-extensions { prefix oc-ext; }
+    import openconfig-packet-match { prefix oc-pkt-match; }
+
+    // meta
+    organization "OpenConfig working group";
+
+    contact
+      "OpenConfig working group
+      netopenconfig@googlegroups.com";
+
+    description
+      "Model for managing hashing policies that would be referenced by the
+      interfaces model.
+
+
+    oc-ext:openconfig-version "0.1.0";
+
+    revision "2023-08-08" {
+        description "Initial hashing model.";
+        reference "0.1.0";
+    }
+
+    // OpenConfig specific extensions for module metadata.
+    oc-ext:regexp-posix;
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    grouping hashing-inputs {
+        description
+          "Top level container for inputs to be used for hashing policies.";
+
+        container config {
+            description
+              "Configurable items at the hashing inputs level.";
+            uses oc-pkt-match:ipv4-protocol-fields-config;
+            uses oc-pkt-match:ipv6-protocol-fields-config;
+            uses oc-pkt-match:transport-fields-config;
+        }
+
+        container state {
+            config false;
+            description
+              "Operational state data at the hashing inputs level.";
+            uses oc-pkt-match:ipv4-protocol-fields-config;
+            uses oc-pkt-match:ipv6-protocol-fields-config;
+            uses oc-pkt-match:transport-fields-config;
+        }
+    }
+
+    grouping hashing-policy-config {
+        description
+          "Configuration data for hashing policies.";
+
+        leaf name {
+            type string;
+            description
+              "The name of the hashing policy.
+
+              When a configured user-controlled policy is created by the
+              system, it is instantiated with the same name in the
+              /policies/policy[name]/state list.";
+        }
+
+        leaf algorithm {
+            default CRC;
+            type enumeration {
+                enum CRC {
+                    description
+                      "CRC hashing algorithm.";
+                }
+                enum CRC_32LO {
+                  description
+                    "CRC_32LO hashing algorithm.";
+                }
+                enum CRC_32HI {
+                  description
+                    "CRC_32HI hashing algorithm.";
+                }
+                enum CRC_CCITT {
+                  description
+                    "CRC using CCITT polynomial based hash algorithm.";
+                }
+                enum CRC_XOR {
+                  description
+                    "Combination of CRC and XOR based hash algorithm.";
+                }
+                enum XOR {
+                  description
+                    "XOR-based hash algorithm.";
+                }
+                enum RANDOM {
+                  description
+                    "Random-based hash algorithm.";
+                }
+            }
+            description
+              "The algorithm used when calculating a hash based on packet headers";
+        }
+
+        leaf offset {
+            type uint64;
+            description
+              "The offset used when calculating the hash algorithm";
+        }
+
+        leaf seed {
+            type uint64;
+            description
+              "The seed used to initialize the hash algorithm";
+        }
+
+        uses hashing-inputs;
+    }
+
+    grouping hashing-top {
+        description
+          "Top level grouping for hashing configuration and operational state
+          data.";
+
+        container policies {
+            description
+              "Top level container for hashing, including configuration and
+              state data.";
+
+            list policy {
+                key "name";
+
+                description
+                  "The list of named policies to be used on the device.";
+
+                leaf name {
+                    type leafref {
+                        path "../config/name";
+                    }
+                    description
+                      "References the name of the hashing policy.";
+                }
+                container config {
+                    description
+                      "Configurable items at the global hash policy level.";
+                    uses hashing-policy-config;
+                }
+                container state {
+                    config false;
+                    description
+                      "Operational state data at the global hash policy
+                      level.";
+
+                    uses hashing-policy-config;
+                }
+            }
+        }
+    }
+}
+

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -24,9 +24,9 @@ module openconfig-transport-types {
 
   oc-ext:openconfig-version "0.16.0";
 
-  revision "2022-09-20" {
+  revision "2022-10-18" {
     description
-      "Add ETH_400GBASE_PSM4 PMD type";
+      "Add ETH_400GMSA_PSM4 PMD type";
     reference "0.16.0";
   }
 
@@ -1050,9 +1050,9 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 400GBASE_DR4";
   }
 
-  identity ETH_400GBASE_PSM4 {
+  identity ETH_400GMSA_PSM4 {
     base ETHERNET_PMD_TYPE;
-    description "Ethernet compliance code: 400GBASE_PSM4";
+    description "Ethernet compliance code: 400GMSA_PSM4";
   }
 
   identity ETH_UNDEFINED {

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
+
+  revision "2022-09-20" {
+    description
+      "Add ETH_400GBASE_PSM4 PMD type";
+    reference "0.16.0";
+  }
 
   revision "2021-07-29" {
     description
@@ -1042,6 +1048,11 @@ module openconfig-transport-types {
   identity ETH_400GBASE_DR4 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 400GBASE_DR4";
+  }
+
+  identity ETH_400GBASE_PSM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_PSM4";
   }
 
   identity ETH_UNDEFINED {


### PR DESCRIPTION
### Change Scope

* Add hashing model to OC. There will be leaf-refs added to interfaces and system models to apply the policies for LAG and L3 ECMP.
* Change is backward compatible.
