### PR TITLE
routing-policy: new explicit action and behaviour clarification

### DIFF
--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -77,7 +77,16 @@ module openconfig-routing-policy {
     the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2022-10-11" {
+    description
+      "Adding explicit policy statement action of NEXT_STATEMENT. Defining
+      default policy statement action as REJECT.
+      Clarify behaviour if given route is not explicitly accepted or rejected in
+      any of statement of any of policies on the list";
+    reference "3.4.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -166,6 +175,14 @@ module openconfig-routing-policy {
       }
       enum REJECT_ROUTE {
         description "Policy rejects the route";
+      }
+      enum NEXT_STATEMENT {
+        description "Route is passed to next statement for evaluation.
+          If current statement is last in policy, route is passed to next policy
+          (if exists).
+          If current statement is last one in last policy, route is REJECTED,
+          unless other configuration or standard (e.g. RFC8212) state 
+          different explicitly";
       }
     }
     description
@@ -738,9 +755,10 @@ module openconfig-routing-policy {
 
     leaf policy-result {
       type policy-result-type;
+      default NEXT_STATEMENT;
       description
         "Select the final disposition for the route, either
-        accept or reject.";
+        accept, reject or pass to next statement for evaluation.";
     }
   }
 

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -181,7 +181,7 @@ module openconfig-routing-policy {
           If current statement is last in policy, route is passed to next policy
           (if exists).
           If current statement is last one in last policy, route is REJECTED,
-          unless other configuration or standard (e.g. RFC8212) state 
+          unless other configuration or standard (e.g. RFC8212) state
           different explicitly";
       }
     }


### PR DESCRIPTION
This PR:
* Adding new option for  policy statement action "NEXT_STATEMENT". 
* Defining default policy statement action as REJECT, if leaf is omitted in setRequest.
* Clarify behaviour if given route is not explicitly accepted or rejected in
      any of statement of any of policies on the list";

This is (potentially) breaking change due to introduction of defaul value.

### Platform Implementations
The are subtele differences among implementations

#### JUNIPER JUNOS: [Actions in Routing Policy Terms](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-configuring-actions-in-routing-policy-terms.html) 
 ```
[edit policy-options policy-statement policy-name term term-name]
then {
    accept|reject|next-term;
}
 ```
Mapping to this proposal. The \* indicate implicit default action.

|This proposal|JUNOS|
|---|---|
|ROUTE_ACCEPT|accept|
|ROUTE_REJECT*|reject|
|NEXT_STATEMENT|next-term*|

Note: JUNOS support few more flow-controll actions

#### CISCO IOS-XR: [Polixy Statement disposition ](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/70x/b-routing-cg-cisco8000-70x/implementi-routing-policy.html#concept_psf_g3p_h3b)

Mapping to this proposal. The \* indicate implicit default action.

|This proposal|IOS-XR RPL|
|---|---|
|ROUTE_ACCEPT| N/A *|
|ROUTE_REJECT*|drop*|
|NEXT_STATEMENT|N/A ("pass" is similar but not exact)|

Note:
  - IOS-XR do not have explicit equivalent of OpenConfig  ROUTE_ACCEPT. If statement is modifying any route attribute, route is implicitly accepted and no further statement are evaluated. If statement do not modify any attribute, route is implicitly dropped.
  - IOS-XR "pass" is similar to OpenConfig NEXT_SATEMENT, except it mark route as t"conditionally accepted" if not rejected by subsequent statement.

#### ARISTA EOS [Route Maps](https://www.arista.com/en/um-eos/eos-acls-and-route-maps#xx1149611)

Mapping to this proposal. The \* indicate implicit default action.

|This proposal|IOS-XR RPL|
|---|---|
|ROUTE_ACCEPT| permit|
|ROUTE_REJECT*|deny|
|NEXT_STATEMENT| continue |

Note:
The "permit" or "deny" are mandatory, hence ther is no implicit action. When "continue" also present, action of highes matching statement is applied.
