### PR TITLE
ECN counters

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,8 +35,14 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
 
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+  
   revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -42,7 +42,7 @@ submodule openconfig-qos-elements {
       "Add support for ECN counters";
     reference "0.11.0";
   }
-  
+
   revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -387,7 +387,7 @@ submodule openconfig-qos-interfaces {
         or AMQ (RED, WRED, etc) induced drops as indicated by the attached
         queue-management-profile";
     }
-    
+
     leaf ecn-marked-pkts {
       type oc-yang:counter64;
       description
@@ -399,16 +399,16 @@ submodule openconfig-qos-interfaces {
       description
         "Number of octets for which ECN codepoint has been changed from ECT to CE";
     }
-    
+
     leaf ecn-selected-pkts {
       type oc-yang:counter64;
       description
         "Number of packets selected by AQM
-        
+
         For RED/WRED AQM this counter counts:
         - all packets enqueued while queue utilization was greater then max-threshold
         - packs enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
-        
+
         Packets are counted regardless of its ECN codepoint";
     }
 
@@ -416,11 +416,11 @@ submodule openconfig-qos-interfaces {
       type oc-yang:counter64;
       description
         "Number of octets of packets selected by AQM
-        
+
         For RED/WRED AQM this counter counts:
         - all octets enqueued while queue utilization was greater then max-threshold
         - octets enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
-        
+
         Octets are counted regardless of its ECN codepoint";
     }
   }

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
+
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
 
   revision "2023-07-26" {
     description
@@ -380,6 +386,42 @@ submodule openconfig-qos-interfaces {
         "Number of octets dropped by the queue due to overrun, that is tail-drop
         or AMQ (RED, WRED, etc) induced drops as indicated by the attached
         queue-management-profile";
+    }
+    
+    leaf ecn-marked-pkts {
+      type oc-yang:counter64;
+      description
+        "number of packets for which ECN codepoint has been changed from ECT to CE";
+    }
+
+    leaf ecn-marked-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets for which ECN codepoint has been changed from ECT to CE";
+    }
+    
+    leaf ecn-selected-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets selected by AQM
+        
+        For RED/WRED AQM this counter counts:
+        - all packets enqueued while queue utilization was greater then max-threshold
+        - packs enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
+        
+        Packets are counted regardless of its ECN codepoint";
+    }
+
+    leaf ecn-selected-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets of packets selected by AQM
+        
+        For RED/WRED AQM this counter counts:
+        - all octets enqueued while queue utilization was greater then max-threshold
+        - octets enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
+        
+        Octets are counted regardless of its ECN codepoint";
     }
   }
 

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,8 +29,14 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
 
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+  
   revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -36,8 +36,8 @@ submodule openconfig-qos-mem-mgmt {
       "Add support for ECN counters";
     reference "0.11.0";
   }
-  
-  revision "2023-07-26" {
+
+revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).
        Make profiles reusable across LAGs and PHY of different speed";

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,8 +27,14 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "0.10.0";
+  oc-ext:openconfig-version "0.11.0";
 
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+  
   revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -34,8 +34,8 @@ module openconfig-qos {
       "Add support for ECN counters";
     reference "0.11.0";
   }
-  
-  revision "2023-07-26" {
+
+revision "2023-07-26" {
     description
       "Add buffer management parameters in time unts (microseconds).
        Make profiles reusable across LAGs and PHY of different speed";


### PR DESCRIPTION
### Change Scope

Adds per queue packets, octets counters  for traffic that:
- has ECN field remarked form ECT(0), ECT(2) to CE dodepoint.
- has beed enqueued while selected by AQN (such WRED)
```
module: openconfig-qos
  +--rw qos
     +--rw interfaces
        +--rw interface* [interface-id]
           +--rw output
              +--rw queues
                 +--rw queue* [name]
                    +--ro state
                       +--ro name?                       string
                       +--ro queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
                       +--ro max-queue-len?              oc-yang:counter64
                       +--ro avg-queue-len?              oc-yang:counter64
                       +--ro transmit-pkts?              oc-yang:counter64
                       +--ro transmit-octets?            oc-yang:counter64
                       +--ro dropped-pkts?               oc-yang:counter64
                       +--ro dropped-octets?             oc-yang:counter64
                       +--ro ecn-marked-pkts?            oc-yang:counter64
                       +--ro ecn-marked-octets?          oc-yang:counter64
                       +--ro ecn-selected-pkts?          oc-yang:counter64
                       +--ro ecn-selected-octets?        oc-yang:counter64
```
Table below shows counter's behaviour:

| ingressing packets ECN bits      | queue utilization | `ecn-selected-pkts`, `ecn-selected-octets` |`ecn-marked-pkts` , `ecn-marked-octets` |
| ----------- | ----------- | ----------- |----------- |
|  **non-ECN (00)** | **below RED min-treshold**| not increments |not increments|
|  **non-ECN (00)** | **between RED min-treshold and max-threshold**| increments w/ probability rate derived form RED slope | not increments|
|  **non-ECN (00)** |**above RED max-treshold**|  increments |not increments|
|  **ECT (01)** | **below RED min-treshold**| not increments |not increments|
|  **ECT (01)** | **between RED min-treshold and max-threshold**| increments w/ probability rate derived form RED slope | increments w/ probability rate derived form RED slope|
|  **ECT (01)** |**above RED max-treshold**|  increments | increments|
|  **ECT (10)** | **below RED min-treshold**| not increments |not increments|
|  **ECT (10)** | **between RED min-treshold and max-threshold**| increments w/ probability rate derived form RED slope | increments w/ probability rate derived form RED slope|
|  **ECT (10)** |**above RED max-treshold**|  increments | increments|
|  **CE (11)** | **below RED min-treshold**| not increments |not increments|
|  **CE (11)** | **between RED min-treshold and max-threshold**| increments w/ probability rate derived form RED slope | not increments|
|  **CE (11)** |**above RED max-treshold**|  increments | not increments|

Change is backward compatible


### Platform Implementations

#### Arista: [link to documentation](https://www.arista.com/en/support/toi/eos-4-21-1f/14082-ecn-counters-per-tx-queue) 
 ```
show qos interface et25/3 ecn counters queue
Ethernet25/3:
   Tx-Queue             Marked Packets
-----------    -----------------------
 0                                   -
 2                                   -
 3                                   0
 4                                   0
 5                            10000000
 6                                   0
 7                                   0
 ```
Arista implements `ecn-selected-pkts`, `ecn-selected-octets`
 #### IExtreme Networks: [link to documentation](https://documentation.extremenetworks.com/slxos/sw/20xx/20.4.2/traffic/GUID-5A483239-25D1-4560-A25D-80C798150D00.shtml)
 ```
 device# show qos red statistics interface eth 0/1

Statistics for interface: Eth 0/1
        Port Statistics:
            Packets Dropped: 147, Queue Full Drops: 222, ECN Marked: 234
 ```
#### Dell/EMC  [link to documentation](https://www.dell.com/support/manuals/en-in/dell-emc-os-9/s6100-on-9.14.2.6-cli-pub/show-qos-statistics-wred-ecn?guid=guid-79d1b2a1-fb2e-4eaa-b390-cd6e5ccf120f&lang=en-us)
```

DellEMC#show qos statistics wred-ecn

--------------------ECN Packet Counter Details------------------------
Interface MarkedTxPkts TotalDropPkts(ECN Enabled Queues)
----------------------------------------------------------------------
Fo 1/32/1 122226925 122178941
Fo 1/1/1 340808237 169105794
Fo 1/17/1 0 0
```
#### [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/qos/70x/configuration/guide/b-qos-cg-8k-70x/congestion_avoidance.html#topic_dxq_fbh_q3b) example:
```
Router# show policy-map int hu 0/0/0/35 output 
TenGigE0/0/0/6 output: pm-out-queue

HundredGigE0/0/0/35 output: egress_qosgrp_ecn
 
Class tc7
  Classification statistics          (packets/bytes)     (rate - kbps)
    Matched             :           195987503/200691203072         0
    Transmitted         :           188830570/193362503680         0
    Total Dropped       :             7156933/7328699392           0
  Queueing statistics
    Queue ID                             : 18183
    Taildropped(packets/bytes)           : 7156933/7328699392
 
    WRED profile for
    RED Transmitted (packets/bytes)            : N/A
    RED random drops(packets/bytes)            : N/A
    RED maxthreshold drops(packets/bytes)      : N/A
    RED ecn marked & transmitted(packets/bytes): 188696802/193225525248
```
Cisco implements `ecn-marked-pkts`, `ecn-marked-octets`
