### PR TITLE
Allow IP addresses in AFT nexthops to be zoned.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -300,7 +300,7 @@ submodule openconfig-aft-common {
     }
 
     leaf ip-address {
-      type oc-inet:ip-address;
+      type oc-inet:ip-address-zoned;
       description
         "The IP address of the next-hop system.";
     }

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2023-11-29" {
+    description
+      "Allow a zone to be used in a next-hop IP address.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description


### PR DESCRIPTION
### Change Scope

* Relaxes the regexp on afts/nexthops/nexthop/state/ip-address to allow for zoned IPv4 and IPv6 values.
* This change is backwards compatible.

### Platform Implementations

### Nokia SRL

```
--{ + running }--[  ]--
A:srl# info network-instance mgmt static-routes
    network-instance mgmt {
        static-routes {
            route 2001:db8::/32 {
                next-hop-group nhop
            }
        }
    }
--{ + running }--[  ]--
A:srl# info network-instance mgmt next-hop-groups
    network-instance mgmt {
        next-hop-groups {
            group nhop {
                nexthop 0 {
                    ip-address fe80::1%mgmt0.0
                    resolve false
                }
            }
        }
    }
--{ + running }--[  ]--
A:srl# show network-instance mgmt  route-table ipv6-unicast prefix 2001:db8::/32 detail
--------------------------------------------------------------------------------------------------------------------------------------------------------
IPv6 unicast route table of network instance mgmt
--------------------------------------------------------------------------------------------------------------------------------------------------------
Destination            : 2001:db8::/32
ID                     : 0
Route Type             : static
Route Owner            : static_route_mgr
Origin Network Instance: mgmt
Metric                 : 1
Preference             : 5
Active                 : true
Last change            : 2023-11-30T02:26:48.203Z
Resilient hash         : false
```

### Arista EOS

Configured with `ipv6 route 2001:db8::/32 Po1 fe80::1` this is a scoped route to a single interface.

### Cisco XR

Configured with:

```
router static
	address-family ipv6 unicast
		2001:db8::/32 bundle-ether1 fe80::1
```

this is a statically scoped entry.

