### PR TITLE
Clarify disable-metric-propagation

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.2.2";
+  oc-ext:openconfig-version "4.2.3";
+
+  revision "2024-01-17" {
+    description
+      "Clarify metric to be used for route redistribution when
+      disable-metric-propagation is set to true.";
+    reference "4.2.3";
+  }
 
   revision "2023-11-03" {
     description

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -31,6 +31,7 @@ submodule openconfig-network-instance-l2 {
       "Clarify metric to be used for route redistribution when
       disable-metric-propagation is set to true.";
     reference "4.4.0";
+  }
 
   revision "2023-12-13" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -55,6 +55,7 @@ module openconfig-network-instance {
       "Clarify metric to be used for route redistribution when
       disable-metric-propagation is set to true.";
     reference "4.4.0";
+  }
 
   revision "2023-12-13" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.2.2";
+  oc-ext:openconfig-version "4.2.3";
+
+  revision "2024-01-17" {
+    description
+      "Clarify metric to be used for route redistribution when
+      disable-metric-propagation is set to true.";
+    reference "4.2.3";
+  }
 
   revision "2023-11-03" {
     description
@@ -1235,8 +1242,8 @@ module openconfig-network-instance {
          - IS-IS metric may be reflected in BGP MED (and vice versa)
          - OSPF metric may be reflected in the BGP MED (and vice versa)
         When this leaf is set to true, this reflection behaviour MUST be
-        disabled, and rather the metric must be set to the default value,
-        or explicitly set by policy.";
+        disabled, and rather the metric must be set to '0' or explicitly
+        set by policy.";
     }
 
     uses oc-rpol:apply-policy-import-config;


### PR DESCRIPTION
### Change Scope

* Specify setting metric to `0` for route redistribution when disable-metric-propagation is set to `true`.
* Previously the description said to use the 'default' metric or policy.  But it is not clear where the 'default' metric is defined.  


### Implementation References

* Example from [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r3-9/routing/configuration/guide/xr12krc39_chapter2.html#task_1061883)
shows metric configuration (either through the default-metric command or a route policy) for redistribution of routes from BGP to EIGRP with a metric specified.  

* Example from [JunOS](https://www.juniper.net/documentation/us/en/software/junos/is-is/bgp/topics/example/isis-community-policy.html) shows metric configuration between BGP and ISIS.
