### PR TITLE
Add transceiver module temp thresholds

### DIFF
--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,7 +66,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.12.0";
+  oc-ext:openconfig-version "0.13.0";
+
+revision "2023-08-30" {
+    description
+      "Add transceiver module temperature thresholds";
+    reference "0.13.0";
+  }
 
   revision "2023-06-27" {
     description
@@ -842,6 +848,22 @@ module openconfig-platform-transceiver {
         fraction-digits 2;
       }
       units volts;
+    }
+    leaf module-temperature-lower {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The lower temperature threshold for the transceiver module.";
+    }
+    leaf module-temperature-upper {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The upper temperature threshold for the transceiver module.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* Add upper and lower temperature thresholds for transceiver modules.  
* This change is backwards compatible.
### Platform Implementations

 * Arista EOS [show interfaces transceiver dom thresholds](https://www.arista.com/en/um-eos/eos-transceiver-performance-monitoring#unique_1157600725)
 * Cisco IOS XR [show controllers optics](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/Interfaces/73x/configuration/guide/b-interfaces-config-guide-cisco8k-r73x/m-configuring-controllers-8k.html)
 * JunOS [show interfaces diagnostics optics](https://www.juniper.net/documentation/us/en/software/junos/interfaces-ethernet-switches/topics/ref/command/show-interfaces-diagnostics-optics-ex-series.html)

### Model tree view

```
        |  +--rw oc-transceiver:thresholds
        |     +--ro oc-transceiver:threshold* [severity]
        |        +--ro oc-transceiver:severity    -> ../state/severity
        |        +--ro oc-transceiver:state
        |           +--ro oc-transceiver:severity?                   identityref
        |           +--ro oc-transceiver:laser-temperature-upper?    decimal64
        |           +--ro oc-transceiver:laser-temperature-lower?    decimal64
        |           +--ro oc-transceiver:output-power-upper?         decimal64
        |           +--ro oc-transceiver:output-power-lower?         decimal64
        |           +--ro oc-transceiver:input-power-upper?          decimal64
        |           +--ro oc-transceiver:input-power-lower?          decimal64
        |           +--ro oc-transceiver:laser-bias-current-upper?   decimal64
        |           +--ro oc-transceiver:laser-bias-current-lower?   decimal64
        |           +--ro oc-transceiver:supply-voltage-upper?       decimal64
        |           +--ro oc-transceiver:supply-voltage-lower?       decimal64
        |           +--ro oc-transceiver:module-temperature-lower?   decimal64   <-- added
        |           +--ro oc-transceiver:module-temperature-upper?   decimal64   <--added
```
