### PR TITLE
Data model for Kubernetes manifest files

### DIFF
--- a/release/models/kubernetes/.spec.yml
+++ b/release/models/kubernetes/.spec.yml
@@ -1,7 +1,7 @@
 - name: openconfig-kubernetes
   docs:
-    - yang/bgp/openconfig-kubernetes-types.yang
-    - yang/bgp/openconfig-kubernetes.yang
+    - yang/kubernetes/openconfig-kubernetes-types.yang
+    - yang/kubernetes/openconfig-kubernetes.yang
   build:
-    - yang/bgp/openconfig-kubernetes.yang
+    - yang/kubernetes/openconfig-kubernetes.yang
   run-ci: true

--- a/release/models/kubernetes/.spec.yml
+++ b/release/models/kubernetes/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-kubernetes
+  docs:
+    - yang/bgp/openconfig-kubernetes-types.yang
+    - yang/bgp/openconfig-kubernetes.yang
+  build:
+    - yang/bgp/openconfig-kubernetes.yang
+  run-ci: true

--- a/release/models/kubernetes/openconfig-kubernetes-state.yang
+++ b/release/models/kubernetes/openconfig-kubernetes-state.yang
@@ -1,0 +1,49 @@
+submodule openconfig-kubernetes-state {
+
+  belongs-to openconfig-kubernetes {
+    prefix "oc-k8s";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that define the state data for the openconfig-kubernetes Yang model.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2023-06-01" {
+    description
+      "Initial public release";
+    reference "0.1.0";
+  }
+
+  grouping cluster-state {
+    description
+      "State data for the entire cluster";
+
+    leaf control-plane-url {
+      type oc-inet:url;
+      description
+        "Location of the control plane instance for this cluster";
+    }
+    leaf service-discovery-application {
+      type oc-inet:url;
+      description
+        "Application providing service discovery for this cluster";
+    }
+    leaf service-discovery-url {
+      type oc-inet:url;
+      description
+        "Location of the service discovery instance for this cluster";
+    }
+  }
+}

--- a/release/models/kubernetes/openconfig-kubernetes-types.yang
+++ b/release/models/kubernetes/openconfig-kubernetes-types.yang
@@ -26,7 +26,7 @@ module openconfig-kubernetes-types {
   revision "2023-05-19" {
     description
       "OpenConfig public release";
-    reference "0.1.0";
+    reference "3.1.0";
   }
 
   // OpenConfig specific extensions for module metadata.

--- a/release/models/kubernetes/openconfig-kubernetes-types.yang
+++ b/release/models/kubernetes/openconfig-kubernetes-types.yang
@@ -1,0 +1,314 @@
+module openconfig-kubernetes-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/kubernetes-types";
+
+  prefix "oc-k8s-types";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module defines the types uses for the openconfig-kubernetes.yang";
+
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2023-05-19" {
+    description
+      "OpenConfig public release";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+  identity RESOURCE_OBJECT_TYPE {
+  	description
+  	 "A base identity which can be extended to indicate the different
+     types, 'Kinds', of objects available and managed in Kubernetes";
+  }
+
+  identity POD {
+    base RESOURCE_OBJECT_TYPE;
+    description
+      "Environment for one or more containers that co-exist on the host system
+      and share resources";
+  }
+
+  identity DEPLOYMENT {
+    base RESOURCE_OBJECT_TYPE;
+    description
+      "Environment for one or more containers that co-exist on the host system
+      and the replication intent for the containers";
+  }
+
+  identity SERVICE {
+    base RESOURCE_OBJECT_TYPE;
+    description
+      "Internal and external network configuration for a cluster";
+  }
+
+  identity CONFIG_MAP {
+    base RESOURCE_OBJECT_TYPE;
+    description
+      "Key / value pairs to be referenced in the cluster";
+  }
+
+  identity SECRET {
+    base RESOURCE_OBJECT_TYPE;
+    description
+      "Hashed and encrypted key / value pairs to be referenced in the cluster";
+  }
+
+  identity SECRET_DATA_TYPE {
+    description
+      "A base identity which can be extended to indicate the different
+      types of secrets supported in Kubernetes";
+  }
+
+  identity OPAQUE {
+    base SECRET_DATA_TYPE;
+    description
+      "Default secret type which with no defined structure and is entered in clear text";
+  }
+
+  identity SERVICE_ACCOUNT_TOKEN {
+    base SECRET_DATA_TYPE;
+    description
+      "Token that references a service account";
+  }
+
+  identity DOCKER_CONFIG_SECRET {
+    base SECRET_DATA_TYPE;
+    description
+      "Credentials for accessing a Docker repository";
+  }
+
+  identity BASIC_AUTH {
+    base SECRET_DATA_TYPE;
+    description
+      "Credentials for authentication typically as username and password";
+  }
+
+  identity SERVICE_TYPE {
+    description
+      "A base identity which can be extended to indicate the different
+      types of services supported in Kubernetes";
+  }
+
+  identity NODE_PORT {
+    base SERVICE_TYPE;
+    description
+      "Exposes the service on each node's IP at a static port";
+  }
+
+  identity CLUSTER_IP {
+    base SERVICE_TYPE;
+    description
+      "Exposes the service on a cluster-internal IP";
+  }
+
+  identity LOAD_BALANCER {
+    base SERVICE_TYPE;
+    description
+      "Exposes the service externally using an external load balancer";
+  }
+
+  identity EXTERNAL_NAME {
+    base SERVICE_TYPE;
+    description
+      "Maps the service to the contents of the ExternalName field";
+  }
+
+  identity VALUE_TYPE {
+  	description
+  	 "A base identity which can be extended to indicate the different
+     types of data stored in the values of the name value list";
+  }
+
+  identity STRING {
+    base VALUE_TYPE;
+    description
+      "Default type in which this value leaf is the actual string value to be used with the name leaf";
+  }
+
+  identity VALUE_FROM_CONFIG_MAP {
+    base VALUE_TYPE;
+    description
+      "Value is a reference key to an entry stored in a ConfigMap list configured in the cluster";
+  }
+
+  identity VALUE_FROM_SECRET {
+    base VALUE_TYPE;
+    description
+      "Value is a reference key to an entry stored in a Secret list configured in the cluster";
+  }
+
+  // typedef statements
+  typedef api-version-type {
+    type enumeration {
+      enum V1 {
+        value 1;
+        description
+          "Manifest version v1";
+      }
+    }
+    description
+      "Manifest Apps API version to be used for Deployment resource";
+  }
+
+  typedef apps-api-version-type {
+    type enumeration {
+      enum APPSV1 {
+        value 1;
+        description
+          "Manifest apps version apps/v1";
+      }
+    }
+    description
+      "Manifest Apps API version to be used for Deployment resource";
+  }
+
+  typedef service-protocol-type {
+    type enumeration {
+      enum TCP;
+      enum UDP;
+      enum ICMP;
+    }
+    description
+      "Service protocol types";
+  }
+
+  // grouping statements
+  grouping name-port-instance-config {
+    description
+      "Instance of a name / port pair";
+
+    leaf name {
+      type string;
+      description
+        "Name associated with the value";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description
+        "Port associated with the name";
+    }
+  }
+
+  grouping name-value-instance-config {
+    description
+      "Instance of a name / value pair.  Only one type of [value, configmap-name, or secret-name] is expected
+      to be associated with the name";
+
+    leaf name {
+      type string;
+      description
+        "Name associated with the value";
+    }
+
+    leaf value {
+      type string;
+      description
+        "String value or reference to a value associated with the name, as indicated by the type";
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-k8s-types:VALUE_TYPE";
+      }
+      default oc-k8s-types:STRING;
+      description
+        "Type of the value stored in this list entry";
+    }
+
+    leaf resource {
+      when "../type != 'oc-k8s-types:STRING'" {
+        description
+          "Valid when the type indicates a reference to another configuration data resource";
+      }
+      type string;
+      description
+        "Name of the ConfigMap or Secret resource in which this container's value is a key to the stored data";
+    }
+  }
+
+  grouping name-value-list-config {
+    description
+      "Generic list of name / value data configuration in which value may include a valueFrom concept
+      referring to a configmap or secret instance";
+
+    container name-value-pairs {
+      description
+        "Data container holding the list of name / value pairs";
+
+      list pair {
+        key "name";
+        description
+          "Name for this name / value pair";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name for this pair";
+        }
+
+        container config {
+          description
+            "Name / value pair data";
+          uses name-value-instance-config;
+        }
+      }
+    }
+  }
+
+  grouping name-port-list-config {
+    description
+      "Generic list of name / port data configuration";
+
+    container name-port-pairs {
+      description
+        "Data container holding the list of name / port pairs";
+
+      list pair {
+        key "name";
+        description
+          "Name for this name / port pair";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name for this pair";
+        }
+
+        container config {
+          description
+            "Name / port pair data";
+          uses name-port-instance-config;
+        }
+      }
+    }
+  }
+}

--- a/release/models/kubernetes/openconfig-kubernetes.yang
+++ b/release/models/kubernetes/openconfig-kubernetes.yang
@@ -1,0 +1,684 @@
+module openconfig-kubernetes {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/system/kubernetes";
+
+  prefix "oc-k8s";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-kubernetes-types { prefix oc-k8s-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+
+  // Include submodules:
+  // openconfig-kubernetes-state contains groupings to represent with kubectl get
+  // and other commands can represent
+  include openconfig-kubernetes-state;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state data
+    related to a system Kubernetes cluster.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+
+  revision "2023-06-01" {
+    description
+      "Initial public release";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+  grouping container-instance-config {
+    description
+      "Configuration of a container instance with all data necessary to install and activate";
+
+    leaf name {
+      type string;
+      description
+        "Name for the container instantiated in the cluster";
+    }
+
+    leaf image {
+      type string;
+      description
+        "Image name to be instantiated for this container";
+    }
+
+    container environment-variables {
+      description
+        "Environment variables to be set for this container";
+
+      uses oc-k8s-types:name-value-list-config;
+    }
+
+    container ports {
+      description
+        "List of ports to be exposed for a container";
+
+      uses oc-k8s-types:name-port-list-config;
+    }
+  }
+
+  grouping match-labels-config {
+    description
+      "Match label configuration information for the selector";
+
+    leaf app {
+      type string;
+      description
+        "Label name for this match";
+    }
+  }
+
+  grouping selector-config {
+    description
+      "Selector information provided for a deployment";
+
+    uses match-labels-config;
+  }
+
+  grouping labels-config {
+    description
+      "Label information provided for an object";
+
+    leaf app {
+      type string;
+      description
+        "Label name for this object";
+    }
+  }
+
+  grouping annotations-config {
+    description
+      "Additional information provided for an object";
+
+    leaf description {
+      type string;
+      description
+        "Summary description of this object";
+    }
+  }
+
+  grouping service-port-config {
+    description
+      "Service port configuration";
+
+    leaf port {
+      type oc-inet:port-number;
+      mandatory true;
+      description
+        "Port service is listening on in the container";
+    }
+
+    leaf protocol {
+      type oc-k8s-types:service-protocol-type;
+      mandatory true;
+      description
+        "Protocol type of this service specification";
+    }
+
+    leaf target-port {
+      type oc-inet:port-number;
+      mandatory true;
+      description
+        "Port exposed outside of the container for this service";
+    }
+
+    leaf node-port {
+      type oc-inet:port-number;
+      description
+        "Port exposed outside of the container for this service when service type is NodePort";
+    }
+  }
+
+  grouping metadata-config {
+     description
+      "Additional information provided for an object or resource.  Metadata is used in a number of object and
+      resource definitions with differing parameters dependent on context.";
+
+    leaf name {
+      type string;
+      description
+        "Reference name for a resource or object.  Name is not required so that an application may choose to
+        utilize the containing instance name as the metadata name and reduce the required configuration data.";
+    }
+
+    leaf namespace {
+      type string;
+      description
+        "Namespace distinguisher for this resource or object";
+    }
+
+    leaf resource-version {
+      type string;
+      description
+        "Version reference for this resource or object";
+    }
+
+    leaf uid {
+      type string;
+      description
+        "User identification reference for this resource or object";
+    }
+
+    leaf creation-timestamp {
+      type string;
+      description
+        "Unformatted timestamp reference for the creation of this resource or object";
+    }
+
+    container labels {
+      description
+        "Labels associated with this resource or object";
+      uses labels-config;
+    }
+
+    container annotations {
+      description
+        "Annotations associated with this resource or object";
+      uses annotations-config;
+    }
+  }
+
+  grouping service-ports-config {
+    description
+      "Configuration of the ports utilized by this service";
+
+    container ports {
+      description
+        "Ports utilized by this service";
+
+      list port {
+        key "port";
+        description
+          "Port number utilized by the service";
+
+        leaf port {
+          type leafref {
+            path "../config/port";
+          }
+          description
+            "Reference to the service port configuration";
+        }
+
+        container config {
+          description
+            "Port configuration for a service";
+          uses service-port-config;
+        }
+      }
+    }
+  }
+
+  grouping container-spec-config {
+    description
+      "Configuration for all containers to be instantiated in the system";
+
+    container containers {
+      description
+        "Containers to be instatiated for this cluster";
+
+      list container {
+        key "name";
+        description
+          "Container to be instantiated";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the container configuration for a cluster";
+        }
+
+        container config {
+          description
+            "Configuration data for a Kubernetes object";
+          uses container-instance-config;
+        }
+      }
+    }
+  }
+
+  grouping template-config {
+    description
+      "Deployment template configuration";
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    container spec {
+      description
+        "Specfication of the container(s) to execute in this deployment";
+      uses container-spec-config;
+    }
+  }
+
+  grouping service-spec-config {
+    description
+      "Services definition for the containers to be instantiated in the system";
+
+    leaf type {
+      type identityref {
+        base "oc-k8s-types:SERVICE_TYPE";
+      }
+      description
+        "Type of service to be instantiated";
+    }
+
+    container selector {
+      description
+        "Service selector configuration";
+      uses selector-config;
+    }
+
+    uses service-ports-config;
+
+  }
+
+  grouping deployment-spec-config {
+    description
+      "Deployment intent for the containers to be instantiated in the system";
+
+    leaf replicas {
+      type uint16;
+      default 1;
+      description
+        "Number of instances of this deployment to provide N-1 redundancy protection";
+    }
+
+    container selector {
+      description
+        "Deployment selector configuration";
+      uses selector-config;
+    }
+
+    container template {
+      description
+        "Template for container instantiation intent";
+      uses template-config;
+    }
+  }
+
+  grouping secret-config {
+    description
+      "Kubernetes 'Secret' configuration that defines key / value pairs used in a cluster";
+
+    leaf api-version {
+      type oc-k8s-types:api-version-type;
+      default V1;
+      description
+        "API version specified for this object";
+    }
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-k8s-types:SECRET_DATA_TYPE";
+      }
+      default oc-k8s-types:OPAQUE;
+      description
+        "Data representation type for the secrets";
+    }
+
+    container data {
+      description
+        "Key / value pairs definition expected to be base64 encoded";
+      uses oc-k8s-types:name-value-list-config;
+    }
+  }
+
+  grouping object-secret-config {
+    description
+      "Object type SECRET configuration";
+
+    container secret {
+      description "Container for cluster Secret configuration";
+
+      uses secret-config;
+    }
+  }
+
+  grouping configmap-config {
+    description
+      "Kubernetes 'ConfigMap' configuration that defines key / value pairs used in a cluster";
+
+    leaf api-version {
+      type oc-k8s-types:api-version-type;
+      default V1;
+      description
+        "API version specified for this object";
+    }
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    container data {
+      description
+        "Key / value pairs definition";
+      uses oc-k8s-types:name-value-list-config;
+    }
+  }
+
+  grouping object-configmap-config {
+    description
+      "Object type POD configuration";
+
+    container config-map {
+      description "Container for cluster ConfigMap configuration";
+
+      uses configmap-config;
+    }
+  }
+
+  grouping pod-config {
+    description
+      "Kubernetes 'Pod' configuration that defines one or more containers running an application";
+
+    leaf api-version {
+      type oc-k8s-types:api-version-type;
+      default V1;
+      description
+        "API version specified for this object";
+    }
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    container spec {
+      description
+        "Specfication of the container(s) to execute in this pod";
+      uses container-spec-config;
+    }
+  }
+
+  grouping object-pod-config {
+    description
+      "Object type POD configuration";
+
+    container pod {
+      description "Container for specific pod object configuration";
+
+      uses pod-config;
+    }
+  }
+
+  grouping service-config {
+    description
+      "Kubernetes 'Service' configuration that makes pods accessible on the network";
+
+    leaf api-version {
+      type oc-k8s-types:api-version-type;
+      default V1;
+      description
+        "API version specified for this object";
+    }
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    container spec {
+      description
+        "Specfication of the container(s) to execute in this pod";
+      uses service-spec-config;
+    }
+  }
+
+  grouping object-service-config {
+    description
+      "Object type SERVICE configuration";
+
+    container service {
+      description "Container for specific service object configuration";
+
+      uses service-config;
+    }
+  }
+
+  grouping deployment-config {
+    description
+      "Kubernetes 'Deployment' configuration to declare intended state of replicas and pods";
+
+    leaf api-version {
+      type oc-k8s-types:apps-api-version-type;
+      default APPSV1;
+      description
+        "Apps/API version specified for this object";
+    }
+
+    container metadata {
+      description
+        "Metadata describing this instance";
+      uses metadata-config;
+    }
+
+    container spec {
+      description
+        "Specfication of the the deployment of container(s) to execute, include the intent of replication";
+
+      uses deployment-spec-config;
+    }
+  }
+
+  grouping object-deployment-config {
+    description
+      "Object type DEPLOYMENT configuration";
+
+    container deployment {
+      description "Container for specific deployment object configuration";
+
+      uses deployment-config;
+    }
+  }
+
+  grouping object-config {
+    description
+      "Highest level Kubernetes data model structure representing a resource or service";
+
+    leaf name {
+      type string;
+      description
+        "Name of Kubernetes object defined in this configuration.";
+    }
+
+    leaf kind {
+      type identityref {
+        base "oc-k8s-types:RESOURCE_OBJECT_TYPE";
+      }
+      mandatory true;
+      description
+        "Type of Kubernetes object type defined in this configuration.";
+    }
+
+    uses object-pod-config {
+      when "./kind = 'oc-k8s-types:POD'" {
+        description
+          "Pod-specific configuration";
+      }
+    }
+    uses object-deployment-config {
+      when "./kind = 'oc-k8s-types:DEPLOYMENT'" {
+        description
+          "Deployment-specific configuration";
+      }
+    }
+    uses object-service-config {
+      when "./kind = 'oc-k8s-types:SERVICE'" {
+        description
+          "Service-specific configuration";
+      }
+    }
+    uses object-configmap-config {
+      when "./kind = 'oc-k8s-types:CONFIG_MAP'" {
+        description
+          "ConfigMap-specific configuration";
+      }
+    }
+    uses object-secret-config {
+      when "./kind = 'oc-k8s-types:SECRET'" {
+        description
+          "Secret-specific configuration";
+      }
+    }
+  }
+
+  grouping objects-top {
+    description
+      "Top-level grouping for resources and services modeled for a Kubernetes cluster";
+
+    container objects {
+      description
+        "Resources and services modeled for a Kubernetes cluster";
+
+      list object {
+        key "name";
+        description
+          "List of objects to be instantiated for this cluster";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the configuration of a resource or service object";
+        }
+
+        container config {
+          description
+            "Configuration data for a Kubernetes object";
+          uses object-config;
+        }
+      }
+    }
+  }
+
+  grouping cluster-config {
+    description
+      "Configuration data for a Kubernetes cluster.  Models the data may ultimately be represented
+      in a set of manifest files for instantiating and operating the cluster";
+
+    leaf name {
+      type string;
+      description
+        "Name for this cluster configuration, primarily used as the key for the list of clusters
+        in the data model, but also likely to be used in forming identifying file names and other
+        system artifacts.  Examples of possible different clusters per system include 'production',
+        'dev', etc.";
+    }
+
+    uses objects-top;
+
+  }
+
+  grouping clusters-top {
+    description
+      "Top-level grouping for cluster container with list of clusters";
+
+    container clusters {
+      description
+        "Container for the list of Kubernetes clusters in the system";
+
+      list cluster {
+        key "name";
+        description
+          "List of clusters to be instantiated in the system";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the configuration of specific cluster";
+        }
+
+        container config {
+          description
+            "Configuration data for a Kubernetes object";
+          uses cluster-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for a Kubernetes cluster";
+          uses cluster-config;
+          uses cluster-state;
+        }
+      }
+    }
+  }
+
+  grouping kubernetes-clusters-top {
+    description
+      "Top-level grouping for Kubernetes cluster configuration and management";
+
+    uses clusters-top;
+  }
+
+  grouping kubernetes-operations-top {
+    description
+      "Top-level grouping for standardized Kubernetes operations and placeholder for augmentation for
+      application-specific operations";
+
+    container operations {
+    }
+  }
+
+  grouping kubernetes-top {
+    description
+      "Top-level grouping for system Kubernetes configuration and management";
+
+    container kubernetes {
+      description
+        "Container for Kubernetes configuration and management";
+
+      uses kubernetes-clusters-top;
+      uses kubernetes-operations-top;
+    }
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/release/models/kubernetes/openconfig-kubernetes.yang
+++ b/release/models/kubernetes/openconfig-kubernetes.yang
@@ -655,9 +655,6 @@ module openconfig-kubernetes {
     description
       "Top-level grouping for standardized Kubernetes operations and placeholder for augmentation for
       application-specific operations";
-
-    container operations {
-    }
   }
 
   grouping kubernetes-top {


### PR DESCRIPTION
Change Scope

- Added base OpenConfig Kubernetes data model with intention of representing what is encoded in manifest files to be invokes with kubectl apply commands. I have an implementation that does that based on this data model. It creates the manifest files based on what is configured (using Tail-f ConfD) and invokes them with an action.
- The action is not included in this data model because the instantiation of the data model should be application specific. e.g. the data model changes could be handled with other kubectl commands and not necessary 'apply'.
- Kubernetes is very rich so the intention is for this to be the base for additions to fully capture the richness.
- The concentration has been on configuration in the OpenConfig style so the state modeling is largely open. It also brings up a question for very hierarchical models like this - because the state usually includes the configuration as well as operational state, the top levels of the state hierarchy would include a lot of config if is to include the top level configuration. I'm sure there are examples and precedent so I'll see how the comments go.

Platform Implementations

- Standard Kubernetes administrated through kubectl.