### PR TITLE
Multipath link bandwidth enabled

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,8 +24,15 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -32,7 +32,7 @@ submodule openconfig-bgp-common-multiprotocol {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,8 +21,15 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -29,7 +29,7 @@ submodule openconfig-bgp-common-structure {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -28,8 +28,8 @@ submodule openconfig-bgp-common-structure {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
     reference "9.7.0";
-  }    
-  
+  }
+
   revision "2023-11-02" {
     description
       "Fix revision '2023-03-31': send-community-type was added to the

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -691,7 +691,7 @@ submodule openconfig-bgp-common {
       Local Administrator subfield of link-bandwidth extended
       community [draft-ietf-idr-link-bandwidth-07].
       This leaf has no effect if BGP multi-path is disabled or
-      if maximum-path attribute of BGP multi-path value is set 
+      if maximum-path attribute of BGP multi-path value is set
       to 1";
     }
   }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -685,7 +685,7 @@ submodule openconfig-bgp-common {
       extended community in pultipath RIB/FIB formation";
     leaf enable {
       type boolean;
-      default "false";
+      default "true";
       description
       "When set to TRUE, BGP multiplepath shall distributed traffic
       load among contributing routes proportionally to value of

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
 
   revision "2023-11-01" {
     description
@@ -627,6 +634,21 @@ submodule openconfig-bgp-common {
       container ibgp {
         description
           "Multipath parameters for iBGP";
+        container link-bandwidth-ext-community {
+          description
+            "Usage of DMZ Link-Bandwidth extended community";
+          container config {
+            description
+            "Configuration parameters relating to usage of link-bandwidth"
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+          container state {
+            config false;
+            description
+            "State information relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+        }
         container config {
           description
             "Configuration parameters relating to iBGP multipath";
@@ -639,6 +661,21 @@ submodule openconfig-bgp-common {
           uses bgp-common-use-multiple-paths-ibgp-config;
         }
       }
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-link-bandwidth-config {
+    description
+      "Parameters controlling usage of  of DMZ Link-Bandwidth
+      extended community in pultipath RIB/FIB formation";
+    leaf enable {
+      type boolean;
+      default "false";
+      description
+      "When set to TRUE, BGP multiplepath shall distributed traffic
+      load among contributing routes proportionally to value of
+      Local Administrator subfield of link-bandwidth extended
+      community [draft-ietf-idr-link-bandwidth-07]";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -31,8 +31,7 @@ submodule openconfig-bgp-common {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
           reference "9.7.0";
-  }   
-
+  }
 
   revision "2023-11-02" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -618,6 +618,21 @@ submodule openconfig-bgp-common {
       container ebgp {
         description
           "Multipath parameters for eBGP";
+        container link-bandwidth-ext-community {
+          description
+            "Usage of DMZ Link-Bandwidth extended community";
+          container config {
+            description
+            "Configuration parameters relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+          container state {
+            config false;
+            description
+            "State information relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+        }
         container config {
           description
             "Configuration parameters relating to eBGP multipath";
@@ -639,7 +654,7 @@ submodule openconfig-bgp-common {
             "Usage of DMZ Link-Bandwidth extended community";
           container config {
             description
-            "Configuration parameters relating to usage of link-bandwidth"
+            "Configuration parameters relating to usage of link-bandwidth";
             uses bgp-common-use-multiple-paths-link-bandwidth-config;
           }
           container state {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -683,14 +683,16 @@ submodule openconfig-bgp-common {
     description
       "Parameters controlling usage of  of DMZ Link-Bandwidth
       extended community in pultipath RIB/FIB formation";
-    leaf enable {
+    leaf enabled {
       type boolean;
-      default "true";
       description
       "When set to TRUE, BGP multiplepath shall distributed traffic
       load among contributing routes proportionally to value of
       Local Administrator subfield of link-bandwidth extended
-      community [draft-ietf-idr-link-bandwidth-07]";
+      community [draft-ietf-idr-link-bandwidth-07].
+      This leaf has no effect if BGP multi-path is disabled or
+      if maximum-path attribute of BGP multi-path value is set 
+      to 1";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,8 +27,15 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -34,7 +34,7 @@ submodule openconfig-bgp-global {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
     reference "9.7.0";
-  }   
+  }
 
   revision "2023-11-02" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -35,7 +35,7 @@ submodule openconfig-bgp-global {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -37,7 +37,7 @@ submodule openconfig-bgp-neighbor {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
           reference "9.7.0";
-  }   
+  }
 
   revision "2023-11-02" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,8 +30,15 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -38,7 +38,7 @@ submodule openconfig-bgp-neighbor {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -33,7 +33,7 @@ submodule openconfig-bgp-peer-group {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -32,8 +32,7 @@ submodule openconfig-bgp-peer-group {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
     reference "9.7.0";
-  }   
-
+  }
 
   revision "2023-11-02" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,8 +25,15 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -75,8 +75,7 @@ module openconfig-bgp {
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
           reference "9.7.0";
-  }   
-
+  }
 
   revision "2023-11-02" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -76,7 +76,7 @@ module openconfig-bgp {
       community for BGP multipath.";
     reference "9.6.0";
   }
-  
+
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,8 +68,15 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.5.0";
+  oc-ext:openconfig-version "9.6.0";
 
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.6.0";
+  }
+  
   revision "2023-11-01" {
     description
       "Add default apply policy to global and per afi-safi config.";


### PR DESCRIPTION
### Change Scope

This PR provides configuration hirarchy that allows to enable/disable honoring link-bandwidth extended community when BGP multipath is forming RIB/FIB entries. 

It is done by by link-bandwidth-ext-community dedicated container, so more attributes can be added in future, without breaking model. (e.g. precission/scalaling/reference factors. Or zero value handling).

```
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw global
                    +--rw afi-safis
                       +--rw afi-safi* [afi-safi-name]
                          +--rw use-multiple-paths
                             +--rw config
                             |  +--rw enabled?   boolean
                             +--ro state
                             |  +--ro enabled?   boolean
                             +--rw ebgp
                             |  +--rw link-bandwidth-ext-community         <<<<<<<<
                             |  |  +--rw config
                             |  |  |  +--rw enabled?   boolean
                             |  |  +--ro state
                             |  |     +--ro enabled?   boolean
                             ...
                             +--rw ibgp
                                +--rw link-bandwidth-ext-community         <<<<<<<<
                                |  +--rw config
                                |  |  +--rw enabled?   boolean
                                |  +--ro state
                                |     +--ro enabled?   boolean
```
same structure repeats for all levels:
```
/network-instances/network-instance/protocols/protocol/bgp/global/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/global/use-multiple-paths/ebgp/link-bandwidth-ext-community/state/enabled
/network-instances/network-instance/protocols/protocol/bgp/global/use-multiple-paths/ibgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/global/use-multiple-paths/ibgp/link-bandwidth-ext-community/state/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/use-multiple-paths/ebgp/link-bandwidth-ext-community/state/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/use-multiple-paths/ibgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/use-multiple-paths/ibgp/link-bandwidth-ext-community/state/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/use-multiple-paths/ebgp/link-bandwidth-ext-community/state/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/use-multiple-paths/ibgp/link-bandwidth-ext-community/config/enabled
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/use-multiple-paths/ibgp/link-bandwidth-ext-community/state/enabled
```

This leaf has no effect if BGP multi-path is disabled or if maximum-path attribute of BGP multi-path value is set to 1.

Implementation that do support only one state (e.g. implementation do not support BGP wECMP at all) should still support this leaf and accept configuration if value is set to FALSE, while reject configuration when value is set to TRUE.

### Platform Implementations

 * Arista: [`ucmp mode 1`](https://www.arista.com/en/support/toi/eos-4-24-1f/14534-bgp-ucmp#enabling-ucmp-locally) 

 * FRRrouting: [bgp bestpath bandwidth ignore](https://docs.frrouting.org/en/latest/bgp.html#controlling-link-bandwidth-processing-on-the-receiver)

* Cumulus: [net add bestpath bandwidth ignore](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-41/Layer-3/Unequal-Cost-Multipath/#set-default-values-for-ucmp-routes)

* Juniper JUNOS, Cisco IOS-XR, Nokia SRL - do not allow to ignore/disable link-bandwidth community. They always instantiate wECMP if all multipath members have  link-bandwidth community attached, or ECMP if at least one do not have it attached.
