### PR TITLE
Add models to reference doc/terminal-device-properties-guide.md

### DIFF
--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -35,10 +35,16 @@ module openconfig-terminal-device-properties {
       the OTSi (OTSiMC). It also includes (optional) aspects such as
       filter characterization, CD and DGD tolerance.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
 
 
   // Revisions
+  revision "2023-12-13" {
+    description
+      "Add reference to the terminal-device-properties-guide.md doc for operational-modes.";
+      reference "0.1.1";
+  }
+
   revision "2022-04-26" {
       description "Initial manifest fine to extend the information
       related to the operational modes supported by a terminal device.";
@@ -531,6 +537,8 @@ module openconfig-terminal-device-properties {
       description
         "Indicates the transceiver's list of supported operational
          modes and its associated transmission features";
+      reference
+         "https://github.com/openconfig/public/blob/master/doc/terminal-device-properties-guide.md";
 
       list mode-descriptor {
         key "mode-id";

--- a/release/models/optical-transport/openconfig-terminal-device.yang
+++ b/release/models/optical-transport/openconfig-terminal-device.yang
@@ -77,7 +77,14 @@ module openconfig-terminal-device {
     ports per linecard, separate linecards for client and line ports,
     etc.).";
 
-  oc-ext:openconfig-version "1.9.0";
+  oc-ext:openconfig-version "1.9.1";
+
+  revision "2023-12-13" {
+    description
+      "Add reference to the terminal-device-properties-guide.md doc for
+      operational-mode.";
+    reference "1.9.1";
+  }
 
   revision "2021-07-29" {
     description
@@ -1289,6 +1296,8 @@ module openconfig-terminal-device {
       // Ideally, this leaf should be a leafref to the supported
       // operational modes, but YANG 1.0 does not allow a r/w
       // leaf to be a leafref to a r/o leaf.
+      reference
+         "https://github.com/openconfig/public/blob/master/doc/terminal-device-properties-guide.md";
     }
 
     leaf line-port {


### PR DESCRIPTION
It was not clear about how `operational-modes` was supposed to be used when just browsing the model. This update should provide a direct reference to the documentation within the model definition.

### Change Scope
* Add doc/terminal-device-properties-guide.md reference to the following model definitions:
  * /operational-modes
  * /components/component/optical-channel/config/operational-mode
* This change is backwards compatible