### PR TITLE
Add `gre` container under next-hops aft entry state. Add `src-ip`, `dst-ip` and `ttl` under `gre` aft entry state for telemetry.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -225,7 +225,9 @@ submodule openconfig-aft-common {
           description
             "When specified, the packet has an GRE
             (Generic Routing Encapsulation)header applied to
-            it before forwarding to the specified next-hop.";
+            it before forwarding to the specified next-hop.
+            encapsulate-header leaf should be set to GRE for this
+            to apply";
 
           container state {
             config false;
@@ -412,10 +414,7 @@ submodule openconfig-aft-common {
       "GRE encapsulation applied on a next-hop";
 
     leaf src-ip {
-      type union {
-        type oc-inet:ip-address;
-        type string;
-      }
+      type oc-inet:ip-address;
       description
         "Source IP address to use for the encapsulated packet. This
          may be expressed as either an IP address or reference

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -418,7 +418,7 @@ submodule openconfig-aft-common {
       type oc-inet:ip-address;
       description
         "The source IP address for the GRE encapsulation may be expressed
-        using this leaf (src-ip) or if may be derived from 
+        using this leaf (src-ip) or if may be derived from
         '../../interface-ref/state/subinterface'";
     }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,15 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+       Add src-ip, dst-ip and ttl under gre aft entry state
+       for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description
@@ -213,6 +221,20 @@ submodule openconfig-aft-common {
           }
         }
 
+        container gre {
+          description
+            "When specified, the packet has an GRE
+            (Generic Routing Encapsulation)header applied to
+            it before forwarding to the specified next-hop.";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to GRE encapsulation.";
+            uses aft-common-entry-nexthop-gre-state;
+          }
+        }
+
         uses oc-if:interface-ref-state;
       }
     }
@@ -382,6 +404,37 @@ submodule openconfig-aft-common {
       type oc-inet:ip-address;
       description
         "Destination IP address to use for the encapsulated packet.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-gre-state {
+    description
+      "GRE encapsulation applied on a next-hop";
+
+    leaf src-ip {
+      type union {
+        type oc-inet:ip-address;
+        type string;
+      }
+      description
+        "Source IP address to use for the encapsulated packet. This
+         may be expressed as either an IP address or reference
+         to the name of an interface.";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+
+    leaf ttl {
+      type uint8;
+      description
+        "This leaf reflects the configured/default TTL value that is used in the
+         outer header during packet encapsulation. When this leaf is not set,
+         the TTL value of the inner packet is copied over as the outer packet's
+         TTL value during encapsulation.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -29,7 +29,8 @@ submodule openconfig-aft-common {
     description
       "Add gre container under next-hops aft entry state.
        Add src-ip, dst-ip and ttl under gre aft entry state
-       for telemetry.";
+       for telemetry. Updated description for
+       tunnel-src-ip-address properties under next-hops.";
     reference "2.5.0";
   }
 
@@ -293,7 +294,7 @@ submodule openconfig-aft-common {
     leaf tunnel-src-ip-address {
       type oc-inet:ip-address;
       description
-        "Where applicable this represents the tunnel source ip address.
+        "Where applicable this represents the vxlan tunnel source ip address.
         For VXLAN this represents the source VTEP ip address";
     }
   }
@@ -411,7 +412,7 @@ submodule openconfig-aft-common {
 
   grouping aft-common-entry-nexthop-gre-state {
     description
-      "GRE encapsulation applied on a next-hop";
+      "GRE encapsulation applied on a IPv4 and IPv6 next-hop.";
 
     leaf src-ip {
       type oc-inet:ip-address;

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -417,9 +417,9 @@ submodule openconfig-aft-common {
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "Source IP address to use for the encapsulated packet. This
-         may be expressed as either an IP address or reference
-         to the name of an interface.";
+        "The source IP address for the GRE encapsulation may be expressed
+        using this leaf (src-ip) or if may be derived from 
+        '../../interface-ref/state/subinterface'";
     }
 
     leaf dst-ip {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,15 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,15 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,15 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,15 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,15 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
 
   revision "2023-09-26" {
     description


### PR DESCRIPTION
* (M) aft/openconfig-aft-common.yang
* (M) aft/openconfig-aft-ethernet.yang
* (M) aft/openconfig-aft-ipv4.yang
* (M) aft/openconfig-aft-ipv6.yang
* (M) aft/openconfig-aft-mpls.yang
* (M) aft/openconfig-aft-pf.yang
* (M) aft/openconfig-aft-state-synced.yang
* (M) aft/openconfig-aft.yang

Change Scope
  - Add `gre` container under next-hops aft entry state. 
  - Add `src-ip`, `dst-ip` and `ttl` under `gre` aft entry state for telemetry.
  - This change is backwards compatible

Platform Implementations
  - Arista [documentation](https://www.arista.com/en/um-eos/eos-nexthop-groups#xx1147395)

Relevant pyang output:
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--ro afts
        |  +--ro next-hops
        |     +--ro next-hop* [index]
        |        +--ro index            -> ../state/index
        |        +--ro state
        |        |  +--ro index?                       uint64
        |        |  +--ro programmed-index?            uint64
        |        |  +--ro ip-address?                  oc-inet:ip-address
        |        |  +--ro mac-address?                 oc-yang:mac-address
        |        |  +--ro pop-top-label?               boolean
        |        |  +--ro pushed-mpls-label-stack*     oc-mplst:mpls-label
        |        |  +--ro encapsulate-header?          oc-aftt:encapsulation-header-type
        |        |  +--ro decapsulate-header?          oc-aftt:encapsulation-header-type
        |        |  +--ro origin-protocol?             identityref
        |        |  +--ro lsp-name?                    string
        |        |  +--ro counters
        |        |  |  +--ro packets-forwarded?   oc-yang:counter64
        |        |  |  +--ro octets-forwarded?    oc-yang:counter64
        |        |  +--ro vni-label?                   oc-evpn-types:evi-id
        |        |  +--ro tunnel-src-ip-address?       oc-inet:ip-address
        |        |  +--ro oc-aftni:network-instance?   oc-ni:network-instance-ref
        |        +--ro ip-in-ip
        |        |  +--ro state
        |        |     +--ro src-ip?   oc-inet:ip-address
        |        |     +--ro dst-ip?   oc-inet:ip-address
        |        +--ro gre
        |        |  +--ro state
        |        |     +--ro src-ip?   oc-inet:ip-address
        |        |     +--ro dst-ip?   oc-inet:ip-address
        |        |     +--ro ttl?      uint8
        |        +--ro interface-ref
        |           +--ro state
        |              +--ro interface?      -> /oc-if:interfaces/interface/name
        |              +--ro subinterface?   -> ../interface]/subinterfaces/subinterface/index
```