### PR TITLE
openconfig/system: add tls-profile-name leaf

### DIFF
--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -30,13 +30,7 @@ module openconfig-gnsi-certz {
     "This module provides a data model for the metadata of gRPC credentials
     installed on a networking device.";
 
-  oc-ext:openconfig-version "0.7.0";
-
-  revision 2024-03-07 {
-    description
-      "add leaf to configure ssl-profile-id";
-    reference "0.7.0";
-  }
+  oc-ext:openconfig-version "0.6.0";
 
   revision 2024-03-05 {
     description
@@ -132,18 +126,6 @@ module openconfig-gnsi-certz {
     }
   }
 
-  grouping grpc-server-certz-ssl-profile-config {
-    description
-      "gRPC server ssl profile configuration";
-
-    leaf ssl-profile-id {
-      type string;
-      description
-        "The ID of this gRPC server's SSL profile
-        as used by the gNSI Certz service";
-    }
-  }
-
   // TODO(earies): move to a system-wide subtree:
   // https://github.com/openconfig/public/issues/1049
   grouping grpc-server-credentials-state {
@@ -201,8 +183,12 @@ module openconfig-gnsi-certz {
         "The timestamp of the moment when the authentication policy
         that is currently used by this gRPC server was created.";
     }
-
-    uses grpc-server-certz-ssl-profile-config;
+    leaf ssl-profile-id {
+      type string;
+      description
+        "The ID of this gRPC server's SSL profile
+        as used by the gNSI Certz service";
+    }
   }
 
   // Augments section.
@@ -222,14 +208,5 @@ module openconfig-gnsi-certz {
     uses grpc-server-certz-counters;
     description
       "gNSI certz server access counters.";
-  }
-
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
-          "oc-sys-grpc:config" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
-    description
-      "gRPC server ssl profile configuration";
-
-    uses grpc-server-certz-ssl-profile-config;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -30,12 +30,18 @@ module openconfig-gnsi-certz {
     "This module provides a data model for the metadata of gRPC credentials
     installed on a networking device.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision 2024-03-14 {
+    description
+      "remove ssl-profile-id comment";
+    reference "0.7.0";
+  }
 
   revision 2024-03-05 {
     description
       "rename access/reject counters";
-    reference "0.6.0";
+    reference "0.7.0";
   }
 
   revision 2024-02-13 {

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -30,7 +30,13 @@ module openconfig-gnsi-certz {
     "This module provides a data model for the metadata of gRPC credentials
     installed on a networking device.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision 2024-03-07 {
+    description
+      "add leaf to configure ssl-profile-id";
+    reference "0.7.0";
+  }
 
   revision 2024-03-05 {
     description
@@ -126,6 +132,18 @@ module openconfig-gnsi-certz {
     }
   }
 
+  grouping grpc-server-certz-ssl-profile-config {
+    description
+      "gRPC server ssl profile configuration";
+
+    leaf ssl-profile-id {
+      type string;
+      description
+        "The ID of this gRPC server's SSL profile
+        as used by the gNSI Certz service";
+    }    
+  }
+
   // TODO(earies): move to a system-wide subtree:
   // https://github.com/openconfig/public/issues/1049
   grouping grpc-server-credentials-state {
@@ -183,15 +201,8 @@ module openconfig-gnsi-certz {
         "The timestamp of the moment when the authentication policy
         that is currently used by this gRPC server was created.";
     }
-    // TODO(earies): Consider aligning this with grpc-server key after moving
-    // to a system-wide subtree:
-    // https://github.com/openconfig/public/issues/1050
-    leaf ssl-profile-id {
-      type string;
-      description
-        "The ID of this gRPC server's SSL profile
-        as used by the gNSI Certz service";
-    }
+
+    uses grpc-server-certz-ssl-profile-config;
   }
 
   // Augments section.
@@ -211,5 +222,14 @@ module openconfig-gnsi-certz {
     uses grpc-server-certz-counters;
     description
       "gNSI certz server access counters.";
+  }
+
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
+          "oc-sys-grpc:config" {
+    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    description
+      "gRPC server ssl profile configuration";
+    
+    uses grpc-server-certz-ssl-profile-config;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -141,7 +141,7 @@ module openconfig-gnsi-certz {
       description
         "The ID of this gRPC server's SSL profile
         as used by the gNSI Certz service";
-    }    
+    }
   }
 
   // TODO(earies): move to a system-wide subtree:
@@ -229,7 +229,7 @@ module openconfig-gnsi-certz {
     when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
     description
       "gRPC server ssl profile configuration";
-    
+
     uses grpc-server-certz-ssl-profile-config;
   }
 }

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -28,7 +28,7 @@ module openconfig-system-grpc {
 
   revision "2024-03-11" {
     description
-     "add tls-profile-name, deprecate certificate-id"
+     "add tls-profile-name, deprecate certificate-id";
     reference "1.1.0";
   }
 

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -174,7 +174,7 @@ module openconfig-system-grpc {
         as the gNOI certificate management service.";
     }
 
-    leaf ssl-profile-name {
+    leaf tls-profile-name {
       type string;
       description
         "Name of the logical grouping of any

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -26,6 +26,11 @@ module openconfig-system-grpc {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
+  revision "2024-03-11" {
+    description
+     "add tls-profile-name, deprecate certificate-id"
+  }
+
   revision "2022-04-19" {
     description
       "Description and default value updates for grpc-server
@@ -161,10 +166,19 @@ module openconfig-system-grpc {
 
     leaf certificate-id {
       type string;
+      status deprecated;
       description
         "Name of the certificate that is associated with the gRPC service. The
         certificate ID is provisioned through other interfaces to the device, such
         as the gNOI certificate management service.";
+    }
+
+    leaf tls-profile-name {
+      type string;
+      description
+        "Name of the logical grouping of any
+        certificate+key/chained certificates/trusted CAs/CRLs,
+        which are associated with the gRPC server";
     }
 
     leaf metadata-authentication {

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -22,13 +22,14 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
   revision "2024-03-11" {
     description
      "add tls-profile-name, deprecate certificate-id"
+    reference "1.1.0";
   }
 
   revision "2022-04-19" {

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -174,7 +174,7 @@ module openconfig-system-grpc {
         as the gNOI certificate management service.";
     }
 
-    leaf ssl-profile-id {
+    leaf ssl-profile-name {
       type string;
       description
         "Name of the logical grouping of any

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -173,7 +173,7 @@ module openconfig-system-grpc {
         as the gNOI certificate management service.";
     }
 
-    leaf tls-profile-name {
+    leaf ssl-profile-id {
       type string;
       description
         "Name of the logical grouping of any

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -171,7 +171,8 @@ module openconfig-system-grpc {
       description
         "Name of the certificate that is associated with the gRPC service. The
         certificate ID is provisioned through other interfaces to the device, such
-        as the gNOI certificate management service.";
+        as the gNOI certificate management service. This leaf has been deprecated
+        in favour of the tls-profile-name leaf.";
     }
 
     leaf tls-profile-name {
@@ -179,7 +180,9 @@ module openconfig-system-grpc {
       description
         "Name of the logical grouping of any
         certificate+key/chained certificates/trusted CAs/CRLs,
-        which are associated with the gRPC server";
+        which are associated with the gRPC server. This grouping
+        is provisioned through other interfaces to the device, such
+        as the gNOI CertificateManagement service or gNSI Certz service";
     }
 
     leaf metadata-authentication {


### PR DESCRIPTION
This was discussed in:
https://github.com/openconfig/public/issues/1050
where it seemed that the 
/system/grpc-servers/grpc-server/config/certificate_id  leaf from 
https://github.com/brianneville/oc-public/blob/7d21dfc82acb9e39ee8b23a05ba3f5101f33b196/release/models/system/openconfig-system-grpc.yang#L162 had effectively been hijacked/repurposed to
provide this utility. 
The leaf added here is explicitly to allow
for configuration of the ssl-profile-id
of a gRPC server.

### Change Scope

* This change adds the following:
```txt
  /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:config:
    +--rw tls-profile-name?   string
 
  /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state:
    +--ro tls-profile-name?   string
```
* This change is backward-compatible, as it is adding a new leaf.

### Platform Implementations

 * Arista SSL profile support: https://www.arista.com/en/um-eos/eos-control-plane-security#xx1004880 
 * Cisco trustpoint support: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/101x/programmability/cisco-nexus-9000-series-nx-os-programmability-guide-release-101x/m-n9k-gnmi-grpc-network-management-interface-101x.html#Cisco_Reference.dita_27eb229d-a636-4b17-a29b-a0d67f48e5cf

(As this is a new leaf it is not supported by any vendor yet)