### PR TITLE
Adding FREQ_2_6_GHZ to wifi-types #923

### DIFF
--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -22,7 +22,13 @@ module openconfig-wifi-types {
     that are used in the openconfig-wifi modules. It can be
     imported by any module to make use of these types.";
 
-  oc-ext:openconfig-version "1.1.1";
+  oc-ext:openconfig-version "1.1.2";
+
+  revision "2023-09-01" {
+    description
+      "Adding FREQ_2_6_GHZ.";
+    reference "1.1.2";
+  }
 
   revision "2022-05-26" {
     description
@@ -270,6 +276,12 @@ module openconfig-wifi-types {
   identity FREQ_2_5_6_GHZ {
     base OPERATING_FREQUENCY;
     description "The Radio or SSID will be tri-band; operating in 2.4, 5 and
+    6GHz frequencies.";
+  }
+
+  identity FREQ_2_6_GHZ {
+    base OPERATING_FREQUENCY;
+    description "The Radio or SSID will be dual band; operating in 2.4 and
     6GHz frequencies.";
   }
 


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]



### Change Scope

* Added type for valid wifi SSID configuration
* This is backwards compatible

 * Implementation A: [Aruba AOS10 See "Band"](https://www.arubanetworks.com/techdocs/central/2.5.6/content/aos10x/cfg/aps/conf_wlan_ssid.htm)
 * Implementation B: [Cisco 6GHZ](https://www.cisco.com/c/en/us/products/collateral/wireless/catalyst-9136-series-access-points/cat9136-series-ap-deployment-guide.html#CreatingaWiFi6EWLAN) 


These features are supported by essentially every vendor, however, it was overlooked during initial 6GHz support.
