### PR TITLE
Add BGP default import/export policy into global config

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -7,6 +7,7 @@ submodule openconfig-bgp-global {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-routing-policy { prefix oc-rpol; }
 
   // Include common submodules
   include openconfig-bgp-common;
@@ -26,7 +27,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description
@@ -397,6 +404,7 @@ submodule openconfig-bgp-global {
       uses bgp-common-global-group-use-multiple-paths;
       uses bgp-common-structure-neighbor-group-add-paths;
       uses bgp-global-mp-all-afi-safi-list-contents;
+      uses oc-rpol:default-policy-group;
     }
   }
 
@@ -482,6 +490,7 @@ submodule openconfig-bgp-global {
     }
 
     uses bgp-global-dynamic-neighbors;
+    uses oc-rpol:default-policy-group;
   }
 
 }

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,13 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.4.1";
+  oc-ext:openconfig-version "9.5.0";
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
 
   revision "2023-06-27" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,14 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.6.0";
+  oc-ext:openconfig-version "1.6.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
 
   revision "2023-05-01" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,14 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.6.0";
+  oc-ext:openconfig-version "1.6.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
 
   revision "2023-05-01" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,14 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.6.0";
+  oc-ext:openconfig-version "1.6.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
 
   revision "2023-05-01" {
     description
@@ -978,6 +985,7 @@ module openconfig-isis {
       "Policy governing the propagation of prefixes between levels.";
 
     uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
   }
 
   grouping isis-mpls-config {

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.2.0";
+  oc-ext:openconfig-version "4.2.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "4.2.1";
+  }
 
   revision "2023-09-07" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.2.0";
+  oc-ext:openconfig-version "4.2.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "4.2.1";
+  }
 
   revision "2023-09-07" {
     description
@@ -1223,6 +1230,7 @@ module openconfig-network-instance {
     }
 
     uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
   }
 
   grouping network-instance-config {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,7 +25,14 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,7 +23,14 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,7 +17,14 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,13 +23,20 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description
       "Add leaf metric to lsdb-summary-lsa-state.";
     reference "0.5.0";
-}
+  }
 
   revision "2023-08-09" {
     description
@@ -317,6 +324,7 @@ submodule openconfig-ospfv2-global {
     }
 
     uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
   }
 
   grouping ospfv2-global-max-metric-config {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,7 +22,14 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,13 +34,20 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
 
   revision "2023-08-25" {
     description
       "Add leaf metric to lsdb-summary-lsa-state.";
     reference "0.5.0";
-}
+  }
 
   revision "2023-08-09" {
     description

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -87,7 +87,14 @@ module openconfig-routing-policy {
     default value for the default-(import|export)-policy leaf must be
     applied.  See RFC6020 7.6.1 which applies to this model.";
 
-  oc-ext:openconfig-version "3.4.1";
+  oc-ext:openconfig-version "3.4.2";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "3.4.2";
+  }
 
   revision "2023-10-24" {
     description
@@ -1211,6 +1218,11 @@ module openconfig-routing-policy {
         for the current peer group, neighbor, address family,
         etc.";
     }
+  }
+
+  grouping default-policy-import-config {
+    description
+      "Configuration data for default import policy";
 
     leaf default-import-policy {
       type default-policy-type;
@@ -1219,7 +1231,6 @@ module openconfig-routing-policy {
         "explicitly set a default policy if no policy definition
         in the import policy chain is satisfied.";
     }
-
   }
 
   grouping apply-policy-export-config {
@@ -1241,6 +1252,11 @@ module openconfig-routing-policy {
         for the current peer group, neighbor, address family,
         etc.";
     }
+  }
+
+  grouping default-policy-export-config {
+    description
+      "Configuration data for default export policy";
 
     leaf default-export-policy {
       type default-policy-type;
@@ -1251,19 +1267,34 @@ module openconfig-routing-policy {
     }
   }
 
-
   grouping apply-policy-config {
     description
       "Configuration data for routing policies";
 
     uses apply-policy-import-config;
     uses apply-policy-export-config;
-
+    uses default-policy-config;
   }
 
+  grouping default-policy-config {
+    description
+      "Configuration data for default routing policies";
 
+    uses default-policy-import-config;
+    uses default-policy-export-config;
+  }
 
   grouping apply-policy-state {
+    description
+      "Operational state associated with routing policy";
+
+    uses default-policy-state;
+
+    //TODO: identify additional state data beyond the intended
+    //policy configuration.
+  }
+
+  grouping default-policy-state {
     description
       "Operational state associated with routing policy";
 
@@ -1299,6 +1330,35 @@ module openconfig-routing-policy {
 
         uses apply-policy-config;
         uses apply-policy-state;
+      }
+    }
+  }
+
+  grouping default-policy-group {
+     description
+      "Top level container for default routing policy applications.";
+
+    container apply-policy {
+      description
+        "Anchor point for routing policies in the model.
+        Import and export policies are with respect to the local
+        routing table, i.e., export (send) and import (receive),
+        depending on the context.";
+
+      container config {
+        description
+          "Policy configuration data.";
+
+        uses default-policy-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state for routing policy";
+
+        uses default-policy-config;
+        uses default-policy-state;
       }
     }
   }


### PR DESCRIPTION
### Change Scope
* The purpose of this change is to add a global level of default action for import/export policy. This configuration would be inherited by each neighbor/peer-group and the respective afi-safi.
* Add the following paths into .../bgp/global and .../bgp/global/afi-safis/afi-safi/
  * apply-policy/default-import-policy
  * apply-policy/default-export-policy
* Refactored apply-policy grouping to separate default from regular policy
  * Split `default-(import|export)-policy` leaves from `apply-policy-(import|export)-config` grouping
  * Created separate `default-policy-config` and `default-policy-group` grouping
    * `default-policy-config` houses `default-(import|export)-policy` groupings
    * `default-policy-group` contains the `config`/`state` containers with just the default policy leaves
  * Updated ISIS, BGP, OSPF, and table-connections groupings to use separate `default-policy-(import|export)-config` groupings
* This change is backwards compatible

#### Relevant pyang output:
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw global
                    +--rw apply-policy
                       +--rw config
                       |  +--rw default-import-policy?   default-policy-type
                       |  +--rw default-export-policy?   default-policy-type
                       +--ro state
                          +--ro default-import-policy?   default-policy-type
                          +--ro default-export-policy?   default-policy-type
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw global
                    +--rw afi-safis
                       +--rw afi-safi* [afi-safi-name]
                          +--rw apply-policy
                             +--rw config
                             |  +--rw default-import-policy?   default-policy-type
                             |  +--rw default-export-policy?   default-policy-type
                             +--ro state
                                +--ro default-import-policy?   default-policy-type
                                +--ro default-export-policy?   default-policy-type
```

### Platform Implementations

 * Arista: [link to documentation](https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1117976)
 