### PR TITLE
Update component temperature thresholds

### DIFF
--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,14 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.24.0";
+  oc-ext:openconfig-version "0.25.0";
+
+  revision "2024-03-05" {
+    description
+      "Add high and low temperature thresholds. Deprecate existing 
+      temperature threshold.";
+    reference "0.25.0";
+  }
 
   revision "2023-11-28" {
     description
@@ -598,10 +605,6 @@ module openconfig-platform {
     description
       "Temperature alarm data for platform components";
 
-    // TODO(aashaikh): consider if these leaves could be in a
-    // reusable grouping (not temperature-specific); threshold
-    // may always need to be units specific.
-
     leaf alarm-status {
       type boolean;
       description
@@ -610,7 +613,26 @@ module openconfig-platform {
         cleared.";
     }
 
+    leaf alarm-threshold-low {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The threshold value for high temperature.";
+    }
+
+    leaf alarm-threshold-high {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The threshold value for low temperature.";
+    }
+
     leaf alarm-threshold {
+      status deprecated;
       type uint32;
       description
         "The threshold value that was crossed for this alarm.";


### PR DESCRIPTION
### Change Scope

* Deprecate existing temperature threshold because it uses units (uint32) which are not compatible with temperature (decimal)
* Add high and low temperature thresholds using decimal64 celsius units
* This change is backwards compatible
### Platform Implementations

 * Implementation A: Cisco IOS XR
 ```
=============================================================================================================
Location  TEMPERATURE                          Value     Crit    Major    Minor    Minor    Major    Crit
          Sensor                             (deg C)     (Lo)     (Lo)     (Lo)     (Hi)     (Hi)    (Hi)
-------------------------------------------------------------------------------------------------------------
0/RP0/CPU0 
          MB_JM01_L1_TEMP                        37      -10       -5        0      130      135      140
          MB_JM01_L2_TEMP                        36      -10       -5        0      130      135      140
          MB_JM11_L1_TEMP                        33      -10       -5        0      130      135      140
          MB_JM21_L1_TEMP                        36      -10       -5        0      130      135      140 
```
