### PR TITLE
Fix typo in RFC5303 reference.

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.6.1";
+  oc-ext:openconfig-version "1.6.2";
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2.";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -39,7 +39,7 @@ submodule openconfig-isis-lsp {
   revision "2024-02-20" {
     description
       "Fix typo in RFC reference for adjacency-state.";
-    reference "1.6.2.";
+    reference "1.6.2";
   }
 
   revision "2023-11-01" {

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.6.1";
+  oc-ext:openconfig-version "1.6.2";
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2.";
+  }
 
   revision "2023-11-01" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -25,7 +25,7 @@ submodule openconfig-isis-routing {
   revision "2024-02-20" {
     description
       "Fix typo in RFC reference for adjacency-state.";
-    reference "1.6.2.";
+    reference "1.6.2";
   }
 
   revision "2023-11-01" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.6.1";
+  oc-ext:openconfig-version "1.6.2";
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2.";
+  }
 
   revision "2023-11-01" {
     description
@@ -1827,7 +1833,7 @@ module openconfig-isis {
       type oc-isis-types:isis-interface-adj-state;
       description
         "P2P 3-way ISIS adjacency state(up, down, init, failed).";
-      reference "RFC4303. TLV 240.";
+      reference "RFC5303. TLV 240.";
     }
 
     leaf up-timestamp {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -59,7 +59,7 @@ module openconfig-isis {
   revision "2024-02-20" {
     description
       "Fix typo in RFC reference for adjacency-state.";
-    reference "1.6.2.";
+    reference "1.6.2";
   }
 
   revision "2023-11-01" {
@@ -1833,7 +1833,7 @@ module openconfig-isis {
       type oc-isis-types:isis-interface-adj-state;
       description
         "P2P 3-way ISIS adjacency state(up, down, init, failed).";
-      reference "RFC5303. TLV 240.";
+      reference "RFC5303: TLV 240.";
     }
 
     leaf up-timestamp {


### PR DESCRIPTION
```
 * (M) release/models/isis/openconfig-isis(-lsp|-routing)?.yang
  - Fix typo in reference to RFC5303 in adjacency state leaf.
```

No feature changes, fix typo.

