### PR TITLE
Adding support for operational state representing interface rates.

### DIFF
--- a/release/models/interfaces/.spec.yml
+++ b/release/models/interfaces/.spec.yml
@@ -8,6 +8,7 @@
     - yang/interfaces/openconfig-if-poe.yang
     - yang/interfaces/openconfig-if-ip-ext.yang
     - yang/interfaces/openconfig-if-8021x.yang
+    - yang/interfaces/openconfig-if-rates.yang
     - yang/vlan/openconfig-vlan.yang
     - yang/interfaces/openconfig-if-tunnel.yang
     - yang/platform/openconfig-platform-port.yang
@@ -26,6 +27,7 @@
     - yang/interfaces/openconfig-if-poe.yang
     - yang/interfaces/openconfig-if-ip-ext.yang
     - yang/interfaces/openconfig-if-8021x.yang
+    - yang/interfaces/openconfig-if-rates.yang
     - yang/vlan/openconfig-vlan.yang
     - yang/interfaces/openconfig-if-tunnel.yang
     - yang/platform/openconfig-platform-port.yang

--- a/release/models/interfaces/openconfig-if-rates.yang
+++ b/release/models/interfaces/openconfig-if-rates.yang
@@ -1,0 +1,114 @@
+module openconfig-if-rates {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/interfaces/rates";
+
+  prefix "oc-if-rates";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix "oc-if"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state for interface rates.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2024-04-02 {
+    description
+      "Augment of /interfaces/interface to include interface rates.";
+    reference
+      "0.1.0";
+  }
+
+  grouping interface-rates-config {
+    description
+      "Grouping of interface rates related configuration";
+
+    leaf load-interval {
+      type uint16 {
+        range "1..600";
+      }
+      units "seconds";
+      default 300;
+      description
+        "The interval of interface rates calculation in seconds";
+    }
+  }
+
+  grouping interface-rates-state {
+    description
+      "Grouping of interface rates with different direction and units";
+
+    leaf load-interval {
+      type uint16;
+      units "seconds";
+      description
+        "The interval of interface rates calculation in seconds";
+    }
+
+    leaf out-bits-rate {
+      type uint64;
+      units "bps";
+      description
+        "The calculated transmitted rate of the interface, measured in bits
+        per second.";
+    }
+
+    leaf in-bits-rate {
+      type uint64;
+      units "bps";
+      description
+        "The calculated received rate of the interface, measured in bits
+        per second.";
+    }
+
+    leaf out-pkts-rate {
+      type uint64;
+      units "pps";
+      description
+        "The calculated transmitted rate of the interface, measured in packets
+        per second.";
+    }
+
+    leaf in-pkts-rate {
+      type uint64;
+      units "pps";
+      description
+        "The calculated received rate of the interface, measured in packets
+        per second.";
+    }
+  }
+
+  augment "/oc-if:interfaces/oc-if:interface" {
+    description
+      "Adds interface rates.";
+
+    container rates {
+      description
+        "Enclosing container for interface rates.";
+
+      container config {
+        description
+          "Enclosing container for interface rates related configuration";
+
+        uses interface-rates-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Enclosing container for operational state representing
+          interface rates.";
+
+        uses interface-rates-state;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Change Scope

* Adding support for configuration and operational state representing interface rates under `/interfaces/interface`.  Given an interface, the load-interval (the interval of interface rates calculation in seconds) is configurable.  Also, given an interface, the operational state will expose ingress/egress rates in units of bits-per-second (bps) and packets-per-second (pps).
* This change is backwards compatible.

pyang output:
```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-if-rates:rates
           +--rw oc-if-rates:config
           |  +--rw oc-if-rates:load-interval?   uint16
           +--ro oc-if-rates:state
              +--ro oc-if-rates:load-interval?   uint16
              +--ro oc-if-rates:out-bits-rate?   uint64
              +--ro oc-if-rates:in-bits-rate?    uint64
              +--ro oc-if-rates:out-pkts-rate?   uint64
              +--ro oc-if-rates:in-pkts-rate?    uint64
```

### Platform Implementations

 * Arista `show interfaces counters rate`: [link to documentation](https://www.arista.com/en/um-eos/eos-ethernet-ports#xx1143927)
*  [Cisco IOSXR](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/system_monitoring/command/reference/b-sysmon-cr-asr9k/b-sysmon-cr-asr9k_chapter_0111.html#wp1787771667) supports 600 as the max in 30 second increments.  
* Nokia SRLinux [info from state interface](https://infocenter.nokia.com/public/SRLINUX213R1A/index.jsp?topic=%2Fcom.srlinux.configbasics%2Fhtml%2Fconfigb-interfaces.html) command supports showing a traffic rate, but does not expose a configuration for the `load-interval` over which the rate is averaged.
* JunOS [show interfaces <interface_name> extensive](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/command/show-interfaces-extensive.html) shows a bits per second rate, but does not expose a configuration for the `load-interval` over which the rate is averaged.