### PR TITLE
Augmented attributes interface-ref and metric fields to mpls-static lsp

### DIFF
--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -25,8 +25,8 @@ submodule openconfig-mpls-igp {
 
   revision "2023-12-14" {
     description
-      "Added additional attributes oc-if:interface-ref,
-      payload-type and metric attributes to static lsp";
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
     reference "3.5.0";
   }
 

--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,14 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref,
+      payload-type and metric attributes to static lsp";
+    reference "3.5.0";
+  }
 
   revision "2023-07-25" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -10,6 +10,7 @@ submodule openconfig-mpls-static {
   import openconfig-mpls-types {prefix oc-mplst; }
   import openconfig-inet-types { prefix inet; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
 
 
   // meta
@@ -23,7 +24,14 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref,
+      payload-type and metric attributes to static lsp";
+    reference "3.5.0";
+  }
 
   revision "2023-07-25" {
     description
@@ -169,6 +177,23 @@ submodule openconfig-mpls-static {
       description
         "label value to push at the current hop for the
         LSP";
+    }
+
+    // interface-ref
+    uses oc-if:interface-ref-common;
+
+    leaf payload-type {
+      type identityref {
+        base oc-mplst:PAYLOAD_TYPE;
+      }
+      description
+        "MPLS payload type";
+    }
+
+    leaf metric {
+      type uint8;
+      description
+        "MPLS static lsp route metric";
     }
   }
 

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -28,8 +28,8 @@ submodule openconfig-mpls-static {
 
   revision "2023-12-14" {
     description
-      "Added additional attributes oc-if:interface-ref,
-      payload-type and metric attributes to static lsp";
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
     reference "3.5.0";
   }
 
@@ -181,14 +181,6 @@ submodule openconfig-mpls-static {
 
     // interface-ref
     uses oc-if:interface-ref-common;
-
-    leaf payload-type {
-      type identityref {
-        base oc-mplst:PAYLOAD_TYPE;
-      }
-      description
-        "Underlying payload type of the MPLS packet";
-    }
 
     leaf metric {
       type uint8;

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -187,13 +187,13 @@ submodule openconfig-mpls-static {
         base oc-mplst:PAYLOAD_TYPE;
       }
       description
-        "MPLS payload type";
+        "Underlying payload type of the MPLS packet";
     }
 
     leaf metric {
       type uint8;
       description
-        "MPLS static lsp route metric";
+        "Specifies metric value used for the MPLS route";
     }
   }
 

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,14 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref,
+      payload-type and metric attributes to static lsp";
+    reference "3.5.0";
+  }
 
   revision "2023-07-25" {
     description

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -34,8 +34,8 @@ submodule openconfig-mpls-te {
 
   revision "2023-12-14" {
     description
-      "Added additional attributes oc-if:interface-ref,
-      payload-type and metric attributes to static lsp";
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
     reference "3.5.0";
   }
 

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -23,8 +23,8 @@ module openconfig-mpls-types {
 
   revision "2023-12-14" {
     description
-      "Added additional attributes oc-if:interface-ref,
-      payload-type and metric attributes to static lsp";
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
     reference "3.5.0";
   }
 
@@ -132,31 +132,6 @@ module openconfig-mpls-types {
   }
 
   // identity statements
-
-  identity PAYLOAD_TYPE {
-    description
-      "base identity for supported MPLS
-       payload types";
-  }
-
-  identity PAYLOAD_MPLS {
-    base "PAYLOAD_TYPE";
-    description
-      "Specifies underlying payload type as MPLS
-       label i.e, represents stacked MPLS labels";
-  }
-
-  identity PAYLOAD_IPV4 {
-    base "PAYLOAD_TYPE";
-    description
-      "Specifies underlying payload type as IPV4";
-  }
-
-  identity PAYLOAD_IPV6 {
-    base "PAYLOAD_TYPE";
-    description
-      "Specifies underlying payload type as IPV6";
-  }
 
   identity PATH_COMPUTATION_METHOD {
     description

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -19,7 +19,14 @@ module openconfig-mpls-types {
   description
     "General types for MPLS / TE data model";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref,
+      payload-type and metric attributes to static lsp";
+    reference "3.5.0";
+  }
 
   revision "2021-12-01" {
     description
@@ -125,6 +132,30 @@ module openconfig-mpls-types {
   }
 
   // identity statements
+
+  identity PAYLOAD_TYPE {
+    description
+      "base identity for supported MPLS
+       payload types";
+  }
+
+  identity PAYLOAD_MPLS {
+    base "PAYLOAD_TYPE";
+    description
+      "payload type MPLS";
+  }
+
+  identity PAYLOAD_IPV4 {
+    base "PAYLOAD_TYPE";
+    description
+      "payload type IPV4";
+  }
+
+  identity PAYLOAD_IPV6 {
+    base "PAYLOAD_TYPE";
+    description
+      "payload type IPV6";
+  }
 
   identity PATH_COMPUTATION_METHOD {
     description

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -142,19 +142,20 @@ module openconfig-mpls-types {
   identity PAYLOAD_MPLS {
     base "PAYLOAD_TYPE";
     description
-      "payload type MPLS";
+      "Specifies underlying payload type as MPLS 
+       label i.e, represents stacked MPLS labels";
   }
 
   identity PAYLOAD_IPV4 {
     base "PAYLOAD_TYPE";
     description
-      "payload type IPV4";
+      "Specifies underlying payload type as IPV4";
   }
 
   identity PAYLOAD_IPV6 {
     base "PAYLOAD_TYPE";
     description
-      "payload type IPV6";
+      "Specifies underlying payload type as IPV6";
   }
 
   identity PATH_COMPUTATION_METHOD {

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -142,7 +142,7 @@ module openconfig-mpls-types {
   identity PAYLOAD_MPLS {
     base "PAYLOAD_TYPE";
     description
-      "Specifies underlying payload type as MPLS 
+      "Specifies underlying payload type as MPLS
        label i.e, represents stacked MPLS labels";
   }
 

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -70,7 +70,14 @@ module openconfig-mpls {
                +------+      |ROUTING|      +-----+
                              +-------+
     ";
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref,
+      payload-type and metric attributes to static lsp";
+    reference "3.5.0";
+  }
 
   revision "2023-07-25" {
     description

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -74,8 +74,8 @@ module openconfig-mpls {
 
   revision "2023-12-14" {
     description
-      "Added additional attributes oc-if:interface-ref,
-      payload-type and metric attributes to static lsp";
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
     reference "3.5.0";
   }
 


### PR DESCRIPTION
* (M) release/models/mpls/openconfig-mpls-static.yang
* (M) release/models/mpls/openconfig-mpls-types.yang
* (M) release/models/mpls/openconfig-mpls.yang
* (M) release/models/mpls/openconfig-mpls-igp.yang
* (M) release/models/mpls/openconfig-mpls-te.yang

### Change Scope

* Augmented with below attributes interface-ref, and metric in the path /network-instances/network-instance/mpls/lsps/static-lsps/static-lsp
```
  +--rw network-instances
     +--rw network-instance [name]
        +--rw mpls
           +--rw lsps
              +--rw static-lsps
                 +--rw static-lsp [name]
                    +--rw ingress
                    |  +--rw config
                    |  |  +--rw interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--rw metric?           uint8
                    |  +--ro state
                    |     +--ro interface?        -> /oc-if:interfaces/interface/name
                    |     +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |     +--ro metric?           uint8
                    +--rw transit
                    |  +--rw config
                    |  |  +--rw interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--rw metric?           uint8
                    |  +--ro state
                    |     +--ro interface?        -> /oc-if:interfaces/interface/name
                    |     +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |     +--ro metric?           uint8
                    +--rw egress
                       +--rw config
                       |  +--rw interface?        -> /oc-if:interfaces/interface/name
                       |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                       |  +--rw metric?           uint8
                       +--ro state
                          +--ro interface?        -> /oc-if:interfaces/interface/name
                          +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                          +--ro metric?           uint8 
```
### Platform Implementations

 * Arista: https://www.arista.com/en/um-eos/eos-mpls-commands#xx1141474
 CLI configuration: mpls static top-label top_tag[ bgp peer [peer IP]] [DEST_INTF] NEXTHOP_ADDR ACTION [PRIORITY]
