### PR TITLE
Static route next-hops in zoned format

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,13 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.0.2";
+
+  revision "2023-12-12" {
+    description
+      "Update static route nexthop to support zoned address format.";
+    reference "2.0.2";
+  }
 
   revision "2022-11-01" {
     description
@@ -221,7 +227,7 @@ module openconfig-local-routing {
 
     leaf next-hop {
       type union {
-        type inet:ip-address;
+        type inet:ip-address-zoned;
         type local-defined-next-hop;
       }
       description


### PR DESCRIPTION
This code is a Contribution to the OpenConfig Public project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.

Change Scope
Static route next-hops should support the ip-address-zoned format. This is needed if you want to statically route traffic towards an IPv6 link-local address on a specific interface.
This change is backwards compatible

Platform Implementations
Arista eos - https://www.arista.com/en/um-eos/eos-nexthop-groups (see section on Support for IPv6 Link-Local Addresses in Nexthop Groups Entries)
Nokia SRLinux - https://documentation.nokia.com/srlinux/23-10/books/config-basics/network-instances.html#configuring-static-routes