### PR TITLE
Fixing the name of the set-metric-type leaf under is-is policy condition

### DIFF
--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -34,12 +34,6 @@ module openconfig-isis-policy {
     reference "0.8.0";
   }
 
-  revision "2023-11-02" {
-    description
-      "Fixing name of condition set-metric-type leaf. There should be no prefix 'set' in the name.";
-    reference "0.8.0";
-  }
-
   revision "2023-04-28" {
     description
       "Adding set metric-type leaf";

--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -28,6 +28,12 @@ module openconfig-isis-policy {
 
   oc-ext:openconfig-version "0.7.0";
 
+  revision "2023-11-02" {
+    description
+      "Fixing name of condition set-metric-type leaf. There should be no prefix 'set' in the name.";
+    reference "0.8.0";
+  }
+
   revision "2023-04-28" {
     description
       "Adding set metric-type leaf";
@@ -151,10 +157,10 @@ module openconfig-isis-policy {
         within it";
     }
 
-    leaf set-metric-type {
+    leaf match-metric-type {
       type isis-types:metric-type;
       description
-        "Set the type of the route to redistribute to INTERNAL or EXTERNAL";
+        "Matches the type of the route to redistribute to INTERNAL or EXTERNAL";
     }
   }
 

--- a/release/models/isis/openconfig-isis-policy.yang
+++ b/release/models/isis/openconfig-isis-policy.yang
@@ -26,7 +26,13 @@ module openconfig-isis-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2023-11-02" {
+    description
+      "Fixing name of condition set-metric-type leaf. There should be no prefix 'set' in the name.";
+    reference "0.8.0";
+  }
 
   revision "2023-11-02" {
     description


### PR DESCRIPTION

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/external-contributions-guide.md]

### Change Scope

Making a fix to a leaf name. Was set-metric-type under ISIS policy conditions, now called match-condition-type.
The previous leaf name is incorrect because we are not doing a set of the metric type we are matching.

- Change is not backward compatible, but the field was just added by my team so it has a low probability is being utilized. A name change is required for the proper use of this leaf.

### Platform Implementations

was originally added and discussed in #863. There you can see examples where the field is called metric-type under a match branch. Thus, this change is supported in the community as proper naming.



[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].
