### PR TITLE
Update openconfig-qos-mem-mgmt.yang

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -42,7 +42,7 @@ submodule openconfig-qos-elements {
       "Clarification on WRED weight in case it is not present";
     reference "0.11.1";
   }
-  
+
   revision "2023-09-15" {
     description
       "Add support for ECN counters";

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,8 +35,14 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.11.0";
+  oc-ext:openconfig-version "0.11.1";
 
+  revision "2023-09-06" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+  
   revision "2023-09-15" {
     description
       "Add support for ECN counters";

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -32,7 +32,7 @@ submodule openconfig-qos-interfaces {
       "Clarification on WRED weight in case it is not present";
     reference "0.11.1";
   }
-  
+
   revision "2023-09-15" {
     description
       "Add support for ECN counters";

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,8 +25,14 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.11.0";
+  oc-ext:openconfig-version "0.11.1";
 
+  revision "2023-09-06" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+  
   revision "2023-09-15" {
     description
       "Add support for ECN counters";

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,13 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.10.1";
+
+  revision "2023-09-06" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.10.1";
+  }
 
   revision "2023-07-26" {
     description
@@ -398,8 +404,8 @@ submodule openconfig-qos-mem-mgmt {
         The previous average is more important for high values of n. Peaks
         and lows in queue size are smoothed by a high value. For low values
         of n, the average queue size is close to the current queue size.
-        
-        When this leaf is not present, implementation default value is 
+
+        When this leaf is not present, implementation default value is
         applied.";
     }
 

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,12 +29,12 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.10.1";
+  oc-ext:openconfig-version "0.11.1";
 
   revision "2023-09-06" {
     description
       "Clarification on WRED weight in case it is not present";
-    reference "0.10.1";
+    reference "0.11.1";
   }
 
   revision "2023-07-26" {

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -397,7 +397,10 @@ submodule openconfig-qos-mem-mgmt {
 
         The previous average is more important for high values of n. Peaks
         and lows in queue size are smoothed by a high value. For low values
-        of n, the average queue size is close to the current queue size.";
+        of n, the average queue size is close to the current queue size.
+        
+        When this leaf is not present, implementation default value is 
+        applied.";
     }
 
     leaf max-drop-probability-percent {

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -34,7 +34,7 @@ module openconfig-qos {
       "Clarification on WRED weight in case it is not present";
     reference "0.11.1";
   }
-  
+
   revision "2023-09-15" {
     description
       "Add support for ECN counters";

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,8 +27,14 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "0.11.0";
+  oc-ext:openconfig-version "0.11.1";
 
+  revision "2023-09-06" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+  
   revision "2023-09-15" {
     description
       "Add support for ECN counters";


### PR DESCRIPTION
Clarification of expected behaviour if WRED weight leaf is not present.

"... When this leaf is not present, implementation default value is applied."

There is a lot of confusion in definition of RED vs. WRED. 
The OpenConfig differentiate  WRED from RED by expose weight used for averange queue utilization according to equaition 

  *avg_Q(t) = avgQ(t-1)*(1-wq)+wq\*q*

where:\
     * q -  is instantinous queue utilization at time t,
     * avgQ(t-1) is previously calculated average queue utilization
     * wq = 2^(-weight). Note: with weight of 0, wq=1 hence avg_Q(t)=q
     
On Wikipedia it is possible to find completly different [WRED definition](https://en.wikipedia.org/wiki/Weighted_random_early_detection)
>Weighted random early detection (WRED) is a queueing discipline for a network scheduler suited for congestion avoidance.[1] It is an extension to random early detection (RED) where a single queue may have several different sets of queue thresholds.
This wikipedia definition is NOT applicable for OpenConfig.

## Implementation refrences:
The WRED capabilities depends on dataplane hardware (ASIC, NPU) of implementation, not simply it's software.

### JUNIPER [link](https://www.juniper.net/documentation/us/en/software/junos/cos/topics/task/cos-configuring-red-drop-profiles.html)
In general Juniper routers **do no allow for weight configuration**. Also JUNOS use terms WRED and RED interchangably. Altrought it is not explicitly stated, It is resonable to assume that what is really supported is RED (or WRED with fixed, weight = 0)

Some acient (c.a. 2004 ) IQ-PIC (EoL today) had have support for setting weights [link](https://www.juniper.net/documentation/us/en/software/junos/cos/topics/task/cos-configuring-weighted-red-buffer-occupancy.html)

### CISCO
In general IOS-XR **do no allow for weight configuration**.
#### CISCO 8000 [link](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/qos/70x/configuration/guide/b-qos-cg-8k-70x/congestion_avoidance.html) Hardware support only RED not Weighted RED.
The RED is the same as WRED with weight=0
#### CISCO ASR9000 [link](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/qos/command/reference/b-qos-cr-asr9k/Congestion_Avoidance_Commands.html#wp1186628620)
> "The exponential weight factor is set to 0 for Cisco ASR 9000 series routers."

In general in ASR9000/IOS-XR documentation terms RED and WRED are used interchangably.

### ARISTA [link](https://www.arista.com/en/um-eos/eos-quality-of-service#xx1161943) [link2](https://www.arista.com/en/support/toi/eos-4-18-0f/13844-wred-support)
In general EoS **do no allow for weight configuration**.

However in narrative part of maual discuss it in this [chapter](https://www.arista.com/en/um-eos/eos-quality-of-service#xx1166435). 


