### PR TITLE
Configuring send-community per AFI-SAFI at neighbor/peer-group (#969)

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,16 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description
@@ -253,6 +262,15 @@ submodule openconfig-bgp-common-multiprotocol {
       description
         "This leaf indicates whether the AFI-SAFI is
         enabled for the neighbor or group";
+    }
+
+    leaf-list send-community-type {
+      type oc-bgp-types:community-type;
+      description
+        "Specify which types of community should be sent to the
+        neighbor or group. The default is to not send the
+        community attribute. This takes precedence over the neighbor
+        or group configuration";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,16 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,16 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,16 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,16 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,16 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,16 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description


### PR DESCRIPTION
This is a  continuation of #843, where the wrong grouping was changed

### Change Scope

* Allowing send-community to be configured not only per neighbor/peer-group, but also per AFI-SAFI inside neighbor/peerg-group making the configuration more flexible.
* This change is backwards compatible.

### Platform Implementations

* Huawei [https://support.huawei.com/enterprise/en/doc/EDOC1100008283/bbae5056/peer-advertise-community]: the peer configuration is done inside the address-family, so the peer-advertise-community configuration is done per peer+afi/safi
* Juniper [https://www.juniper.net/documentation/en_US/junose15.1/topics/reference/command-summary/neighbor-send-community.html]: Configuration mode indicates the config can be done per address-family
* FRR [https://docs.frrouting.org/en/latest/bgp.html]: Then configuration example show send-community parameter is also configured in address-family mode

```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw name                              -> ../config/name
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw identifier          -> ../config/identifier
              +--rw name                -> ../config/name
              +--rw bgp
                 +--rw global
                 |  +--rw afi-safis
                 |     +--rw afi-safi* [afi-safi-name]
                 |        +--rw afi-safi-name              -> ../config/afi-safi-name
                 |        +--rw config
                 |        |  +--rw afi-safi-name?         identityref
                 |        |  +--rw enabled?               boolean
                 |        |  +--rw send-community-type   oc-bgp-types:community-type
                 |        +--ro state
                 |           +--ro afi-safi-name?         identityref
                 |           +--ro enabled?               boolean
                 |           +--ro send-community-type   oc-bgp-types:community-type
                 |           +--ro total-paths?           uint32
                 |           +--ro total-prefixes?        uint32
                 +--rw neighbors
                 |  +--rw neighbor* [neighbor-address]
                 |     +--rw neighbor-address      -> ../config/neighbor-address
                 |     +--rw config
                 |     |  +--rw peer-group?            -> ../../../../peer-groups/peer-group/peer-group-name
                 |     |  +--rw ...
                 |     |  **+--rw send-community-type*   oc-bgp-types:community-type**
                 |     +--ro state
                 |     |  +--ro peer-group?                   -> ../../../../peer-groups/peer-group/peer-group-name
                 |     |  +--ro ...
                 |     |  **+--ro send-community-type*          oc-bgp-types:community-type**
                 |     +--rw afi-safis
                 |        +--rw afi-safi* [afi-safi-name]
                 |           +--rw afi-safi-name           -> ../config/afi-safi-name
                 |           +--rw config
                 |           |  +--rw afi-safi-name?         identityref
                 |           |  +--rw enabled?               boolean
                 |           |  **+--rw send-community-type*   oc-bgp-types:community-type**   <-- NEW LEAF-LIST
                 |           +--ro state
                 |              +--ro afi-safi-name?         identityref
                 |              +--ro enabled?               boolean
                 |              **+--ro send-community-type*   oc-bgp-types:community-type**   <-- NEW LEAF-LIST
                 |              +--ro active?                boolean
                 +--rw peer-groups
                    +--rw peer-group* [peer-group-name]
                       +--rw peer-group-name       -> ../config/peer-group-name
                       +--rw config
                       |  +--rw peer-group-name?       string
                       |  +--rw ...
                       |  **+--rw send-community-type*   oc-bgp-types:community-type**
                       +--ro state
                       |  +--ro peer-group-name?       string
                       |  +--ro ...
                       |  **+--ro send-community-type*   oc-bgp-types:community-type**
                       +--rw afi-safis
                          +--rw afi-safi* [afi-safi-name]
                             +--rw afi-safi-name           -> ../config/afi-safi-name
                             +--rw config
                             |  +--rw afi-safi-name?         identityref
                             |  +--rw enabled?               boolean
                             |  **+--rw send-community-type*   oc-bgp-types:community-type**   <-- NEW LEAF-LIST
                             +--ro state
                                +--ro afi-safi-name?         identityref
                                +--ro enabled?               boolean
                                **+--ro send-community-type*   oc-bgp-types:community-type**   <-- NEW LEAF-LIST
```