### PR TITLE
Update description for forwarding-viable

### DIFF
--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -47,9 +47,8 @@ module openconfig-if-sdn-ext {
         This is used by an external programming entity to disable an interface
         (usually part of an aggregate) for the purposes of forwarding
         traffic. This allows a logical aggregate to continue to be
-        used with partial capacity, for example.  Note that setting
-        `forwarding-viable = false` is not equivalent to
-        administratively disabling the interface.
+        used with partial capacity. Setting `forwarding-viable = false` is not 
+        equivalent to administratively disabling the interface.
         Some rules to follow when a port/bundle is set for 
         Forwarding-viable=False:
           1. Given that L2 protocols like LACP should be allowed to be 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -52,13 +52,46 @@ module openconfig-if-sdn-ext {
         administratively disabling the interface -- in particular, the
         interface is expected to participate in L2 protocols such as
         LLDP or LACP even if it blocked from forwarding traffic.
-        Some rules to follow when a port/bundle is set for Forwarding-viable=False,
-          1. Given that L2 protocols like LACP should be allowed to be transmitted and received on such ports, a device mustn't consider such ports in the calculation for minimum number of links required for an aggregate bundle when such a configuration exists on the box. Hence, the device musn't disable the bundle because the minimum number of member links requirement is not met for the bundle.
-          2. While it is required that L2 protocols like LLDP, LACP, P4RT must be allowed for transmit and receive on such ports/bundles, CLNS protocol is an exception and must be treated as per the requirement for L3 protocols below.
-          3. L3 packets, control-plane as well as data-plane must be received but not transmitted on such ports/bundles. By doing so, expectation is that the other end of the connection ceases to use its respective ports for transmit and receive when either the dead-timer or the hold-down timer of its L3 protocol expires. 
-          4. An implementation should follow rule#3 even when the subject port/bundle is the last resort of communication for the device.";
+        Some rules to follow when a port/bundle is set for 
+        Forwarding-viable=False:
+          1. Given that L2 protocols like LACP should be allowed to be 
+          transmitted and received on such ports, a device mustn't consider 
+          such ports in the calculation for minimum number of links required 
+          for an aggregate bundle when such a configuration exists on the box.
+          Hence, the device musn't disable the bundle because the minimum
+          number of member links requirement is not met for the bundle.
+          2. While it is required that L2 protocols like LLDP, LACP, P4RT must
+          be allowed for transmit and receive on such ports/bundles, CLNS
+          protocol is an exception and must be treated as per the requirement
+          for L3 protocols below.
+          3. L3 packets, control-plane as well as data-plane must be received
+          but not transmitted on such ports/bundles. By doing so, expectation
+          is that the other end of the connection ceases to use its respective
+          ports for transmit and receive when either the dead-timer or the
+          hold-down timer of its L3 protocol expires. 
+          4. An implementation should follow rule#3 even when the subject
+          port/bundle is the last resort of communication for the device.";
     }
   }
+
+You, 46 min
+how did u do that?
+
+Rahul Unnikrishnan, 45 min
+manually
+i can see the column width in text editor
+
+You, 45 min
+ok, ... 🙂
+what is the expected width
+?
+
+Rahul Unnikrishnan, 44 min
+i've seen Dan Ameme changing my python script width to <80 columns.
+so i did that here too
+also the max width previously in the file was 79. so setting it to <79 or less seemed safe
+
+
 
   augment "/oc-if:interfaces/oc-if:interface/oc-if:config" {
     description

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -21,7 +21,13 @@ module openconfig-if-sdn-ext {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision 2024-02-21 {
+    description
+      "Initial revision.";
+    reference "0.2.0";
+  }
 
   revision 2021-03-30 {
     description

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -51,30 +51,25 @@ module openconfig-if-sdn-ext {
         equivalent to administratively disabling the interface.
         Some rules to follow when an interface or aggregate interface is set for 
         Forwarding-viable=False:
-          1. When forwarding-viable is FALSE `/interfaces/interface/state/oper-status` should 
-          reflect the L2 status, which when UP should be treated as such for 
+          1. When forwarding-viable is FALSE `/interfaces/interface/state/oper-status` 
+          should reflect the L2 status, which when UP should be treated as such for 
           aggregate interface `min-links` checks.
 
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
           receive on such ports/bundles, IS-IS PDUs should be handled as per the 
           requirements for L3 packets below.
 
-          3. L3 packets, control-plane as well as data-plane must be received
-          but not transmitted on such ports/bundles. Since the port is receiving 
+          3. For L3 packets, control-plane as well as data-plane packets must be 
+          received but not transmitted on such ports/bundles. Since the port is receiving 
           L3 packets, inflight data-plane traffic will continue to be delivered to its 
-          destination post FIB lookup. Also, received control-plane traffic should be 
-          handled normally. Given that the router is not allowed to transmit L3 control-plane 
-          packets (for protocols like IS-IS and BGP) on such a port with its FV set to false, 
-          if this is a singleton port, OR if all member interfaces in a bundle are ever set to be 
-          FV=False, expectations are that the remote end of the connection will have its L3 
-          protocol's dead-interval OR hold-down timer expired taking down the adjacency/peering on 
-          that connection. 
-          This by no means suggests that the peer should stop using the interface/s for 
-          forwarding traffic and may can continue to do so if an external programming entity has 
-          placed forwarding rules with the subject interface/s as the next-hop. 
-          In this scenario, the subject router where the FV was set to false
-          may continue to receive traffic over such interfaces indefinitley and hence 
-          must continue to forward the traffic as such.
+          destination post FIB lookup. Also, received control-plane traffic must be 
+          handled normally. Therefore, when all ports in a bundle are set to FV=False,
+          it is possible that the dead-interval or Hold-down timer of L3 protocols like 
+          IS-IS/BGP on the peer router may expire taking down the adjacency or peering 
+          on that connection. However, the peer may still continue to use the bundle for 
+          forwarding traffic towards the subject router if the peer's forwarding table 
+          is programmed by an external programming entity. In this scenario, the subject 
+          router will continue to recieve traffic indefinitely on such a bundle.
 
           4. An implementation should follow rule #3 even when the subject
           interface is the last resort of communication for the device.";

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -51,7 +51,12 @@ module openconfig-if-sdn-ext {
         `forwarding-viable = false` is not equivalent to
         administratively disabling the interface -- in particular, the
         interface is expected to participate in L2 protocols such as
-        LLDP or LACP even if it blocked from forwarding traffic.";
+        LLDP or LACP even if it blocked from forwarding traffic.
+        Some rules to follow when a port/bundle is set for Forwarding-viable=False,
+          1. Given that L2 protocols like LACP should be allowed to be transmitted and received on such ports, a device mustn't consider such ports in the calculation for minimum number of links required for an aggregate bundle when such a configuration exists on the box. Hence, the device musn't disable the bundle because the minimum number of member links requirement is not met for the bundle.
+          2. While it is required that L2 protocols like LLDP, LACP, P4RT must be allowed for transmit and receive on such ports/bundles, CLNS protocol is an exception and must be treated as per the requirement for L3 protocols below.
+          3. L3 packets, control-plane as well as data-plane must be received but not transmitted on such ports/bundles. By doing so, expectation is that the other end of the connection ceases to use its respective ports for transmit and receive when either the dead-timer or the hold-down timer of its L3 protocol expires. 
+          4. An implementation should follow rule#3 even when the subject port/bundle is the last resort of communication for the device.
     }
   }
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -57,14 +57,22 @@ module openconfig-if-sdn-ext {
           for an aggregate bundle when such a configuration exists on the box.
           Hence, the device mustn't disable the bundle because the minimum
           number of member links requirement is not met for the bundle.
+
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
           receive on such ports/bundles, IS-IS PDUs should be handled as per the 
           requirements for L3 packets below.
+
           3. L3 packets, control-plane as well as data-plane must be received
-          but not transmitted on such ports/bundles. By doing so, expectation
-          is that the other end of the connection ceases to use its respective
-          ports for transmit and receive when either the dead-timer or the
-          hold-down timer of its L3 protocol expires. 
+          but not transmitted on such ports/bundles. Since the port is receiving 
+          L3 packets, inflight traffic will continue to be delivered to its destination 
+          post FIB lookup.
+          Given that the router is not allowed to transmit L3 control plane packets 
+          on such a port with its FV set to false, if this is a singleton port, OR if 
+          all member interfaces in a bundle are ever set to be FV=False, 
+          expectations are that the remote end of the connection will have its L3 protocol's 
+          dead-interval OR hold-down timer expired taking down the adjacency/peering on 
+          that connection.
+
           4. An implementation should follow rule#3 even when the subject
           port/bundle is the last resort of communication for the device.";
     }

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -49,16 +49,14 @@ module openconfig-if-sdn-ext {
         traffic. This allows a logical aggregate to continue to be
         used with partial capacity, for example.  Note that setting
         `forwarding-viable = false` is not equivalent to
-        administratively disabling the interface -- in particular, the
-        interface is expected to participate in L2 protocols such as
-        LLDP or LACP even if it blocked from forwarding traffic.
+        administratively disabling the interface.
         Some rules to follow when a port/bundle is set for 
         Forwarding-viable=False:
           1. Given that L2 protocols like LACP should be allowed to be 
           transmitted and received on such ports, a device mustn't consider 
           such ports in the calculation for minimum number of links required 
           for an aggregate bundle when such a configuration exists on the box.
-          Hence, the device musn't disable the bundle because the minimum
+          Hence, the device mustn't disable the bundle because the minimum
           number of member links requirement is not met for the bundle.
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
           receive on such ports/bundles, IS-IS should be handled as per the 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -60,7 +60,7 @@ module openconfig-if-sdn-ext {
           for an aggregate bundle when such a configuration exists on the box.
           Hence, the device musn't disable the bundle because the minimum
           number of member links requirement is not met for the bundle.
-          2. While it is required that L2 protocols like LLDP, LACP, P4RT must
+          2. While it is required that L2 protocols like LLDP, LACP must
           be allowed for transmit and receive on such ports/bundles, CLNS
           protocol is an exception and must be treated as per the requirement
           for L3 protocols below.

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -51,7 +51,7 @@ module openconfig-if-sdn-ext {
         equivalent to administratively disabling the interface.
         Some rules to follow when an interface or aggregate interface is set for 
         Forwarding-viable=False:
-          1. When forwarding-viable is FALSE the interface oper-state should still 
+          1. When forwarding-viable is FALSE `/interfaces/interface/state/oper-status` should 
           reflect the L2 status, which when UP should be treated as such for 
           aggregate interface `min-links` checks.
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -59,7 +59,7 @@ module openconfig-if-sdn-ext {
           number of member links requirement is not met for the bundle.
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
           receive on such ports/bundles, IS-IS should be handled as per the 
-          requirements for L3 protocols below.
+          requirements for L3 packets below.
           3. L3 packets, control-plane as well as data-plane must be received
           but not transmitted on such ports/bundles. By doing so, expectation
           is that the other end of the connection ceases to use its respective

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -60,16 +60,18 @@ module openconfig-if-sdn-ext {
           requirements for L3 packets below.
 
           3. For L3 packets, control-plane as well as data-plane packets must be 
-          received but not transmitted on such ports/bundles. Since the port is receiving 
-          L3 packets, inflight data-plane traffic will continue to be delivered to its 
-          destination post FIB lookup. Also, received control-plane traffic must be 
-          handled normally. Therefore, when all ports in a bundle are set to FV=False,
-          it is possible that the dead-interval or Hold-down timer of L3 protocols like 
-          IS-IS/BGP on the peer router may expire taking down the adjacency or peering 
-          on that connection. However, the peer may still continue to use the bundle for 
-          forwarding traffic towards the subject router if the peer's forwarding table 
-          is programmed by an external programming entity. In this scenario, the subject 
-          router will continue to recieve traffic indefinitely on such a bundle.
+          received but not transmitted on such ports/bundles. Since the port 
+          is receiving L3 packets, inflight data-plane traffic will continue to 
+          be delivered to its destination post FIB lookup. Also, received 
+          control-plane traffic must be handled normally. Therefore, when all 
+          ports in a bundle are set to FV=False, it is possible that the 
+          dead-interval or Hold-down timer of L3 protocols like IS-IS/BGP on the 
+          peer router may expire taking down the adjacency or peering on that 
+          connection. However, the peer may still continue to use the bundle for 
+          forwarding traffic towards the subject router if the peer's forwarding 
+          table is programmed by an external programming entity. In this scenario, 
+          the subject router will continue to recieve traffic indefinitely on 
+          such a bundle.
 
           4. An implementation should follow rule #3 even when the subject
           interface is the last resort of communication for the device.";

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -60,16 +60,16 @@ module openconfig-if-sdn-ext {
           transmit and receive on such ports/bundles.  IS-IS PDUs should be
           handled as per the requirements for L3 packets below.
 
-          3. L3 packets must not be transmitted on the interface.  
-          
+          3. L3 packets must not be transmitted on the interface.
+
           4. Received L3 packets must be processed normally.  Received data-plane
           traffic will continue to forwarded to its destination post FIB lookup.
-          Received control-plane traffic must also be processed normally. 
-          
+          Received control-plane traffic must also be processed normally.
+
           5. It is possible that the dead-interval or hold-down timer of L3
           protocols like IS-IS/BGP on the peer router may expire taking down the
           adjacency or peering on that connection. However, the peer may still
-          continue to transmit packets which are received by the local device.  
+          continue to transmit packets which are received by the local device.
           These received packet should continue to be processed normally as
           per rule #4 above.
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -56,7 +56,7 @@ module openconfig-if-sdn-ext {
           1. Given that L2 protocols like LACP should be allowed to be transmitted and received on such ports, a device mustn't consider such ports in the calculation for minimum number of links required for an aggregate bundle when such a configuration exists on the box. Hence, the device musn't disable the bundle because the minimum number of member links requirement is not met for the bundle.
           2. While it is required that L2 protocols like LLDP, LACP, P4RT must be allowed for transmit and receive on such ports/bundles, CLNS protocol is an exception and must be treated as per the requirement for L3 protocols below.
           3. L3 packets, control-plane as well as data-plane must be received but not transmitted on such ports/bundles. By doing so, expectation is that the other end of the connection ceases to use its respective ports for transmit and receive when either the dead-timer or the hold-down timer of its L3 protocol expires. 
-          4. An implementation should follow rule#3 even when the subject port/bundle is the last resort of communication for the device.
+          4. An implementation should follow rule#3 even when the subject port/bundle is the last resort of communication for the device.";
     }
   }
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -70,8 +70,8 @@ module openconfig-if-sdn-ext {
           dead-interval OR hold-down timer expired taking down the adjacency/peering on 
           that connection.
 
-          4. An implementation should follow rule#3 even when the subject
-          port/bundle is the last resort of communication for the device.";
+          4. An implementation should follow rule #3 even when the subject
+          interface is the last resort of communication for the device.";
     }
   }
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -64,11 +64,11 @@ module openconfig-if-sdn-ext {
 
           3. L3 packets, control-plane as well as data-plane must be received
           but not transmitted on such ports/bundles. Since the port is receiving 
-          L3 packets, inflight traffic will continue to be delivered to its destination 
-          post FIB lookup.
-          Given that the router is not allowed to transmit L3 control plane packets 
-          on such a port with its FV set to false, if this is a singleton port, OR if 
-          all member interfaces in a bundle are ever set to be FV=False, 
+          L3 packets, inflight data-plane traffic will continue to be delivered to its 
+          destination post FIB lookup. Also, received control-plane traffic should be 
+          handled normally. Given that the router is not allowed to transmit L3 control-plane 
+          packets on such a port with its FV set to false, if this is a singleton 
+          port, OR if all member interfaces in a bundle are ever set to be FV=False, 
           expectations are that the remote end of the connection will have its L3 protocol's 
           dead-interval OR hold-down timer expired taking down the adjacency/peering on 
           that connection.

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -49,7 +49,7 @@ module openconfig-if-sdn-ext {
         traffic. This allows a logical aggregate to continue to be
         used with partial capacity. Setting `forwarding-viable = false` is not 
         equivalent to administratively disabling the interface.
-        Some rules to follow when a port/bundle is set for 
+        Some rules to follow when an interface or aggregate interface is set for 
         Forwarding-viable=False:
           1. Given that L2 protocols like LACP should be allowed to be 
           transmitted and received on such ports, a device mustn't consider 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -74,25 +74,6 @@ module openconfig-if-sdn-ext {
     }
   }
 
-You, 46 min
-how did u do that?
-
-Rahul Unnikrishnan, 45 min
-manually
-i can see the column width in text editor
-
-You, 45 min
-ok, ... 🙂
-what is the expected width
-?
-
-Rahul Unnikrishnan, 44 min
-i've seen Dan Ameme changing my python script width to <80 columns.
-so i did that here too
-also the max width previously in the file was 79. so setting it to <79 or less seemed safe
-
-
-
   augment "/oc-if:interfaces/oc-if:interface/oc-if:config" {
     description
       "Add SDN extensions to interface intended configuration.";

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -64,14 +64,17 @@ module openconfig-if-sdn-ext {
           L3 packets, inflight data-plane traffic will continue to be delivered to its 
           destination post FIB lookup. Also, received control-plane traffic should be 
           handled normally. Given that the router is not allowed to transmit L3 control-plane 
-          packets on such a port with its FV set to false, if this is a singleton 
-          port, OR if all member interfaces in a bundle are ever set to be FV=False, 
-          expectations are that the remote end of the connection will have its L3 protocol's 
-          dead-interval OR hold-down timer expired taking down the adjacency/peering on 
-          that connection. This by no means suggests that the peer should stop using the 
-          interface/s for forwarding traffic and can continue to do so if an external
-          programming entity has placed forwarding rules with the subject interface/s as
-          the next-hop.
+          packets (for protocols like IS-IS and BGP) on such a port with its FV set to false, 
+          if this is a singleton port, OR if all member interfaces in a bundle are ever set to be 
+          FV=False, expectations are that the remote end of the connection will have its L3 
+          protocol's dead-interval OR hold-down timer expired taking down the adjacency/peering on 
+          that connection. 
+          This by no means suggests that the peer should stop using the interface/s for 
+          forwarding traffic and may can continue to do so if an external programming entity has 
+          placed forwarding rules with the subject interface/s as the next-hop. 
+          In this scenario, the subject router where the FV was set to false
+          may continue to receive traffic over such interfaces indefinitley and hence 
+          must continue to forward the traffic as such.
 
           4. An implementation should follow rule #3 even when the subject
           interface is the last resort of communication for the device.";

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -51,12 +51,9 @@ module openconfig-if-sdn-ext {
         equivalent to administratively disabling the interface.
         Some rules to follow when an interface or aggregate interface is set for 
         Forwarding-viable=False:
-          1. Given that L2 protocols like LACP should be allowed to be 
-          transmitted and received on such ports, a device mustn't consider 
-          such ports in the calculation for minimum number of links required 
-          for an aggregate bundle when such a configuration exists on the box.
-          Hence, the device mustn't disable the bundle because the minimum
-          number of member links requirement is not met for the bundle.
+          1. When forwarding-viable is FALSE the interface oper-state should still 
+          reflect the L2 status, which when UP should be treated as such for 
+          aggregate interface `min-links` checks.
 
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
           receive on such ports/bundles, IS-IS PDUs should be handled as per the 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -47,34 +47,42 @@ module openconfig-if-sdn-ext {
         This is used by an external programming entity to disable an interface
         (usually part of an aggregate) for the purposes of forwarding
         traffic. This allows a logical aggregate to continue to be
-        used with partial capacity. Setting `forwarding-viable = false` is not 
+        used with partial capacity. Setting `forwarding-viable = false` is not
         equivalent to administratively disabling the interface.
-        Some rules to follow when an interface or aggregate interface is set for 
+        Some rules to follow when an interface or aggregate interface is set for
         Forwarding-viable=False:
-          1. When forwarding-viable is FALSE `/interfaces/interface/state/oper-status` 
-          should reflect the L2 status, which when UP should be treated as such for 
-          aggregate interface `min-links` checks.
+          1. Aggregate interface '/interfaces/interface/aggregation/state/min-links'
+           checks should be evaluated based on
+          `/interfaces/interface/state/oper-status`.  'min-links' should not be
+          affected by the use of forwarding viable.
 
-          2. L2 protocols like LLDP, LACP must be allowed for transmit and 
-          receive on such ports/bundles, IS-IS PDUs should be handled as per the 
-          requirements for L3 packets below.
+          2. L2 protocols like LLDP and LACP must be processed normally on
+          transmit and receive on such ports/bundles.  IS-IS PDUs should be
+          handled as per the requirements for L3 packets below.
 
-          3. For L3 packets, control-plane as well as data-plane packets must be 
-          received but not transmitted on such ports/bundles. Since the port 
-          is receiving L3 packets, inflight data-plane traffic will continue to 
-          be delivered to its destination post FIB lookup. Also, received 
-          control-plane traffic must be handled normally. Therefore, when all 
-          ports in a bundle are set to FV=False, it is possible that the 
-          dead-interval or Hold-down timer of L3 protocols like IS-IS/BGP on the 
-          peer router may expire taking down the adjacency or peering on that 
-          connection. However, the peer may still continue to use the bundle for 
-          forwarding traffic towards the subject router if the peer's forwarding 
-          table is programmed by an external programming entity. In this scenario, 
-          the subject router will continue to recieve traffic indefinitely on 
-          such a bundle.
+          3. L3 packets must not be transmitted on the interface.  
+          
+          4. Received L3 packets must be processed normally.  Received data-plane
+          traffic will continue to forwarded to its destination post FIB lookup.
+          Received control-plane traffic must also be processed normally. 
+          
+          5. It is possible that the dead-interval or hold-down timer of L3
+          protocols like IS-IS/BGP on the peer router may expire taking down the
+          adjacency or peering on that connection. However, the peer may still
+          continue to transmit packets which are received by the local device.  
+          These received packet should continue to be processed normally as
+          per rule #4 above.
 
-          4. An implementation should follow rule #3 even when the subject
-          interface is the last resort of communication for the device.";
+          For example, if the peer's forwarding table is programmed using gRIBI
+          by an external controller, the local device will continue to receive
+          packets.
+
+          6. An implementation should follow rule #3 even when the subject
+          interface on the local device is the last resort of communication for a
+          given destination.  For example, the only nexthop for a destination is
+          an aggregate interface which has all member interfaces set to
+          forwarding-viable = false.  In this scenario all L3 packets for that
+          destination will be dropped.";
     }
   }
 

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -60,10 +60,9 @@ module openconfig-if-sdn-ext {
           for an aggregate bundle when such a configuration exists on the box.
           Hence, the device musn't disable the bundle because the minimum
           number of member links requirement is not met for the bundle.
-          2. While it is required that L2 protocols like LLDP, LACP must
-          be allowed for transmit and receive on such ports/bundles, CLNS
-          protocol is an exception and must be treated as per the requirement
-          for L3 protocols below.
+          2. L2 protocols like LLDP, LACP must be allowed for transmit and 
+          receive on such ports/bundles, IS-IS should be handled as per the 
+          requirements for L3 protocols below.
           3. L3 packets, control-plane as well as data-plane must be received
           but not transmitted on such ports/bundles. By doing so, expectation
           is that the other end of the connection ceases to use its respective

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -68,7 +68,10 @@ module openconfig-if-sdn-ext {
           port, OR if all member interfaces in a bundle are ever set to be FV=False, 
           expectations are that the remote end of the connection will have its L3 protocol's 
           dead-interval OR hold-down timer expired taking down the adjacency/peering on 
-          that connection.
+          that connection. This by no means suggests that the peer should stop using the 
+          interface/s for forwarding traffic and can continue to do so if an external
+          programming entity has placed forwarding rules with the subject interface/s as
+          the next-hop.
 
           4. An implementation should follow rule #3 even when the subject
           interface is the last resort of communication for the device.";

--- a/release/models/interfaces/openconfig-if-sdn-ext.yang
+++ b/release/models/interfaces/openconfig-if-sdn-ext.yang
@@ -58,7 +58,7 @@ module openconfig-if-sdn-ext {
           Hence, the device mustn't disable the bundle because the minimum
           number of member links requirement is not met for the bundle.
           2. L2 protocols like LLDP, LACP must be allowed for transmit and 
-          receive on such ports/bundles, IS-IS should be handled as per the 
+          receive on such ports/bundles, IS-IS PDUs should be handled as per the 
           requirements for L3 packets below.
           3. L3 packets, control-plane as well as data-plane must be received
           but not transmitted on such ports/bundles. By doing so, expectation


### PR DESCRIPTION
Add more clarity/rules for the forwarding-viable leaf.

1. When a controller "voluntarily" changes the state of all member-links on a LAG bundle or the bundle itself to forwarding-viable=False, it expects that the port/bundle is not used to transmit data-plane traffic even when that is the port of last resort.

a. This requirement can be easily be achieved by an implementation if they follow the rule that, when a port/bundle is set to forwarding-viable=false, do not transmit L3 packets. This is true for both control-plane or data-plane packets. As a result, it would be a graceful transition for L3 traffic on that connection because, the other end of the connection will have its L3 protocol's dead-interval/hold-down timer expired leading for it to migrate away from the connection eventually.

2. I feel minimum-link calculation for aggregate bundle should be ignored for member ports whose forwarding-viable=false. Minimum-Links add unnecessary complications on the controller end. Also, that will result in an implementation to disable a bundle if the min-links requirement is not met and that is not the expectation. Expectation is that, the implementation must continue to Receive and Transmit L2 and only Receive L3 packets on such ports.

3. Finally, in order to remove confusions around IS-IS, the pull calls out that IS-IS should be treated as L3 protocols from this leaf's perspective.

More details in [go/forwarding_viable_expected_behavior](http://goto.google.com/forwarding_viable_expected_behavior)