### PR TITLE
Changing type for NTP fields in openconfig-system.yang

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -753,7 +753,7 @@ module openconfig-system {
     }
 
     leaf root-delay {
-      type uint32;
+      type oc-types:ieeefloat32;
       // TODO: reconsider units for these values -- the spec defines
       // rootdelay and rootdisperson as 2 16-bit integers for seconds
       // and fractional seconds, respectively.  This gives a
@@ -770,7 +770,7 @@ module openconfig-system {
     }
 
     leaf root-dispersion {
-      type uint64;
+      type oc-types:ieeefloat32;
       units "milliseconds";
       description
         "Dispersion (epsilon) represents the maximum error inherent
@@ -781,7 +781,7 @@ module openconfig-system {
     }
 
     leaf offset {
-      type uint64;
+      type oc-types:ieeefloat32;
       units "milliseconds";
       description
         "Estimate of the current time offset from the peer.  This is


### PR DESCRIPTION
Changing type for root-delay, root-dispersion and offset
from uint32, uint64 and uint64 respectively to oc-types:ieeefloat32

* type has been changed for 3 NTP fields in openconfig-system.yang
https://github.com/openconfig/public/blob/master/release/models/system/openconfig-system.yang

 * Implementation A: In NTP RFC 5905, these fields are defined as floating point numbers and implemented as floating point numbers.
 https://datatracker.ietf.org/doc/html/rfc5905

This difference in type has resulted in implementations to deviate these fields as not-supported.