### PR TITLE
add uptime and promote system to v1

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,7 +47,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.17.1";
+  oc-ext:openconfig-version "1.0.0";
+
+revision "2023-10-26" {
+    description
+      "Add up-time leaf and promote module to version 1.0.";
+    reference "1.0.0";
+  }
 
   revision "2023-06-16" {
     description
@@ -369,6 +375,14 @@ module openconfig-system {
         type oc-yang:date-and-time;
         description
           "The current system date and time.";
+    }
+
+    leaf up-time {
+        type oc-types:timeticks64;
+        units "nanoseconds";
+        description
+          "The amount of time since the network operating system was 
+          initialized.";
     }
 
     leaf boot-time {


### PR DESCRIPTION
### Change Scope

* Add /system/up-time
* Bump the openconfig-system module to version 1.0
* This change is backwards compatible
 
### Platform Implementations

 * [Cisco XROS show version](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-management/b-system-management/m-hardware-redundancy-commands.html) 
 * [JunOS show system uptime](https://www.juniper.net/documentation/us/en/software/junos/junos-overview/topics/ref/command/show-system-uptime.html)
