### PR TITLE
Update openconfig-transport-types.yang

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,14 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.20.0";
+  oc-ext:openconfig-version "0.21.0";
+
+  revision "2023-08-03" {
+    description
+      "Add new PMDs: ETH_100GBASE_ER4L (MSA\100GBASE-ER4 Lite),
+      ETH_1GBASE_LX10. ETH_40GBASE_ACU10M and ETH_100GBASE_CU5M";
+    reference "0.21.0";
+  }
 
   revision "2023-08-03" {
     description
@@ -989,6 +996,11 @@ module openconfig-transport-types {
       "Ethernet compliance codes (PMD) supported by transceivers";
   }
 
+  identity ETH_1GBASE_LX10 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: ETH_1GBASE_LX10";
+  }
+
   identity ETH_10GBASE_LRM {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 10GBASE_LRM";
@@ -1039,6 +1051,11 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 40GBASE_PSM4";
   }
 
+  identity ETH_40GBASE_ACU10M {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: ETH_40GBASE_ACU10M";
+  }
+
   identity ETH_4X10GBASE_LR {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 4x10GBASE_LR";
@@ -1074,6 +1091,11 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 100GBASE_LR4";
   }
 
+  identity ETH_100GBASE_ER4L {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_ER4L";
+  }
+
   identity ETH_100GBASE_ER4 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 100GBASE_ER4";
@@ -1107,6 +1129,11 @@ module openconfig-transport-types {
   identity ETH_100GBASE_DR {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 100GBASE_DR";
+  }
+
+  identity ETH_100GBASE_CU5M {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_CU5M";
   }
 
   identity ETH_400GBASE_ZR {


### PR DESCRIPTION
Aditional PMD types

### Change Scope

Using the openconfig-platform model to discover the transceivers in our network, we discovered some cases that require a new type in Openconfig PMD.
identity ETH_100GBASE_ER4L: Defined in MSA\100GBASE-ER4 Lite 
identity ETH_1GBASE_LX10:  (note that the SFP MSA has also EX, ZX... )
identity ETH_40GBASE_ACU10M (this one and the next I would like to discuss what to do with other distances, I see that there is wide variety that are reported by the devices)
 identity ETH_100GBASE_CU5M

### Platform Implementations

The proposed codes are ethernet standards and available to use in all the platforms using plugables. No proprietary modes are included. 
