### PR TITLE
Clarify interface TESTING mode

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -612,8 +612,9 @@ module openconfig-interfaces {
             "The interface is should be treated as if in admin-down state for
             control plane protocols.  In addition, while in TESTING state the
             device should remove the interface from aggregate interfaces.
-            This state may be set by the device as part of a transaction such
-            as gNOI Link Qualification Service.";
+            An interface transition to the TESTING state based on a qualification 
+            workflow, or internal device triggered action - such as the gNOI Link
+            Qualification service";
             reference
               "gNOI Link Qualification Service
                https://github.com/openconfig/gnoi/blob/main/packet_link_qualification/index.md";

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -612,7 +612,7 @@ module openconfig-interfaces {
             "The interface is should be treated as if in admin-down state for
             control plane protocols.  In addition, while in TESTING state the
             device should remove the interface from aggregate interfaces.
-            An interface transition to the TESTING state based on a qualification 
+            An interface transition to the TESTING state based on a qualification
             workflow, or internal device triggered action - such as the gNOI Link
             Qualification service";
             reference

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -609,7 +609,7 @@ module openconfig-interfaces {
         }
         enum TESTING {
           description
-            "The interface is should be treated as if in admin-down state for
+            "The interface should be treated as if in admin-down state for
             control plane protocols.  In addition, while in TESTING state the
             device should remove the interface from aggregate interfaces.
             An interface transition to the TESTING state based on a qualification

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,15 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.7.0";
+
+  revision "2023-11-06" {
+      description
+        "Clarify description for admin-status TESTING.";
+      reference
+        "3.7.0";
+  }
+
   revision "2023-08-29" {
       description
         "Add augment for penalty-based additive-increase, exponential-decrease link damping algorithm.";
@@ -600,11 +608,15 @@ module openconfig-interfaces {
             "Not ready to pass packets and not in some test mode.";
         }
         enum TESTING {
-          //TODO: This is generally not supported as a configured
-          //admin state, though it's in the standard interfaces MIB.
-          //Consider removing it.
           description
-            "In some test mode.";
+            "The interface is should be treated as if in admin-down state for
+            control plane protocols.  In addition, while in TESTING state the
+            device should remove the interface from aggregate interfaces.
+            This state may be set by the device as part of a transaction such
+            as gNOI Link Qualification Service.";
+            reference
+              "gNOI Link Qualification Service
+               https://github.com/openconfig/gnoi/blob/main/packet_link_qualification/index.md";
         }
       }
       //TODO:consider converting to an identity to have the
@@ -636,7 +648,7 @@ module openconfig-interfaces {
         enum TESTING {
           value 3;
           description
-            "In some test mode.  No operational packets can
+            "In test mode.  No operational packets can
              be passed.";
         }
         enum UNKNOWN {


### PR DESCRIPTION
### Change Scope

* Clarify the description of TESTING mode for interfaces.
* This change is backwards compatible.

### Platform Implementations
 * This mode is in development by multiple vendors to support [gNOI link qualification](https://github.com/openconfig/gnoi/blob/main/packet_link_qualification/index.md).
 * An [OpenConfig feature profiles test](https://github.com/openconfig/featureprofiles/tree/e91835ce37a73474f9e7ac59c50c0b78b946ec9f/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test) exercises this functionality.
 