### PR TITLE
add gnoi service identity to grpc services

### DIFF
--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,7 +22,7 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "1.0.1";
+  oc-ext:openconfig-version "1.1.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,9 +22,15 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2024-03-01" {
+    description
+      "gNOI service identity.";
+    reference "1.0.1";
+  }
 
   revision "2022-04-19" {
     description
@@ -54,6 +60,12 @@ module openconfig-system-grpc {
     base GRPC_SERVICE;
     description
       "gNMI: gRPC Network Management Interface";
+  }
+
+  identity GNOI {
+    base GRPC_SERVICE;
+    description
+      "gNOI: gRPC Network Operations Interface";
   }
 
   grouping grpc-service-structural {

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -29,7 +29,7 @@ module openconfig-system-grpc {
   revision "2024-03-01" {
     description
       "gNOI service identity.";
-    reference "1.0.1";
+    reference "1.1.0";
   }
 
   revision "2022-04-19" {


### PR DESCRIPTION
### Change Scope
- Add `gNOI` grpc service identity to complement the existing list of configurable grpc services (gNMI, gRIBI, P4RT, and soon-to-be-merged gNSI).
- This change is backward compatible.

