### PR TITLE
Candidate Model for Repeated BGP set-communities/set-ext-communities

### DIFF
--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -1015,7 +1015,7 @@ module openconfig-bgp-policy {
       "Configuration data for referening a extended community-set
       in the set-ext-community action";
 
-    leaf ext-community-set-refs {
+    leaf-list ext-community-set-refs {
       type leafref {
         path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
           "oc-bgp-pol:bgp-defined-sets/" +

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -28,7 +28,16 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "6.1.1";
+  oc-ext:openconfig-version "6.2.0";
+
+  revision "2023-10-03" {
+    description
+      "Deprecate community-set-ref and ext-community-set-ref,
+      add the following leaf-list nodes:
+      * community-set-refs
+      * ext-community-set-refs";
+    reference "6.2.0";
+  }
 
   revision "2023-03-27" {
     description
@@ -831,7 +840,19 @@ module openconfig-bgp-policy {
       "Configuration data for referening a community-set in the
       set-community action";
 
+    leaf-list community-set-refs {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:community-sets/oc-bgp-pol:community-set/" +
+          "oc-bgp-pol:community-set-name";
+      }
+      description
+        "References a list of defined community sets by name";
+    }
+
     leaf community-set-ref {
+      status deprecated;
       type leafref {
         path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
           "oc-bgp-pol:bgp-defined-sets/" +
@@ -994,7 +1015,21 @@ module openconfig-bgp-policy {
       "Configuration data for referening a extended community-set
       in the set-ext-community action";
 
+    leaf ext-community-set-refs {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:ext-community-sets/" +
+          "oc-bgp-pol:ext-community-set/" +
+          "oc-bgp-pol:ext-community-set-name";
+      }
+      description
+        "References a list of defined extended community sets by
+        name";
+    }
+
     leaf ext-community-set-ref {
+      status deprecated;
       type leafref {
         path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
           "oc-bgp-pol:bgp-defined-sets/" +


### PR DESCRIPTION
### Change Scope

* Deprecating the old leaves in favour of leaf-lists with a plural name:
      * community-set-ref (deprecated) -> community-set-refs
      * ext-community-set-ref (deprecated) -> ext-community-set-refs
* This change is backwards-compatible.

Note: [`set-as-path-prepend`](https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-routing-policy.html#routing-policy-policy-definitions-policy-definition-statements-statement-actions-bgp-actions-set-as-path-prepend) may also be a candidate for being repeatable if it is supported by multiple platforms.

### Platform Implementations

 * Cisco: [link to documentation](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-0/routing/command/reference/rr40crs1book_chapter8.html#wp446732862)
 * Juniper: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-defining-bgp-communities-and-extended-communities-for-use-in-routing-policy-match-conditions.html)

```
leaf added: /openconfig-routing-policy/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-community/reference/config/community-set-refs ("openconfig-bgp-policy": openconfig-version 6.1.1 -> 6.2.0)
leaf added: /openconfig-routing-policy/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-community/reference/state/community-set-refs ("openconfig-bgp-policy": openconfig-version 6.1.1 -> 6.2.0)
leaf added: /openconfig-routing-policy/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-ext-community/reference/config/ext-community-set-refs ("openconfig-bgp-policy": openconfig-version 6.1.1 -> 6.2.0)
leaf added: /openconfig-routing-policy/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-ext-community/reference/state/ext-community-set-refs ("openconfig-bgp-policy": openconfig-version 6.1.1 -> 6.2.0)
```