### PR TITLE
Add support for vni-peer-group container

### DIFF
--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -44,7 +44,7 @@ module openconfig-evpn {
 
   revision "2023-12-12" {
    description
-     "Add vni-peer-group container";
+     "Add vni-peer-groups container";
    reference   "0.7.0";
   }
 
@@ -917,7 +917,7 @@ module openconfig-evpn {
               "Container for state parameters related to this VTEP peer";
             uses evpn-endpoint-peer-state;
         }
-        container vni-peer-group {
+        container vni-peer-groups {
           config false;
           description
             "Container for associating ingress and egress VNIs to router MACs";

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,13 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2023-12-12" {
+   description
+     "Add vni-peer-group container";
+   reference   "0.7.0";
+  }
 
   revision "2023-07-12" {
    description
@@ -911,6 +917,49 @@ module openconfig-evpn {
               "Container for state parameters related to this VTEP peer";
             uses evpn-endpoint-peer-state;
         }
+        container vni-peer-group {
+          config false;
+          description
+            "Container for associating ingress and egress VNIs to router MACs";
+          list vni-peer-group {
+            key "cp-vni egress-vni";
+            description
+              "List of VNI peer groups";
+            leaf cp-vni {
+              type leafref {
+                path "../state/cp-vni";
+              }
+              description
+                "A reference to the control-plane VNI for the VNI peer group";
+            }
+            leaf egress-vni {
+              type leafref {
+                path "../state/egress-vni";
+              }
+              description
+                "A reference to the egress VNI for the VNI peer group";
+            }
+
+            container state {
+              description "State container for the VNI peer group";
+              config false;
+
+              leaf cp-vni {
+                type oc-evpn-types:vni-id;
+                description
+                  "The control-plane VNI discovered behind this peer VTEP";
+              }
+              leaf egress-vni {
+                type oc-evpn-types:vni-id;
+                description "Egress VNI associated with the remote VTEP";
+              }
+              leaf router-mac {
+                type oc-yang:mac-address;
+                description "MAC address of the remote VTEP";
+              }
+            }
+          }
+        }
       }
     }
 
@@ -978,6 +1027,7 @@ module openconfig-evpn {
 
     leaf-list control-plane-vnis {
       type oc-evpn-types:vni-id;
+      status deprecated;
       description
         "The control-plane VNIs are all of the VNIs that are discovered by the
         control-plane behind this peer VTEP";
@@ -985,6 +1035,7 @@ module openconfig-evpn {
 
     leaf router-mac {
       type oc-yang:mac-address;
+      status deprecated;
       description "MAC address of the remote VTEP";
     }
   }


### PR DESCRIPTION
### Change Scope

The changes introduce operational state properties only.

* Deprecate two properties `control-plane-vnis` and `router-mac`
    * This means the properties will be supported but deprecated and removed in a future OC model release
* Add the new container structure `vni-peer-group` which allows the association between `cp-vni-id`, `egress-vni` and `router-mac`
* Keying on both `cp-vni` and `egress-vni` allows flexibility for both symmetric and asymmetric use cases.  For symmetric VNIs both keys would be set to the same value.
* The change is backwards compatible

### Tree Structure

```bash
        |           +--rw vxlan
        |              +--rw config
        |              |  +--rw description?        string
        |              |  +--rw enabled?            boolean
        |              |  +--rw source-interface?   string
        |              +--ro state
        |              |  +--ro description?        string
        |              |  +--ro enabled?            boolean
        |              |  +--ro source-interface?   string
        |              +--ro endpoint-peers
        |              |  +--ro endpoint-peer* [peer-address]
        |              |     +--ro peer-address      -> ../state/peer-address
        |              |     +--ro state
        |              |     |  +--ro peer-address?         oc-inet:ip-address
        |              |     |  +--ro peer-state?           enumeration
        |              |     |  +--ro uptime?               oc-types:timeticks64
        |              |     |  x--ro control-plane-vnis*   oc-evpn-types:vni-id
        |              |     |  x--ro router-mac?           oc-yang:mac-address
        |              |     +--ro vni-peer-group
        |              |        +--ro vni-peer-group* [cp-vni egress-vni]
        |              |           +--ro cp-vni        -> ../state/cp-vni
        |              |           +--ro egress-vni    -> ../state/egress-vni
        |              |           +--ro state
        |              |              +--ro cp-vni?       oc-evpn-types:vni-id
        |              |              +--ro egress-vni?   oc-evpn-types:vni-id
        |              |              +--ro router-mac?   oc-yang:mac-address
        |              +--ro endpoint-vnis
```
With new counters included in the output

```bash
        |           +--rw vxlan
        |              +--rw config
        |              |  +--rw description?        string
        |              |  +--rw enabled?            boolean
        |              |  +--rw source-interface?   string
        |              +--ro state
        |              |  +--ro description?        string
        |              |  +--ro enabled?            boolean
        |              |  +--ro source-interface?   string
        |              +--ro endpoint-peers
        |              |  +--ro endpoint-peer* [peer-address]
        |              |     +--ro peer-address       -> ../state/peer-address
        |              |     +--ro state
        |              |     |  +--ro peer-address?         oc-inet:ip-address
        |              |     |  +--ro peer-state?           enumeration
        |              |     |  +--ro uptime?               oc-types:timeticks64
        |              |     |  x--ro control-plane-vnis*   oc-evpn-types:vni-id
        |              |     |  x--ro router-mac?           oc-yang:mac-address
        |              |     |  +--ro counters
        |              |     |     +--ro total-encap-pkts?           oc-yang:counter64
        |              |     |     +--ro total-encap-bytes?          oc-yang:counter64
        |              |     |     +--ro bum-encap-pkts?             oc-yang:counter64
        |              |     |     +--ro total-decap-pkts?           oc-yang:counter64
        |              |     |     +--ro total-decap-bytes?          oc-yang:counter64
        |              |     |     +--ro unicast-decap-pkts?         oc-yang:counter64
        |              |     |     +--ro bum-decap-pkts?             oc-yang:counter64
        |              |     |     +--ro bum-decap-multicast-pkts?   oc-yang:counter64
        |              |     |     +--ro bum-decap-ir-pkts?          oc-yang:counter64
        |              |     |     +--ro drop-decap-pkts?            oc-yang:counter64
        |              |     |     +--ro except-decap-pkts?          oc-yang:counter64
        |              |     +--ro vni-peer-groups
        |              |        +--ro vni-peer-group* [cp-vni egress-vni]
        |              |           +--ro cp-vni        -> ../state/cp-vni
        |              |           +--ro egress-vni    -> ../state/egress-vni
        |              |           +--ro state
        |              |              +--ro cp-vni?       oc-evpn-types:vni-id
        |              |              +--ro egress-vni?   oc-evpn-types:vni-id
        |              |              +--ro router-mac?   oc-yang:mac-address
        |              +--ro endpoint-vnis
```

### Platform Implementations

 * Cisco NXOS: [link to documentation](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/vxlan/configuration/guide/b-cisco-nexus-9000-series-nx-os-vxlan-configuration-guide-93x/b-cisco-nexus-9000-series-nx-os-vxlan-configuration-guide-93x_chapter_0101.html#Cisco_Concept.dita_f63f1c72-6039-4166-9cae-287ae3d6ab17)

```bash
switch# show nve peers control-plane-vni peer-ip 203.1.1.1
Peer       VNI     Learn-Source Gateway-MAC     Peer-type  Egress-VNI SW-BD  State                 
---------  -----   ------------ --------------- ---------- ---------- -----  ----------------------
203.1.1.1  2000003 BGP          f40f.1b6f.f8db   FAB        3000003      3005   peer-vni-add-complete
```

 * Nokia: [link to documentation](https://infocenter.nokia.com/public/7750SR227R1A/index.jsp?topic=%2Fcom.nokia.L2_Services_and_EVPN_Guide%2Fstatic_vxlan_te-ai9enrmqcl.html)
     * From the document: VNIs configured in static VXLAN instances are ‟symmetric”, that is, the same ingress and egress VNIs are used for VXLAN packets using that instance. Note that asymmetric VNIs are actually possible in EVPN VXLAN instances.



