### PR TITLE
Add DEFAULT_INSTANCE under connection-points endpoints

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,13 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.2.2";
+  oc-ext:openconfig-version "4.3.0";
+
+  revision "2023-12-13" {
+    description
+      "Expand when statement for connection-points endpoints";
+    reference "4.3.0";
+  }
 
   revision "2023-11-03" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.2.2";
+  oc-ext:openconfig-version "4.3.0";
+
+  revision "2023-12-13" {
+    description
+      "Expand when statement for connection-points endpoints";
+    reference "4.3.0";
+  }
 
   revision "2023-11-03" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -808,15 +808,10 @@ module openconfig-network-instance {
                   }
                 }
                 container vxlan {
-                    when "../config/type = 'oc-ni-types:VXLAN'" {
-                      description
-                        "Only include the vxlan configuration when
-                        the endpoint is specified to be vxlan";
-                    }
-                    description
-                      "Configuration and operational state parameters
-                      relating to a VXLAN tunnel end-point interface";
-                    uses oc-evpn:evpn-overlays-grp-top;
+                  description
+                    "Configuration and operational state parameters
+                    relating to a VXLAN tunnel end-point interface";
+                  uses oc-evpn:evpn-overlays-grp-top;
                 }
               }
             }

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -699,7 +699,8 @@ module openconfig-network-instance {
 
             container endpoints {
               when "../../../config/type = 'oc-ni-types:L2P2P' " +
-                 "or ../../../config/type = 'oc-ni-types:L2VSI'" {
+                 "or ../../../config/type = 'oc-ni-types:L2VSI'" +
+                 "or ../../../config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
                 description
                   "Configuration parameters to associate interfaces
                    into a common group for use in Layer 2 network


### PR DESCRIPTION
### Change Scope

* Expand `when` statement under `/network-instances/network-instance/connection-points/connection-point/endpoints` to include `oc-ni-types:DEFAULT_INSTANCE'`
* The change adds to the list of network-instance types that are supported so in that sense the change is backwards compatible
* Update on `12/20/23` expands the scope slightly for this PR:
    * Fixes a bug in the model by removing the `when` statement for `/network-instances/network-instance/connection-points/connection-point/endpoints/endpoint/vxlan`.  The `when` statement references [identity ENDPOINT_TYPE](https://github.com/openconfig/public/blob/master/release/models/network-instance/openconfig-network-instance-types.yang#L178) but it only includes `LOCAL` and `REMOTE`, not `VXLAN`.

The `/network-instances/network-instance/connection-points/connection-point/endpoints/endpoint/vxlan` container was added as part of the original EVPN support for the network-instance model.  [Change Details](https://github.com/openconfig/public/commit/b39439b2a55681c5b5a0d59e4644499916eac294)

This container represents the configuration and operational state parameters relating to a VXLAN tunnel end-point interfaces.  The `when` clause should have been expanded with the original commit since this information should belong to the default network instance.

The layer2 network instance include already has the expanded `when` clause that includes `DEFAULT_INSTANCE`.

```yaml
        uses l2ni-instance {
            when "./config/type = 'oc-ni-types:L2VSI'
                  or ./config/type = 'oc-ni-types:L2P2P'
                  or ./config/type = 'oc-ni-types:L2L3'
                  or ./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
                  description
                    "Layer 2 configuration parameters included when
                    a network instance is a Layer 2 instance or a
                    combined L2L3 instance";
            }
        }
```