### PR TITLE
Adapt mtu range to support Linux loopback max MTU of 65536

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,13 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2023-10-11" {
+    description
+      "Adapt mtu range to support Linux loopback max MTU of 65536";
+    reference "3.6.0";
+  }
 
   revision "2023-07-14" {
     description
@@ -416,7 +422,9 @@ module openconfig-interfaces {
     }
 
     leaf mtu {
-      type uint16;
+      type uint32 {
+        range 68..65536;
+      }
       description
         "Set the max transmission unit size in octets
         for the physical interface.  If this is not set, the mtu is


### PR DESCRIPTION
### Change Scope

* Extend the range of the allowed MTU to 65536 instead of max 65535
* Changes the type from uint16 to uint32 and adds range restriction
### Platform Implementations

 * Linux loopback MTU value: https://elixir.bootlin.com/linux/latest/source/drivers/net/loopback.c#L203

### Other

See discussion in https://github.com/openconfig/public/issues/129
