### PR TITLE
Remove default value for gRPC transport-security

### DIFF
--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,9 +22,15 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2023-09-19" {
+    description
+      "Minor patch to remove transport-security default of true";
+    reference "1.0.1";
+  }
 
   revision "2022-04-19" {
     description
@@ -152,11 +158,11 @@ module openconfig-system-grpc {
 
     leaf transport-security {
       type boolean;
-      default true;
       description
-        "Use gRPC transport security (e.g., SSL or TLS). Enabled by default.
-        This leaf allows transport security to be disabled for use cases that
-        are not supported, such as lab testing.";
+        "Use gRPC transport security (e.g., SSL or TLS). It is
+        recommended that transport-security be enabled at all times
+        except for use cases that are not supported, such as lab
+        testing.";
     }
 
     leaf certificate-id {


### PR DESCRIPTION
  * (M) release/models/system/openconfig-system-grpc.yang
    - Remove default value for gRPC transport-security since an
      implementation cannot enable by default without other mandatory
      TLS attributes

### Change Scope

* Remove `default=true` for gRPC transport-security.  While it is
  recommended/preferred to enable transport-security, a YANG default here
  implies that the listening server has the ability to enable TLS without other
  mandatory parameters such as a `certificate-id`, `mutual-authentication` (and
  other future attributes for mutual-authentication that do not yet exist)

### Platform Implementations

* N/A
