### PR TITLE
Extending ISIS GR to support configuration of RFC5306/REFC8706 timers

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -932,6 +932,16 @@ module openconfig-isis {
         retaining forwarding information during a remote speaker's restart.";
     }
 
+    leaf non-planed-only {
+      type boolean;
+      description
+        "When this leaf is set to TRUE, planned restart procedures, as
+        described in RFV8706 are not used.";
+      reference
+      "RFC 5706: Restart Signaling
+      for IS-IS";
+    }
+
     leaf restart-time {
       type int64;
       default 30;
@@ -939,9 +949,8 @@ module openconfig-isis {
         "Value of RFC5306/RFC8706 T2 timer";
     }
 
-    leaf interface-time {
+    leaf interface-timer {
       type int64;
-      default 3;
       description
         "Value of RFC5306/RFC8706 T1 timer";
     }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -925,7 +925,31 @@ module openconfig-isis {
         graceful restart procedures during its own restart, but supports
         retaining forwarding information during a remote speaker's restart.";
     }
-    reference "RFC 5306: Restart Signaling for IS-IS.";
+
+    leaf restart-time {
+      type int64;
+      default 30;
+      description
+        "Value of RFC5306/RFC8706 T2 timer";
+    }
+
+    leaf interface-time {
+      type int64;
+      default 3;
+      description
+        "Value of RFC5306/RFC8706 T1 timer";
+
+    leaf interface-time-expirations {
+      type int64;
+      description
+        "Number of times T1 expires before IIH without Restart TLV's RR flag
+        set is sent. That is GR helper is not supported by adjacents
+        Inermediate System";
+    }
+
+    reference 
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
   }
 
   // configuration context containers
@@ -1492,6 +1516,28 @@ module openconfig-isis {
       uses isis-base-level-config;
       uses isis-metric-style-config;
       uses isis-authentication-check-config;
+    }
+
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart.";
+
+      container config {
+        description
+          "This container defines ISIS graceful-restart configuration.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS graceful-restart.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+      }
     }
 
     container system-level-counters {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -947,7 +947,7 @@ module openconfig-isis {
         Inermediate System";
     }
 
-    reference 
+    reference
       "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
       for IS-IS";
   }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -944,6 +944,7 @@ module openconfig-isis {
       default 3;
       description
         "Value of RFC5306/RFC8706 T1 timer";
+    }
 
     leaf interface-time-expirations {
       type int64;


### PR DESCRIPTION
### Change Scope

* add ISIS graceful-restart timer parameters - T2 (restart-time), T1 (interface-time), and number of T1 expirations after which adjacency is considered GR not capable.
* adding graceful-restart container under level, as per RFC5306/8706 timers and capabiolities as well as GR procedures are on per-level basis.

change is non-breaking

### Platform Implementations

 * CISCO IOS-XR: [ISIS NSF](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/78x/b-routing-cg-cisco8000-78x/implement-is-is.html#task_qmk_53t_g3b) 
 ```
RP/0/RP0/CPU0:router# configure
RP/0/RP0/CPU0:router(config)# router isis isp
RP/0/RP0/CPU0:router(config-isis)# nsf ietf
RP/0/RP0/CPU0:router(config-isis)# nsf interface-expires 1
RP/0/RP0/CPU0:router(config-isis) nsf interface-timer 3
RP/0/RP0/CPU0:router(config-isis)# nsf lifetime 30
```
 * Juniper JUNOS: [Configuring Graceful Restart Options for IS-IS
](https://www.juniper.net/documentation/us/en/software/junos/high-availability/topics/task/graceful-restart-for-routing-protocols-configuring.html#section-graceful-restart-options-for-isis)
```
protocols {
    isis {
        graceful-restart {
            disable;
            helper-disable;
            restart-duration seconds;
        }
    }
}
```