### PR TITLE
AFT model improvements (state-synced default change, description refinements, other as protocol/encap type)

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -316,7 +316,7 @@ submodule openconfig-aft-common {
       description
         "The MAC address of the next-hop if resolved by the local
         network instance.
-        
+
         This leaf may have no value if the mac address is determined
         by mechanisms outside route programming -i.e. by ARP or IPv6
         neighbor discovery.";
@@ -647,12 +647,12 @@ submodule openconfig-aft-common {
         path "../../../next-hop-group/state/id";
       }
       description
-        "The backup next-hop-group that is available for the current group. 
+        "The backup next-hop-group that is available for the current group.
         When all entries within the next-hop group become unusable, the backup
         next-hop group is used if specified.
-        
+
         This leaf does not indicate whether the backup-next-hop-group is in
-        active use or not; it only indicates whether a backup NHG is 
+        active use or not; it only indicates whether a backup NHG is
         available";
     }
   }
@@ -679,7 +679,7 @@ submodule openconfig-aft-common {
         is balanced across the next-hops within the group in the
         proportion of weight/(sum of weights of the next-hops within
         the next-hop group).
-        
+
         This is the programmed weight as supplied by the higher level
         protocol or agent; it is not the necessarily the weight
         used in the datapath programming of the NHG.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description
@@ -309,7 +315,11 @@ submodule openconfig-aft-common {
       type oc-yang:mac-address;
       description
         "The MAC address of the next-hop if resolved by the local
-        network instance.";
+        network instance.
+        
+        This leaf may have no value if the mac address is determined
+        by mechanisms outside route programming -i.e. by ARP or IPv6
+        neighbor discovery.";
     }
 
     leaf pop-top-label {
@@ -388,14 +398,15 @@ submodule openconfig-aft-common {
   grouping aft-common-install-protocol {
     description
       "Grouping for a common reference to the protocol which
-      installed an entry.";
+      installed an entry or that resolved a next-hop.";
 
     leaf origin-protocol {
       type identityref {
         base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
       }
       description
-        "The protocol from which the AFT entry was learned.";
+        "The (pseudo) protocol that installed an entry or that
+        resolved a next-hop.";
     }
 
   }
@@ -636,9 +647,13 @@ submodule openconfig-aft-common {
         path "../../../next-hop-group/state/id";
       }
       description
-        "The backup next-hop-group for the current group. When all
-        entries within the next-hop group become unusable, the backup
-        next-hop group is used if specified.";
+        "The backup next-hop-group that is available for the current group. 
+        When all entries within the next-hop group become unusable, the backup
+        next-hop group is used if specified.
+        
+        This leaf does not indicate whether the backup-next-hop-group is in
+        active use or not; it only indicates whether a backup NHG is 
+        available";
     }
   }
 
@@ -663,7 +678,11 @@ submodule openconfig-aft-common {
         "The weight applied to the next-hop within the group. Traffic
         is balanced across the next-hops within the group in the
         proportion of weight/(sum of weights of the next-hops within
-        the next-hop group).";
+        the next-hop group).
+        
+        This is the programmed weight as supplied by the higher level
+        protocol or agent; it is not the necessarily the weight
+        used in the datapath programming of the NHG.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description
@@ -49,7 +55,7 @@ submodule openconfig-aft-state-synced {
 
       leaf ipv4-unicast {
         type boolean;
-        default false;
+        default true;
         description
           "State synced signal indicating consistent device snapshot of
           IPv4 unicast AFT entries. Before setting this flag to true
@@ -60,7 +66,7 @@ submodule openconfig-aft-state-synced {
 
       leaf ipv6-unicast {
         type boolean;
-        default false;
+        default true;
         description
           "State synced signal indicating consistent device snapshot of
           IPv6 unicast AFT entries. Before setting this flag to true

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.1.1";
+
+  revision "2024-02-12" {
+    description
+        "Add other to encapsulation-header-type.";
+      reference "1.1.1";
+  }
 
   revision "2022-05-05" {
     description
@@ -88,6 +94,10 @@ module openconfig-aft-types {
       enum VXLAN {
         description
           "The encapsulation header is a VXLAN packet header";
+      }
+      enum OTHER {
+        description
+          "The encapsulation header is not a format defined by OC";
       }
     }
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.4.0";
+  oc-ext:openconfig-version "2.4.1";
+
+  revision "2024-02-12" {
+    description
+      "Change state-synced defaults to true.";
+    reference "2.4.1";
+  }
 
   revision "2023-09-26" {
     description

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -295,7 +295,7 @@ module openconfig-policy-types {
     description
       "Another type of route.
 
-      The protocol or agent that installed the route does not have an 
+      The protocol or agent that installed the route does not have an
       identity defined by OpenConfig.";
   }
 }

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -24,7 +24,13 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.2.3";
+  oc-ext:openconfig-version "3.2.4";
+
+  revision "2024-02-12" {
+    description
+      "Add INSTALL_PROTOCOL_TYPE other.";
+    reference "3.2.4";
+  }
 
   revision "2022-11-08" {
     description
@@ -282,5 +288,14 @@ module openconfig-policy-types {
       and the derived LOCAL route is
 
       10.244.136.79/32.";
+  }
+
+  identity OTHER {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Another type of route.
+
+      The protocol or agent that installed the route does not have an 
+      identity defined by OpenConfig.";
   }
 }


### PR DESCRIPTION
This code is a Contribution to the OpenConfig Public project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.

Change Scope

Description changes:
* next-hop/mac-address: description now notes that absence of a value may indicate that the mac address will be learned by mechanisms such as ARP/ND and not by direct programming
* next-hop/origin-protocol: description now notes that in the context of a next-hop this refers to the protocol that resolves the next-hop
* next-hop-group/backup-next-hop-group: description now notes that this indicates availability of a backup NHG, not its active use in the datapath at the time when this state is retrieved
* next-hop-group/next-hop/weight: description now notes that this is the raw weight from higher level protocol interaction, and may not be equal to the weight used by the datapath hashing algorithm

Default changes:
afts/state-synced/state/ipv4-unicast: default is changed from FALSE to TRUE
afts/state-synced/state/ipv6-unicast: default is changed from FALSE to TRUE
Rationale: state-synced FALSE represents an abnormal condition, and should therefore be the exception case, not the normal case

Config changes:
INSTALL_PROTOCOL_TYPE: new identity OTHER to allow an implementation to specify that the entry it is reporting was installed by a protocol that is not defined by OpenConfig
encapsulation-header-type: new enum OTHER to allow an implementation to specify that the encapsulation format is not defined by OpenConfig
