### PR TITLE
Fix descriptions of root-delay and root-dispersion

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,7 +47,14 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.17.1";
+  oc-ext:openconfig-version "0.17.2";
+
+  revision "2023-12-19" {
+    description
+      "Update descriptions of root-delay and root-dispersion for accuracy and
+      clarity.";
+    reference "0.17.2";
+  }
 
   revision "2023-06-16" {
     description
@@ -754,30 +761,23 @@ module openconfig-system {
 
     leaf root-delay {
       type uint32;
-      // TODO: reconsider units for these values -- the spec defines
-      // rootdelay and rootdisperson as 2 16-bit integers for seconds
-      // and fractional seconds, respectively.  This gives a
-      // precision of ~15 us (2^-16).  Using milliseconds here based
-      // on what implementations typically provide and likely lack
-      // of utility for less than millisecond precision with NTP
-      // time sync.
       units "milliseconds";
       description
-        "The round-trip delay to the server, in milliseconds.";
+        "The total round-trip delay to the reference clock, in milliseconds.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 7.3";
     }
 
     leaf root-dispersion {
       type uint64;
       units "milliseconds";
       description
-        "Dispersion (epsilon) represents the maximum error inherent
-        in the measurement";
+        "The maximum error inherent in the measurement, accumulated over the
+        stratum levels from the reference clock.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 4";
     }
 
     leaf offset {


### PR DESCRIPTION
 * Remove the comment about reconsidering units of root-delay. As long as it's uint32, milliseconds are the smallest possible units that allow it to have sufficient range.  (The root delay values in NTP packets have a maximum value of about 18 hours.  The range of a uint32 as milliseconds is 2^32 * 0.001 seconds = about 1193 hours. That's big enough, by far.  The range of a uint32 as microseconds is about 1.193 hour = too small.)
 * The old description of root-delay matched the (single-server = non-"root") delay, but the *root* delay is accumulated across strata.
 * The old description of root-dispersion was not clearly differentiated from the (single-server = non-"root") dispersion.

This change suggests the question: Does it make sense for these leaf nodes to be the root values, rather than the single-server values? I think the answer is yes, because the root delay and dispersion are included among the fields in NTP packets.

### Change Scope

* This change affects only node descriptions. It is backwards compatible.
### Platform Implementations

* N/A