### PR TITLE
ISIS graceful-restart timers and planned restart toggle

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,7 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.6.3";
+  oc-ext:openconfig-version "1.7.0";
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -39,7 +39,7 @@ submodule openconfig-isis-lsp {
   revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
-    reference "1.6.3";
+    reference "1.7.0";
   }
 
   revision "2024-02-20" {

--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -36,7 +36,7 @@ submodule openconfig-isis-lsp {
 
   oc-ext:openconfig-version "1.6.3";
 
-  revision "2024-02-27" {
+  revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
     reference "1.6.3";

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,7 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.6.3";
+  oc-ext:openconfig-version "1.7.0";
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -25,7 +25,7 @@ submodule openconfig-isis-routing {
   revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
-    reference "1.6.3";
+    reference "1.7.0";
   }
 
   revision "2024-02-20" {

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -22,7 +22,7 @@ submodule openconfig-isis-routing {
 
   oc-ext:openconfig-version "1.6.3";
 
-  revision "2024-02-27" {
+  revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
     reference "1.6.3";

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,7 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.6.3";
+  oc-ext:openconfig-version "1.7.0";
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -932,6 +932,16 @@ module openconfig-isis {
         retaining forwarding information during a remote speaker's restart.";
     }
 
+    leaf non-planed-only {
+      type boolean;
+      description
+        "When this leaf is set to TRUE, planned restart procedures, as
+        described in RFV8706 are not used.";
+      reference
+      "RFC 5706: Restart Signaling
+      for IS-IS";
+    }
+
     leaf restart-time {
       type int64;
       default 30;
@@ -939,9 +949,8 @@ module openconfig-isis {
         "Value of RFC5306/RFC8706 T2 timer";
     }
 
-    leaf interface-time {
+    leaf interface-timer {
       type int64;
-      default 3;
       description
         "Value of RFC5306/RFC8706 T1 timer";
     }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -56,7 +56,7 @@ module openconfig-isis {
 
   oc-ext:openconfig-version "1.6.3";
 
-  revision "2024-02-27" {
+  revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
     reference "1.6.3";

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.6.2";
+  oc-ext:openconfig-version "1.6.3";
+
+  revision "2024-02-27" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.6.3";
+  }
 
   revision "2024-02-20" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -925,7 +925,31 @@ module openconfig-isis {
         graceful restart procedures during its own restart, but supports
         retaining forwarding information during a remote speaker's restart.";
     }
-    reference "RFC 5306: Restart Signaling for IS-IS.";
+
+    leaf restart-time {
+      type int64;
+      default 30;
+      description
+        "Value of RFC5306/RFC8706 T2 timer";
+    }
+
+    leaf interface-time {
+      type int64;
+      default 3;
+      description
+        "Value of RFC5306/RFC8706 T1 timer";
+
+    leaf interface-time-expirations {
+      type int64;
+      description
+        "Number of times T1 expires before IIH without Restart TLV's RR flag
+        set is sent. That is GR helper is not supported by adjacents
+        Inermediate System";
+    }
+
+    reference 
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
   }
 
   // configuration context containers
@@ -1492,6 +1516,28 @@ module openconfig-isis {
       uses isis-base-level-config;
       uses isis-metric-style-config;
       uses isis-authentication-check-config;
+    }
+
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart.";
+
+      container config {
+        description
+          "This container defines ISIS graceful-restart configuration.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS graceful-restart.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+      }
     }
 
     container system-level-counters {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -947,7 +947,7 @@ module openconfig-isis {
         Inermediate System";
     }
 
-    reference 
+    reference
       "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
       for IS-IS";
   }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -932,7 +932,7 @@ module openconfig-isis {
         retaining forwarding information during a remote speaker's restart.";
     }
 
-    leaf non-planed-only {
+    leaf non-planned-only {
       type boolean;
       description
         "When this leaf is set to TRUE, planned restart procedures as
@@ -952,7 +952,7 @@ module openconfig-isis {
       for ISIS level/LSDB";
 
     leaf restart-time {
-      type unit16;
+      type uint16;
       default 30;
       description
         "Value of RFC5306/RFC8706 T2 timer";

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -1465,6 +1465,25 @@ module openconfig-isis {
         uses isis-bfd-config;
       }
     }
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart for interface";
+
+      container config {
+        description
+          "This container defines interface config parameters for ISIS
+          graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
+      container state {
+        config false;
+        description
+          "This container defines information for ISIS graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
+    }
   }
 
   grouping isis-bfd-config {
@@ -1812,26 +1831,6 @@ module openconfig-isis {
         "This container defines ISIS authentication.";
 
       uses isis-hello-authentication-group;
-    }
-
-    container graceful-restart {
-      description
-        "This container defines ISIS Graceful Restart for interface";
-
-      container config {
-        description
-          "This container defines interface config parameters for ISIS
-          graceful-restart.";
-
-        uses isis-graceful-restart-interface-config;
-      }
-      container state {
-        config false;
-        description
-          "This container defines information for ISIS graceful-restart.";
-
-        uses isis-graceful-restart-interface-config;
-      }
     }
   }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -59,7 +59,7 @@ module openconfig-isis {
   revision "2024-02-28" {
     description
       "ISIS graceful-restart timers and per-level configuration.";
-    reference "1.6.3";
+    reference "1.7.0";
   }
 
   revision "2024-02-20" {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -952,7 +952,7 @@ module openconfig-isis {
       for ISIS level/LSDB";
 
     leaf restart-time {
-      type int64;
+      type unit16;
       default 30;
       description
         "Value of RFC5306/RFC8706 T2 timer";

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -944,6 +944,7 @@ module openconfig-isis {
       default 3;
       description
         "Value of RFC5306/RFC8706 T1 timer";
+    }
 
     leaf interface-time-expirations {
       type int64;

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -935,8 +935,8 @@ module openconfig-isis {
     leaf non-planed-only {
       type boolean;
       description
-        "When this leaf is set to TRUE, planned restart procedures, as
-        described in RFV8706 are not used.";
+        "When this leaf is set to TRUE, planned restart procedures as
+        described in RFC 8706 are not used.";
       reference
       "RFC 5706: Restart Signaling for IS-IS";
     }

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -938,8 +938,7 @@ module openconfig-isis {
         "When this leaf is set to TRUE, planned restart procedures, as
         described in RFV8706 are not used.";
       reference
-      "RFC 5706: Restart Signaling
-      for IS-IS";
+      "RFC 5706: Restart Signaling for IS-IS";
     }
 
     reference

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -942,12 +942,32 @@ module openconfig-isis {
       for IS-IS";
     }
 
+    reference
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
+  }
+
+  grouping isis-graceful-restart-level-config {
+    description
+      "This grouping defines ISIS graceful restart configuration relevant
+      for ISIS level/LSDB";
+
     leaf restart-time {
       type int64;
       default 30;
       description
         "Value of RFC5306/RFC8706 T2 timer";
     }
+
+    reference
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
+  }
+
+  grouping isis-graceful-restart-interface-config {
+    description
+      "This grouping defines ISIS graceful restart configuration relevant
+      for ISIS interface/adjacency";
 
     leaf interface-timer {
       type int64;
@@ -1167,6 +1187,8 @@ module openconfig-isis {
 
         uses admin-config;
         uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-interface-config;
       }
 
       container state {
@@ -1176,6 +1198,8 @@ module openconfig-isis {
 
         uses admin-config;
         uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-interface-config;
       }
     }
 
@@ -1543,7 +1567,7 @@ module openconfig-isis {
           "This container defines ISIS graceful-restart configuration.";
 
         uses admin-config;
-        uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
       }
 
       container state {
@@ -1552,7 +1576,7 @@ module openconfig-isis {
           "This container defines state information for ISIS graceful-restart.";
 
         uses admin-config;
-        uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
       }
     }
 
@@ -1788,6 +1812,26 @@ module openconfig-isis {
         "This container defines ISIS authentication.";
 
       uses isis-hello-authentication-group;
+    }
+
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart for interface";
+
+      contanet config {
+        description
+          "This container defines interface config parameters for ISIS
+          graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
+      contanet state {
+        config false;
+        description
+          "This container defines information for ISIS graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
     }
   }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -1818,14 +1818,14 @@ module openconfig-isis {
       description
         "This container defines ISIS Graceful Restart for interface";
 
-      contanet config {
+      container config {
         description
           "This container defines interface config parameters for ISIS
           graceful-restart.";
 
         uses isis-graceful-restart-interface-config;
       }
-      contanet state {
+      container state {
         config false;
         description
           "This container defines information for ISIS graceful-restart.";

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -969,7 +969,7 @@ module openconfig-isis {
       for ISIS interface/adjacency";
 
     leaf interface-timer {
-      type int64;
+      type uint16;
       description
         "Value of RFC5306/RFC8706 T1 timer";
     }


### PR DESCRIPTION
### Change Scope

* add ISIS graceful-restart timer parameters - T2 (restart-time), T1 (interface-time), and number of T1 expirations after which adjacency is considered GR not capable.
* adding graceful-restart container under level, as per RFC5306/8706 timers and capabilities as well as GR procedures are on per-level basis.
* toggle to enable/disable support for RFC8706 planned restart.

Changes to ISIS global configuration:
```
module: openconfig-network-instance
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw global
                    +--rw graceful-restart
                       +--rw config
                       |  +--rw enabled?                      boolean
                       |  +--rw helper-only?                  boolean
                       |  +--rw non-planed-only?              boolean                        <<< NEW
                       |  +--rw restart-time?                 int64                          <<< NEW
                       |  +--rw interface-timer?              int64                          <<< NEW
                       |  +--rw interface-time-expirations?   int64                          <<< NEW
                       +--ro state
                          +--ro enabled?                      boolean
                          +--ro helper-only?                  boolean
                          +--ro non-planed-only?              boolean                        <<< NEW
                          +--ro restart-time?                 int64                          <<< NEW
                          +--ro interface-timer?              int64                          <<< NEW
                          +--ro interface-time-expirations?   int64                          <<< NEW
```
Changes to ISIS level configuration. Allows distinct timer per LSDB.
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw levels
                    +--rw level* [level-number]
                       +--rw graceful-restart                          <<< NEW
                          +--rw config
                          |  +--rw enabled?        boolean
                          |  +--rw restart-time?   int64
                          +--ro state
                             +--ro enabled?        boolean
                             +--ro restart-time?   int64
```
Changes to ISIS interface configuration. Allows distinct timer per interface.
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw interfaces
                    +--rw interface* [interface-id]
                       +--rw graceful-restart                          <<< NEW
                          +--rw config
                          |  +--rw interface-timer?              int64
                          |  +--rw interface-time-expirations?   int64
                          +--ro state
                             +--ro interface-timer?              int64
                             +--ro interface-time-expirations?   int64
```

change is non-breaking

### Platform Implementations

 * CISCO IOS-XR: [ISIS NSF](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/78x/b-routing-cg-cisco8000-78x/implement-is-is.html#task_qmk_53t_g3b) 
 ```
RP/0/RP0/CPU0:router# configure
RP/0/RP0/CPU0:router(config)# router isis isp
RP/0/RP0/CPU0:router(config-isis)# nsf ietf
RP/0/RP0/CPU0:router(config-isis)# nsf interface-expires 1
RP/0/RP0/CPU0:router(config-isis) nsf interface-timer 3
RP/0/RP0/CPU0:router(config-isis)# nsf lifetime 30
```
 * Juniper JUNOS: [Configuring Graceful Restart Options for IS-IS
](https://www.juniper.net/documentation/us/en/software/junos/high-availability/topics/task/graceful-restart-for-routing-protocols-configuring.html#section-graceful-restart-options-for-isis)
```
protocols {
    isis {
        graceful-restart {
            disable;
            helper-disable;
            restart-duration seconds;
        }
    }
}
```