### PR TITLE
gnsi: align with latest certz version

### DIFF
--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -30,13 +30,11 @@ module openconfig-gnsi-certz {
     "This module provides a data model for the metadata of gRPC credentials
     installed on a networking device.";
 
-  oc-ext:openconfig-version "0.5.0";
+  oc-ext:openconfig-version "0.6.0";
 
-  revision 2024-03- {
+  revision 2024-03-05 {
     description
-      "align yang with the openconfig/gnsi version as of:
-      https://github.com/openconfig/gnsi/tree/e08ebfe537e1603015291898e6d5e9abe1562a0b
-      (update counter names)";
+      "rename access/reject counters";
     reference "0.6.0";
   }
 

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -32,6 +32,14 @@ module openconfig-gnsi-certz {
 
   oc-ext:openconfig-version "0.5.0";
 
+  revision 2024-03- {
+    description
+      "align yang with the openconfig/gnsi version as of:
+      https://github.com/openconfig/gnsi/tree/e08ebfe537e1603015291898e6d5e9abe1562a0b
+      (update counter names)";
+    reference "0.6.0";
+  }
+
   revision 2024-02-13 {
     description
       "Major style updates and move to openconfig/public from openconfig/gnsi.
@@ -87,36 +95,36 @@ module openconfig-gnsi-certz {
       "A collection of counters that were collected while evaluating
       access to the gRPC server.";
 
-    container certz-counters {
+    container counters {
       config false;
       description
-        "A collection of counters that were collected by the gRPC during
-        the authentication process.";
+      "A collection of counters that were collected by the gRPC during
+      the authentication process.";
 
-      leaf access-rejects {
+      leaf connection-rejects {
         type oc-yang:counter64;
         description
-          "The total number of times a TLS handshake failure has occurred and
-          the gRPC server denied access a client.";
+        "The total number of times that gRPC clients have failed
+        in establishing a connection to the server.";
       }
-      leaf last-access-reject {
+      leaf last-connection-reject {
         type oc-types:timeticks64;
         description
-          "A timestamp of the last time the gRPC denied access to
-          the server.";
+        "A timestamp of the last time a gRPC client failed
+        in establishing a connection to the server.";
       }
-      leaf access-accepts {
+      leaf connection-accepts {
         type oc-yang:counter64;
         description
-          "The total number of times a successful TLS handshake is completed
-          and the gPRC server allows access to a client.";
+        "The total number of times that gRPC clients have succeeded
+        in establishing a connection to the server.";
       }
-      leaf last-access-accept {
+      leaf last-connection-accept {
         type oc-types:timeticks64;
         description
-          "A timestamp of the last time the gRPC allowed access to
-          the server.";
-      }
+        "A timestamp of the last time a gRPC client succeeded
+        in establishing a connection to the server.";
+        }
     }
   }
 


### PR DESCRIPTION
The certz yang file was updated since 
the PR to move from openconfig/gnsi to 
openconfig/public, and this updated
version of certz had not been
included in the PR.

see the changes to gnsi-certz.yang at:
https://github.com/openconfig/gnsi/pull/156

This commit also sets the container
name for the certz counters to be just
"counters" to be backward-compatible 
with the existing gnsi-certz.yang.

The module name/prefix already 
mark these counters as certz-related,
so we don't need to duplicate this
information in the container name too.

### Change Scope

* changes to models:
```yang
    augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state:
    +--ro certz-counters
       +--ro access-rejects?       oc-yang:counter64
       +--ro last-access-reject?   oc-types:timeticks64
       +--ro access-accepts?       oc-yang:counter64
       +--ro last-access-accept?   oc-types:timeticks64
```       
is being changed to:
```yang
  augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state:
    +--ro counters
       +--ro connection-rejects?       oc-yang:counter64
       +--ro last-connection-reject?   oc-types:timeticks64
       +--ro connection-accepts?       oc-yang:counter64
       +--ro last-connection-accept?   oc-types:timeticks64
```
       
* this is not backwards-compatible with the current model at 
https://github.com/openconfig/public/blob/9826cae9e0aa1b81dbe5abcbce842adcc35f7921/release/models/gnsi/openconfig-gnsi-certz.yang (merged 2 days ago so presumably not in-use yet).
However, it is backwards compatible with the current model from the gNSI repo at 
https://github.com/openconfig/gnsi/blob/718ee9102f4676e11485ff151e9caa4fa74f57e1/certz/gnsi-certz.yang
which is in-use by vendors.
The current model from the gNSI repo provides the paths:
```yang
module: gnsi-certz

  augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state:
    +--ro certificate-version?                             version
    +--ro certificate-created-on?                          created-on
    +--ro ca-trust-bundle-version?                         version
    +--ro ca-trust-bundle-created-on?                      created-on
    +--ro certificate-revocation-list-bundle-version?      version
    +--ro certificate-revocation-list-bundle-created-on?   created-on
    +--ro authentication-policy-version?                   version
    +--ro authentication-policy-created-on?                created-on
    +--ro ssl-profile-id?                                  string
    +--ro counters
       +--ro connection-rejects?       oc-yang:counter64
       +--ro last-connection-reject?   oc-types:timeticks64
       +--ro connection-accepts?       oc-yang:counter64
       +--ro last-connection-accept?   oc-types:timeticks64
```

### Platform Implementations

 * Arista Certz support: https://www.arista.com/en/support/toi/eos-4-31-0f/18445-support-for-gnsi-grpc-network-security-interface
 * Cisco Certz support: https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5000/sysman/711x/configuration/guide/b-system-management-cg-ncs5000-711x/configuring-synce.pdf
