### PR TITLE
Add pipeline no-route counter

### DIFF
--- a/release/models/platform/openconfig-platform-pipeline-counters.yang
+++ b/release/models/platform/openconfig-platform-pipeline-counters.yang
@@ -65,9 +65,15 @@ module openconfig-platform-pipeline-counters {
     5 blocks, is to have the abililty to receive all drop counters from
     all 5 blocks, for example, with one request.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2023-09-26" {
+    description
+      "Add no-route aggregate drop counter.";
+    reference "0.5.0";
+  }
 
   revision "2023-02-03" {
     description
@@ -1114,6 +1120,16 @@ module openconfig-platform-pipeline-counters {
         packets are dropped due to failing uRPF lookup check.  This counter
         and the packet-processing-aggregate counter should be incremented
         for each uRPF packet drop.";
+    }
+
+    leaf no-route {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to no FIB entry for this ipv4 or ipv6 lookup.
+
+        This counter and the packet-processing-aggregate counter should be
+        incremented for each no-route packet drop.";
     }
 
   }


### PR DESCRIPTION
### Change Scope
Add pipeline drop counter for 'no-route`.   

This change is backwards compatible.

### Platform Implementations
* Cisco IOS XR inplements a `L3_ROUTE_LOOKUP_FAILED` counter
```
Trap Type                                     NPU  Trap  Punt       Punt  Punt  Punt Configured Hardware   Policer Avg-Pkt Packets              Packets
                                              ID   ID    Dest       VoQ   VLAN  TC   Rate(pps)  Rate(pps)  Level   Size    Accepted             Dropped
====================================================================================================================================================================
            
L3_ROUTE_LOOKUP_FAILED                        0    110  RPLC_CPU    265   1538  1    67         75         IFG     64      62553                4536519688
```

 * JunOS implements a variety of [packet drop counters](https://www.juniper.net/documentation/us/en/software/junos/junos-overview/topics/concept/using-show-commands-for-packet-drops.html), of which their Normal discard counter seems to include the condition for no route.
