### PR TITLE
add NEXT-STATEMENT to policy-result-type

### DIFF
--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -90,7 +90,7 @@ module openconfig-routing-policy {
 
   revision "2023-10-11" {
     description
-      "Add NEXT_STATEMENT and NEXT_POLICY policy-result-type enums.";
+      "Add NEXT_STATEMENT policy-result-type enums.";
     reference "3.4.0";
   }
 
@@ -187,11 +187,6 @@ module openconfig-routing-policy {
       enum NEXT_STATEMENT {
         description "Any modifications of the route are preserved and the evaluation of the policy will continue to the
         next statement.";
-      }
-      enum NEXT_POLICY {
-        description "Evaluation of statements in current policy will
-        stop.  Any modifications to the route are preserved and
-        evaluation proceeds to the next policy.";
       }
     }
     description

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -59,11 +59,7 @@ module openconfig-routing-policy {
 
     If the action statement has the NEXT_STATEMENT policy result, all the
     defined actions are exectued and policy evaluation proceeds to the next
-    statement.  If the action statement has NEXT-POLICY as the policy result,
-    there is no final disposition of the route, all the defined actions are
-    executed, evaluation of statements within the current policy stops and
-    evaluation proceeds to the next policy in the chain, if any.  The
-    NEXT_STATEMENT is the default policy result action.
+    statement.  The NEXT_STATEMENT is the default policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to
     the next policy statement.  If none of the policy statement
@@ -189,6 +185,7 @@ module openconfig-routing-policy {
         next statement.";
       }
     }
+    default NEXT_STATEMENT;
     description
       "Type used to specify route disposition in
       a policy chain";

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -55,8 +55,12 @@ module openconfig-routing-policy {
     statement has either accept-route or reject-route actions, policy
     evaluation of the current policy definition stops, and no further
     policy definitions in the chain are evaluated.  If the action
-    statement has the continue action, policy evaluation proceeds to
-    the next statement. Continue is the default policy result action.
+    statement has the NEXT-STATEMENT action, policy evaluation proceeds
+    to the next statement. If the action statement has the NEXT-POLICY
+    action, evaluation of statements within the current policy stops.
+    Any modifications to a route are preserved and evaluation proceeds
+    to the next policy, if any.  The NEXT-STATEMENT is the default
+    policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to
     the next policy statement.  If none of the policy statement
@@ -177,12 +181,17 @@ module openconfig-routing-policy {
         description "Policy rejects the route and evaluation of the
         current policy definition stops.";
       }
-      enum CONTINUE {
+      enum NEXT-STATEMENT {
         description "Evaluation of the policy will continue to the
         next statement.";
       }
+      enum NEXT-POLICY {
+        description "Evaluation of statements in current policy will
+        stop.  Any modifications to the route are preserved and
+        evaluation proceeds to the next policy.";
+      }
     }
-    default CONTINUE;
+    default NEXT-STATEMENT;
     description
       "Type used to specify route disposition in
       a policy chain.";

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -51,16 +51,18 @@ module openconfig-routing-policy {
     Evaluation of each policy definition proceeds by evaluating its
     corresponding individual policy statements in order.  When a
     condition statement in a policy statement is satisfied, the
-    corresponding action statement is executed.  If the action
-    statement has a final disposition configured as policy result, either accept-route or reject-route,
-    evaluation of the current policy definition stops after having executed all the defined actions , and no further policy statements are evaluated. In case there is a policy chain, no further 
-    policy definitions in the chain are evaluated.  If the action
-    statement has the NEXT_STATEMENT action, policy evaluation proceeds
-    to the next statement. If the action statement has the NEXT-POLICY
-    action, evaluation of statements within the current policy stops.
-    Any modifications to a route are preserved and evaluation proceeds
-    to the next policy, if any.  The NEXT_STATEMENT is the default
-    policy result action.
+    corresponding action statement is executed.
+
+    If the action statement has either accept-route or reject-route actions,
+    policy evaluation of the current policy definition stops, all
+    modifications to the route are applied and no further statements in the
+    policy are evaluated. In case there is a policy chain, no further policy
+    definitions in the chain are evaluated.  If the action statement has
+    the NEXT_STATEMENT action, policy evaluation proceeds to the next
+    statement.  If the action statement has the NEXT-POLICY action all
+    the modifications to the route are applied, evaluation of statements
+    within the current policy stops and the next policy in the chain is
+    evaluated.
 
     If the condition is not satisfied, then evaluation proceeds to
     the next policy statement.  If none of the policy statement
@@ -83,13 +85,7 @@ module openconfig-routing-policy {
     the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  oc-ext:openconfig-version "3.4.0";
-
-  revision "2023-08-31" {
-    description
-      "Add 'continue' to policy-result-type.";
-    reference "3.4.0";
-  }
+  oc-ext:openconfig-version "3.3.0";
 
   revision "2022-05-24" {
     description
@@ -191,10 +187,9 @@ module openconfig-routing-policy {
         evaluation proceeds to the next policy.";
       }
     }
-    default NEXT_STATEMENT;
     description
       "Type used to specify route disposition in
-      a policy chain.";
+      a policy chain";
   }
 
 

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -181,11 +181,11 @@ module openconfig-routing-policy {
         description "Policy rejects the route and evaluation of the
         current policy definition stops.";
       }
-      enum NEXT-STATEMENT {
+      enum NEXT_STATEMENT {
         description "Evaluation of the policy will continue to the
         next statement.";
       }
-      enum NEXT-POLICY {
+      enum NEXT_POLICY {
         description "Evaluation of statements in current policy will
         stop.  Any modifications to the route are preserved and
         evaluation proceeds to the next policy.";

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -53,7 +53,7 @@ module openconfig-routing-policy {
     condition statement in a policy statement is satisfied, the
     corresponding action statement is executed.  If the action
     statement has a final disposition configured as policy result, either accept-route or reject-route,
-    evaluation of the current policy definition stops, and no further
+    evaluation of the current policy definition stops after having executed all the defined actions , and no further policy statements are evaluated. In case there is a policy chain, no further 
     policy definitions in the chain are evaluated.  If the action
     statement has the NEXT_STATEMENT action, policy evaluation proceeds
     to the next statement. If the action statement has the NEXT-POLICY

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -56,10 +56,10 @@ module openconfig-routing-policy {
     accept-route or reject-route, evaluation of the current policy definition
     stops, and no further policy statements are evaluated. In case there is a
     policy chain, no further policy definitions in the chain are evaluated.
-    
+
     If the action statement has the NEXT_STATEMENT policy result, all the
     defined actions are exectued and policy evaluation proceeds to the next
-    statement. If the action statement has NEXT-POLICY as the policy result,
+    statement.  If the action statement has NEXT-POLICY as the policy result,
     there is no final disposition of the route, all the defined actions are
     executed, evaluation of statements within the current policy stops and
     evaluation proceeds to the next policy in the chain, if any.  The
@@ -86,7 +86,13 @@ module openconfig-routing-policy {
     the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-10-11" {
+    description
+      "Add NEXT_STATEMENT and NEXT_POLICY policy-result-type enums.";
+    reference "3.4.0";
+  }
 
   revision "2022-05-24" {
     description

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -58,7 +58,7 @@ module openconfig-routing-policy {
     policy chain, no further policy definitions in the chain are evaluated.
 
     If the action statement has the NEXT_STATEMENT policy result, all the
-    defined actions are exectued and policy evaluation proceeds to the next
+    defined actions are executed and policy evaluation proceeds to the next
     statement.  The NEXT_STATEMENT is the default policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -54,7 +54,9 @@ module openconfig-routing-policy {
     corresponding action statement is executed.  If the action
     statement has either accept-route or reject-route actions, policy
     evaluation of the current policy definition stops, and no further
-    policy definitions in the chain are evaluated.
+    policy definitions in the chain are evaluated.  If the action
+    statement has the continue action, policy evaluation proceeds to
+    the next statement. Continue is the default policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to
     the next policy statement.  If none of the policy statement
@@ -77,7 +79,13 @@ module openconfig-routing-policy {
     the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2023-08-31" {
+    description
+      "Add 'continue' to policy-result-type.";
+    reference "3.4.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -162,15 +170,22 @@ module openconfig-routing-policy {
   typedef policy-result-type {
     type enumeration {
       enum ACCEPT_ROUTE {
-        description "Policy accepts the route";
+        description "Policy accepts the route and evaluation of the
+        current policy definition stops.";
       }
       enum REJECT_ROUTE {
-        description "Policy rejects the route";
+        description "Policy rejects the route and evaluation of the
+        current policy definition stops.";
+      }
+      enum CONTINUE {
+        description "Evaluation of the policy will continue to the
+        next statement.";
       }
     }
+    default CONTINUE;
     description
       "Type used to specify route disposition in
-      a policy chain";
+      a policy chain.";
   }
 
 

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -182,7 +182,7 @@ module openconfig-routing-policy {
         current policy definition stops.";
       }
       enum NEXT_STATEMENT {
-        description "Evaluation of the policy will continue to the
+        description "Any modifications of the route are preserved and the evaluation of the policy will continue to the
         next statement.";
       }
       enum NEXT_POLICY {

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -55,11 +55,11 @@ module openconfig-routing-policy {
     statement has either accept-route or reject-route actions, policy
     evaluation of the current policy definition stops, and no further
     policy definitions in the chain are evaluated.  If the action
-    statement has the NEXT-STATEMENT action, policy evaluation proceeds
+    statement has the NEXT_STATEMENT action, policy evaluation proceeds
     to the next statement. If the action statement has the NEXT-POLICY
     action, evaluation of statements within the current policy stops.
     Any modifications to a route are preserved and evaluation proceeds
-    to the next policy, if any.  The NEXT-STATEMENT is the default
+    to the next policy, if any.  The NEXT_STATEMENT is the default
     policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to
@@ -191,7 +191,7 @@ module openconfig-routing-policy {
         evaluation proceeds to the next policy.";
       }
     }
-    default NEXT-STATEMENT;
+    default NEXT_STATEMENT;
     description
       "Type used to specify route disposition in
       a policy chain.";

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -52,7 +52,7 @@ module openconfig-routing-policy {
     corresponding individual policy statements in order.  When a
     condition statement in a policy statement is satisfied, the
     corresponding action statement is executed.  If the action
-    statement has either accept-route or reject-route actions, policy
+    statement has a final disposition configured as policy result, either accept-route or reject-route,
     evaluation of the current policy definition stops, and no further
     policy definitions in the chain are evaluated.  If the action
     statement has the NEXT_STATEMENT action, policy evaluation proceeds

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -52,15 +52,18 @@ module openconfig-routing-policy {
     corresponding individual policy statements in order.  When a
     condition statement in a policy statement is satisfied, the
     corresponding action statement is executed.  If the action
-    statement has a final disposition configured as policy result, either accept-route or reject-route,
-    evaluation of the current policy definition stops after having executed all the defined actions , and no further policy statements are evaluated. In case there is a policy chain, no further 
-    policy definitions in the chain are evaluated.  If the action
-    statement has the NEXT_STATEMENT policy result, all the defined actions are exectued and policy evaluation proceeds
-    to the next statement. If the action statement has the NEXT-POLICY
-    action, evaluation of statements within the current policy stops.
-    Any modifications to a route are preserved and evaluation proceeds
-    to the next policy, if any.  The NEXT_STATEMENT is the default
-    policy result action.
+    statement has a final disposition configured as policy result, either
+    accept-route or reject-route, evaluation of the current policy definition
+    stops, and no further policy statements are evaluated. In case there is a
+    policy chain, no further policy definitions in the chain are evaluated.
+    
+    If the action statement has the NEXT_STATEMENT policy result, all the
+    defined actions are exectued and policy evaluation proceeds to the next
+    statement. If the action statement has NEXT-POLICY as the policy result,
+    there is no final disposition of the route, all the defined actions are
+    executed, evaluation of statements within the current policy stops and
+    evaluation proceeds to the next policy in the chain, if any.  The
+    NEXT_STATEMENT is the default policy result action.
 
     If the condition is not satisfied, then evaluation proceeds to
     the next policy statement.  If none of the policy statement

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -86,7 +86,7 @@ module openconfig-routing-policy {
 
   revision "2023-10-11" {
     description
-      "Add NEXT_STATEMENT policy-result-type enums.";
+      "Add NEXT_STATEMENT policy-result-type enum value.";
     reference "3.4.0";
   }
 


### PR DESCRIPTION
### Change Scope

* Add `NEXT-STATEMENT` to the typedef for `route-policy-result`.
* Use `NEXT-STATEMENT` as the default.
* This does not change the intended functionality of routing policies.  It is intended to
clarify the expected behavior if there is a match for a policy, but no policy-result is
specified.

This change adds a default where there previously was none.  So if an implementation performs some other action than  `NEXT-STATEMENT` by default, it could be a breaking change.  

### Platform Implementations
This result type corresponds to the the following  policy match actions in existing implementations.

 * JunOS implements [next term](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-configuring-actions-in-routing-policy-terms.html) which is equivalent to `NEXT-STATEMENT`
 *  Cisco implements [pass](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/configuration/guide/rc40xr12k_chapter7.html) which is similar to `NEXT-STATEMENT`.   It differs in that `pass` means both accept-route and continue.  In OC, `NEXT-STATEMENT` only means move to the next action in the policy.  
 *  Arista EOS implements [continue](https://www.arista.com/en/um-eos/eos-acls-and-route-maps#xx1150191) which is a superset of `NEXT-STATEMENT`.    Arista's continue statement has additional parameters not contemplated in this PR.

