### PR TITLE
add bgp comm regex-match

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,8 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    branch=$(git tag -l 'v13.*' | sort -V | tail -1)
+    #branch=$(git tag -l 'v13.*' | sort -V | tail -1)
+    branch=dont-omit-output-when-script-fails
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,8 +52,7 @@ steps:
     git clone git@github.com:openconfig/models-ci.git /go/src/github.com/openconfig/models-ci
     cd /go/src/github.com/openconfig/models-ci
     # Modify the major version to update models-ci version.
-    #branch=$(git tag -l 'v13.*' | sort -V | tail -1)
-    branch=dont-omit-output-when-script-fails
+    branch=$(git tag -l 'v13.*' | sort -V | tail -1)
     git checkout $branch
   volumes:
   - name: 'ssh'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -230,24 +230,6 @@ steps:
   waitFor: ['validator prep', 'go path creation', 'oc-pyang']
   id: 'goyang-ygot'
 
-############### YGNMI ###############
-- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
-  entrypoint: 'bash'
-  args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
-  secretEnv: ['GITHUB_ACCESS_TOKEN']
-  volumes:
-  - name: 'gopath'
-    path: /go
-  env:
-  - 'GOPATH=/go'
-  - '_PR_NUMBER=$_PR_NUMBER'
-  - '_MODEL_ROOT=$_MODEL_ROOT'
-  - 'COMMIT_SHA=$COMMIT_SHA'
-  - '_REPO_SLUG=$_REPO_SLUG'
-  - 'BRANCH_NAME=$BRANCH_NAME'
-  waitFor: ['validator prep', 'go path creation', 'oc-pyang', 'pyangbind']
-  id: 'ygnmi'
-
 ############### PYANG ###############
 - name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
@@ -283,6 +265,24 @@ steps:
     path: /go
   waitFor: ['validator prep', 'oc-pyang']
   id: 'pyangbind'
+
+############### YGNMI ###############
+- name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
+  entrypoint: 'bash'
+  args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
+  secretEnv: ['GITHUB_ACCESS_TOKEN']
+  volumes:
+  - name: 'gopath'
+    path: /go
+  env:
+  - 'GOPATH=/go'
+  - '_PR_NUMBER=$_PR_NUMBER'
+  - '_MODEL_ROOT=$_MODEL_ROOT'
+  - 'COMMIT_SHA=$COMMIT_SHA'
+  - '_REPO_SLUG=$_REPO_SLUG'
+  - 'BRANCH_NAME=$BRANCH_NAME'
+  waitFor: ['validator prep', 'go path creation', 'oc-pyang', 'pyangbind'] # wait for pyangbind to avoid possible OOM.
+  id: 'ygnmi'
 
 ############### COMPATIBILITY REPORT ###############
 - name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -245,7 +245,7 @@ steps:
   - 'COMMIT_SHA=$COMMIT_SHA'
   - '_REPO_SLUG=$_REPO_SLUG'
   - 'BRANCH_NAME=$BRANCH_NAME'
-  waitFor: ['validator prep', 'go path creation', 'oc-pyang']
+  waitFor: ['validator prep', 'go path creation', 'oc-pyang', 'pyangbind']
   id: 'ygnmi'
 
 ############### PYANG ###############

--- a/release/models/bgp/openconfig-bgp-errors.yang
+++ b/release/models/bgp/openconfig-bgp-errors.yang
@@ -18,7 +18,14 @@ submodule openconfig-bgp-errors {
     "This module defines BGP NOTIFICATION message error codes
     and subcodes";
 
-  oc-ext:openconfig-version "5.6.0";
+  oc-ext:openconfig-version "6.0.0";
+
+  revision "2024-01-31" {
+    description
+      "Update community-sets/members/member union type by replacing
+      the bgp-regex type with posix-eregexp.";
+    reference "6.0.0";
+  }
 
   revision "2023-12-26" {
     description

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -596,7 +596,7 @@ module openconfig-bgp-policy {
     leaf-list community-member {
       type union {
         type oc-bgp-types:bgp-std-community-type;
-        type oc-types:posix-eregexp;
+        type oc-bgp-types:bgp-community-regexp-type;
         type oc-bgp-types:bgp-well-known-community-type;
       }
       description

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -8,6 +8,7 @@ module openconfig-bgp-policy {
   prefix "oc-bgp-pol";
 
   // import some basic types
+  import openconfig-types { prefix oc-types; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-routing-policy {prefix oc-rpol; }
   import openconfig-policy-types { prefix oc-pol-types; }
@@ -28,7 +29,12 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "6.3.0";
+  oc-ext:openconfig-version "6.4.0";
+
+  revision "2024-01-31" {
+    description
+    "Add regex-match to community-set.";
+  }
 
   revision "2023-10-23" {
     description
@@ -589,6 +595,14 @@ module openconfig-bgp-policy {
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
         removed.";
+    }
+
+    leaf regex-match {
+      type oc-types:posix-eregexp;
+      description "A regex string used to match BGP communities.
+      This regex should be matched against a string which lists
+      BGP communities each represented as [0-9]+:[0-9]+ and space
+      separated.  The BGP community entries are not order dependent.";
     }
 
     leaf match-set-options {

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -676,7 +676,7 @@ module openconfig-bgp-policy {
 
     leaf-list ext-community-member {
       type union {
-        type oc-bgp-types:bgp-std-community-type;
+        type oc-bgp-types:bgp-ext-community-type;
         type oc-types:posix-eregexp;
       }
       description

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -8,13 +8,12 @@ module openconfig-bgp-policy {
   prefix "oc-bgp-pol";
 
   // import some basic types
-  import openconfig-types { prefix oc-types; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-routing-policy {prefix oc-rpol; }
   import openconfig-policy-types { prefix oc-pol-types; }
   import openconfig-bgp-types { prefix oc-bgp-types; }
   import openconfig-extensions { prefix oc-ext; }
-
+  import openconfig-types { prefix oc-types; }
 
   // meta
   organization
@@ -29,11 +28,13 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "6.4.0";
+  oc-ext:openconfig-version "7.0.0";
 
   revision "2024-01-31" {
     description
-    "Add regex-match to community-set.";
+      "Update community-sets/members/member union type by replacing
+      the bgp-regex type with posix-eregexp.";
+    reference "7.0.0";
   }
 
   revision "2023-10-23" {
@@ -584,25 +585,21 @@ module openconfig-bgp-policy {
     leaf-list community-member {
       type union {
         type oc-bgp-types:bgp-std-community-type;
-        type oc-bgp-types:bgp-community-regexp-type;
+        type oc-types:posix-eregexp;
         type oc-bgp-types:bgp-well-known-community-type;
       }
       description
-        "members of the community set.
+        "Members of the community set.
         For an ADD operation these are the communities that will be added;
         the regexp type is not valid in this operation.
+        
         For REMOVE or REPLACE operations then matching communities will
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
-        removed.";
-    }
-
-    leaf regex-match {
-      type oc-types:posix-eregexp;
-      description "A regex string used to match BGP communities.
-      This regex should be matched against a string which lists
-      BGP communities each represented as [0-9]+:[0-9]+ and space
-      separated.  The BGP community entries are not order dependent.";
+        removed.
+        
+        For MATCH operations a regexp type should be evaluated against
+        each community associated with a prefix one community at a time.";
     }
 
     leaf match-set-options {
@@ -674,17 +671,21 @@ module openconfig-bgp-policy {
 
     leaf-list ext-community-member {
       type union {
-        type oc-bgp-types:bgp-ext-community-type;
-        type oc-bgp-types:bgp-community-regexp-type;
+        type oc-bgp-types:bgp-std-community-type;
+        type oc-types:posix-eregexp;
       }
       description
-        "members of the extended community set
+        "Members of the extended community set.
         For an ADD operation these are the communities that will be added;
         the regexp type is not valid in this operation.
+        
         For REMOVE or REPLACE operations then matching communities will
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
-        removed.";
+        removed.
+        
+        For MATCH operations a regexp type should be evaluated against
+        each community associated with a prefix one community at a time.";
     }
 
     leaf match-set-options {

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -590,16 +590,21 @@ module openconfig-bgp-policy {
       }
       description
         "Members of the community set.
-        For an ADD operation these are the communities that will be added;
-        the regexp type is not valid in this operation.
+        For an ADD operation these are the communities that will be
+        added.  The regexp type is not valid in this operation.
 
         For REMOVE or REPLACE operations then matching communities will
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
         removed.
 
-        For MATCH operations a regexp type should be evaluated against
-        each community associated with a prefix one community at a time.";
+        For MATCH operations the posix-eregexp type should be evaluated
+        against each community associated with a prefix one community
+        at a time.  Communities must be represented as strings in formats
+        conforming to oc-bgp-types:bgp-std-community-type.  For example:
+        - `1000:1000` for a standard community
+        - `route-origin:1000:1000` for the origin type extended community,
+        and so on.";
     }
 
     leaf match-set-options {

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -592,12 +592,12 @@ module openconfig-bgp-policy {
         "Members of the community set.
         For an ADD operation these are the communities that will be added;
         the regexp type is not valid in this operation.
-        
+
         For REMOVE or REPLACE operations then matching communities will
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
         removed.
-        
+
         For MATCH operations a regexp type should be evaluated against
         each community associated with a prefix one community at a time.";
     }
@@ -678,12 +678,12 @@ module openconfig-bgp-policy {
         "Members of the extended community set.
         For an ADD operation these are the communities that will be added;
         the regexp type is not valid in this operation.
-        
+
         For REMOVE or REPLACE operations then matching communities will
         be removed unless match-set-options is INVERT which will
         reverse this to mean that anything that does not match will be
         removed.
-        
+
         For MATCH operations a regexp type should be evaluated against
         each community associated with a prefix one community at a time.";
     }

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -602,9 +602,7 @@ module openconfig-bgp-policy {
         against each community associated with a prefix one community
         at a time.  Communities must be represented as strings in formats
         conforming to oc-bgp-types:bgp-std-community-type.  For example:
-        - `1000:1000` for a standard community
-        - `route-origin:1000:1000` for the origin type extended community,
-        and so on.";
+        `1000:1000` for a standard community";
     }
 
     leaf match-set-options {
@@ -689,8 +687,12 @@ module openconfig-bgp-policy {
         reverse this to mean that anything that does not match will be
         removed.
 
-        For MATCH operations a regexp type should be evaluated against
-        each community associated with a prefix one community at a time.";
+        For MATCH operations the posix-eregexp type should be evaluated
+        against each community associated with a prefix one community
+        at a time.  Communities must be represented as strings in formats
+        conforming to oc-bgp-types:bgp-ext-community-type.  For example:
+        `route-origin:1000:1000` for the origin type extended community,
+        and so on.";
     }
 
     leaf match-set-options {

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -28,8 +28,7 @@ module openconfig-bgp-types {
 
   revision "2024-02-01" {
     description
-      "Remove unused bgp-community-regexp-type in favor of
-      oc-types:posix-eregexp";
+      "Modify bgp-community-regexp-type.";
     reference "6.0.0";
   }
 
@@ -680,6 +679,18 @@ module openconfig-bgp-types {
     reference
       "RFC 4360 - BGP Extended Communities Attribute
        RFC 5668 - 4-Octet AS Specific BGP Extended Community";
+  }
+
+  typedef bgp-community-regexp-type {
+    type oc-types:posix-eregexp;
+    description
+      "Type definition for communities specified as regular
+      expression patterns.  The regular expression must be a
+      POSIX extended regular expression with some limitations
+      which are commonly found in device implementations described
+      in draft-ietf-idr-bgp-model";
+    reference 
+      "https://datatracker.ietf.org/doc/html/draft-ietf-idr-bgp-model";
   }
 
   typedef bgp-origin-attr-type {

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -672,15 +672,6 @@ module openconfig-bgp-types {
        RFC 5668 - 4-Octet AS Specific BGP Extended Community";
   }
 
-  typedef bgp-community-regexp-type {
-    // TODO: needs more work to decide what format these regexps can
-    // take.
-    type oc-types:std-regexp;
-    description
-      "Type definition for communities specified as regular
-      expression patterns";
-  }
-
   typedef bgp-origin-attr-type {
     type enumeration {
       enum IGP {

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -688,7 +688,7 @@ module openconfig-bgp-types {
       expression patterns.  The regular expression must be a
       POSIX extended regular expression with some limitations
       which are commonly found in device implementations described
-      in draft-ietf-idr-bgp-model";
+      in draft-ietf-idr-bgp-model.";
     reference
       "draft-ietf-idr-bgp-model";
   }

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -29,7 +29,7 @@ module openconfig-bgp-types {
 
   revision "2024-02-01" {
     description
-      "Remove unused bgp-community-regexp-type in favor of 
+      "Remove unused bgp-community-regexp-type in favor of
       oc-types:posix-eregexp";
     reference "6.0.0";
   }

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -641,11 +641,15 @@ module openconfig-bgp-types {
         - route-origin:<2b ASN>:<4b value> per RFC4360 section 5
         - route-origin:<4b IPv4>:<2b value> per RFC4360 section 5
         - color:<CO bits>:<4b value> per draft-ietf-idr-segment-routing-te-policy
-          section 3";
+          section 3
+        - link-bandwidth:<2 byte asn>:<bandwidth_value> per
+          draft-ietf-idr-link-bandwidth-07";
+
     reference
       "RFC 4360 - BGP Extended Communities Attribute
        RFC 5668 - 4-Octet AS Specific BGP Extended Community
-       draft-ietf-idr-segment-routing-te-policy";
+       draft-ietf-idr-segment-routing-te-policy
+       draft-ietf-idr-link-bandwidth-07";
   }
 
   typedef bgp-ext-community-recv-type {

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -5,7 +5,6 @@ module openconfig-bgp-types {
 
   prefix "oc-bgp-types";
 
-  import openconfig-types { prefix "oc-types"; }
   import openconfig-inet-types { prefix "oc-inet"; }
   import openconfig-extensions { prefix "oc-ext"; }
 

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -4,7 +4,7 @@ module openconfig-bgp-types {
   namespace "http://openconfig.net/yang/bgp-types";
 
   prefix "oc-bgp-types";
-
+  import openconfig-types { prefix "oc-types"; }
   import openconfig-inet-types { prefix "oc-inet"; }
   import openconfig-extensions { prefix "oc-ext"; }
 
@@ -689,8 +689,8 @@ module openconfig-bgp-types {
       POSIX extended regular expression with some limitations
       which are commonly found in device implementations described
       in draft-ietf-idr-bgp-model";
-    reference 
-      "https://datatracker.ietf.org/doc/html/draft-ietf-idr-bgp-model";
+    reference
+      "draft-ietf-idr-bgp-model";
   }
 
   typedef bgp-origin-attr-type {

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -25,7 +25,14 @@ module openconfig-bgp-types {
     policy. It can be imported by modules that make use of BGP
     attributes";
 
-  oc-ext:openconfig-version "5.6.0";
+  oc-ext:openconfig-version "6.0.0";
+
+  revision "2024-02-01" {
+    description
+      "Remove unused bgp-community-regexp-type in favor of 
+      oc-types:posix-eregexp";
+    reference "6.0.0";
+  }
 
   revision "2023-12-26" {
     description

--- a/release/models/types/openconfig-types.yang
+++ b/release/models/types/openconfig-types.yang
@@ -21,7 +21,13 @@ module openconfig-types {
     are used across OpenConfig models. It can be imported by modules
     that make use of these types.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2024-01-31" {
+    description
+      "Add posix-eregexp type and promote model to version 1.0.0.";
+    reference "1.0.0";
+  }
 
   revision "2019-04-16" {
     description
@@ -99,6 +105,14 @@ module openconfig-types {
       OpenConfig models. Further discussion is required to
       consider the type of regular expressions that are to be
       supported. An initial proposal is POSIX compatible.";
+  }
+
+  typedef posix-eregexp {
+    type string;
+    description
+      "This is a string which represents an extended POSIX
+      regular expression.";
+    reference "IEEE Std 1003.1-2017";
   }
 
   typedef timeticks64 {


### PR DESCRIPTION
### Change Scope

* Add OC type for posix extended regular expressions.
* Change the union type for BGP community sets to use posix extended regular expression.
* Clarify how the regex is used when matching communities.

Rather than using various implementation specific regex implementations
1. A  posix regex format is proposed to be used for BGP community sets.
2. An algorithm for BGP communities to be matched is proposed to make it clear how the regex-match leaf will behave.

The result is a vendor neutral method for writing regex for BGP communities which can be tested.  Testing is possible because the regex implementation is standard and implemented in many open source development and testing tools versus the proprietary regex that are present today.  

This is an incremental step towards an end state for bgp community set modeling described in https://github.com/openconfig/public/pull/883

### Tree Representation
Since this is only a type and description change, there is no change to the OC tree.   Affected paths are:
- `/routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set/config/community-member`
- `/routing-policy/defined-sets/bgp-defined-sets/ext-community-sets/ext-community-set/config/ext-community-member`

### Platform Implementations

Regex based pattern matching for community is widely implemented but most use a proprietary format for the regex.  References are included for comparison of BGP community regex matching behavior.

- [Cisco IOS XR community matching](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-0/routing/command/reference/rr40crs1book_chapter8.html#wp1911706197) explicitly supports regex evaluation for one community at a time.  
- [JunOS community matching using regex](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-bgp-communities-extended-communities-evaluation-in-routing-policy-match-conditions.html) 