### PR TITLE
tag-set association for local routes (static and aggregate)

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -13,6 +13,7 @@ module openconfig-local-routing {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-bfd { prefix oc-bfd; }
+  import openconfig-routing-policy { prefix oc-rpol; }
 
   // meta
   organization "OpenConfig working group";
@@ -43,7 +44,13 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.0.2";
+
+  revision "2023-08-17" {
+    description
+      "Allow tag-set association with static and aggregate routes.";
+    reference "2.0.2";
+  }
 
   revision "2022-11-01" {
     description
@@ -141,6 +148,17 @@ module openconfig-local-routing {
       description
         "Set a generic tag value on the route. This tag can be
         used for filtering routes that are distributed to other
+        routing protocols.";
+    }
+
+     leaf apply-tag-set {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-rpol:tag-sets/oc-rpol:tag-set/oc-rpol:name";
+      }
+      description
+        "Apply all the tags in the defined tag-set to the route. These tags
+        can be used for filtering routes that are distributed to other
         routing protocols.";
     }
 


### PR DESCRIPTION
This code is a Contribution to the OpenConfig Public project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.

**Change Scope**

Currently it is only possible to associate a single tag value with a particular static or aggregate route. In some situations it would make more sense to associate the route with a tag-set rather than a singular tag value: a tag-set can include multiple tag values each representing a different policy dimension and the chance of misconfiguration is reduced if the static route configuration makes use of the same tag-set configuration as the export policy of the protocol redistributing this static route on the basis of tags. This PR adds tag-set association in parallel to the existing "set-tag" leaf, which is not removed for backwards compatibility reasons. An implementation may choose to support one or the other -- either the existing "set-tag" leaf or the new "apply-tag-set" leaf proposed by this PR.

**Implementations**

The tag-set construct is an established construct in the OC routing-policy model as well as the IETF routing-policy model (RFC9067) even though it is not widely implemented across vendors. It is therefore difficult to reference a platform implementation that already supports this.
