### PR TITLE
openconfig/system: Add password-mode-type for special behaviors regarding passwords

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,13 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2024-03-12" {
+    description
+      "Add password-mode for admin-user and normal usesrs.";
+      reference "1.0.1";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,13 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2024-03-12" {
+    description
+      "Add password-mode for admin-user and normal usesrs.";
+      reference "1.0.1";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa-types.yang
+++ b/release/models/system/openconfig-aaa-types.yang
@@ -22,7 +22,13 @@ module openconfig-aaa-types {
     "This module defines shared types for data related to AAA
     (authentication, authorization, accounting).";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.4.2";
+
+  revision "2024-03-12" {
+    description
+      "Add password-mode-type.";
+    reference "0.4.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -166,6 +172,28 @@ module openconfig-aaa-types {
         6 | SHA-512
 
       These may not all be supported by a target device.";
+  }
+
+  typedef password-mode-type {
+    type enumeration {
+      enum PASSWORD_DISABLED {
+        description
+          "The user cannot use password to log in.";
+      }
+      enum PASSWORD_NOT_REQUIRED {
+        description
+          "The user can log in without entering a password.";
+      }
+      enum PASSWORD_REQUIRED {
+        description
+          "The user is required to log in with a password, and
+          the password is hashed and stored in the system. If
+          choosing this mode, the operator should also supply
+          the user password, as a hashed value or cleartext.";
+      }
+    }
+    description
+      "Configure the mode of the password for user.";
   }
 
 

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -32,7 +32,13 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2024-03-12" {
+    description
+      "Add password-mode for admin-user and normal usesrs.";
+      reference "1.0.1";
+  }
 
   revision "2022-07-29" {
     description
@@ -321,6 +327,20 @@ module openconfig-aaa {
         using the notation described in the definition of the
         crypt-password-type.";
     }
+
+    leaf admin-password-mode {
+      type oc-aaa-types:password-mode-type;
+      description
+        "The mode of the admin/root password.
+
+        The possible values would be:
+        PASSWORD_DISABLED     <- cannot use password to log in
+        PASSWORD_NOT_REQUIRED <- can log in without a password
+        PASSWORD_REQUIRED     <- other cases
+
+        If PASSWORD_REQUIRED is configured, the operator should
+        also supply the password, as a hashed value or cleartext.";
+    }
   }
 
   grouping aaa-admin-state {
@@ -387,6 +407,20 @@ module openconfig-aaa {
         "The user password, supplied as a hashed value
         using the notation described in the definition of the
         crypt-password-type.";
+    }
+
+    leaf password-mode {
+      type oc-aaa-types:password-mode-type;
+      description
+        "The mode of the user password.
+
+        The possible values would be:
+        PASSWORD_DISABLED     <- cannot use password to log in
+        PASSWORD_NOT_REQUIRED <- can log in without a password
+        PASSWORD_REQUIRED     <- other cases
+
+        If PASSWORD_REQUIRED is configured, the operator should
+        also supply the password, as a hashed value or cleartext.";
     }
 
     leaf ssh-key {


### PR DESCRIPTION
### Change Scope

In current OpenConfig public model, to configure passwords for root/non-root users, the following YANG path is being used respectively:
```
root user:
/system/aaa/authentication/admin-user/config/admin-password-hashed
/system/aaa/authentication/admin-user/state/admin-password-hashed
non-root users:
/system/aaa/authentication/users/user/config/password-hashed
/system/aaa/authentication/users/user/state/password-hashed
```
Other than the normal use case where they contain a hashed value of the password, there are 2 special semantics related to passwords:

1. User can’t use password to login
1. User can login without entering a password

These semantics can be achieved by overloading the existing leaf for passwords(make them not present/present but value is empty string), but that will be not ideal/user friendly. 
So we propose to add a new leaf `password-mode` to explicitly indicate these special behaviors. It's a enum with 3 values: `PASSWORD_DISABLED` indicates that user can't use password to log in; `PASSWORD_NOT_REQUIRED` indicates that user can log in without a password; and `PASSWORD_REQUIRED` for normal cases. 

This new leaf will become sibling to `password-hashed` and `admin-password-hashed` to explicitly describe the password behavior. So the YANG tree will have the following newly added leafs:

```
module: openconfig-system
  +--rw system
     +--rw aaa
        +--rw authentication
           +--rw admin-user
              +--rw config
              |  +--rw admin-password-mode?     oc-aaa-types:password-mode-type
              +--ro state
                 +--ro admin-password-mode?     oc-aaa-types:password-mode-type

module: openconfig-system
  +--rw system
     +--rw aaa
        +--rw authentication
           +--rw users
              +--rw user* [username]
                 +--rw username    -> ../config/username
                 +--rw config
                 |  +--rw password-mode?     oc-aaa-types:password-mode-type
                 +--ro state
                    +--ro password-mode?     oc-aaa-types:password-mode-type
```


This change is backwards compatible.

### Platform Implementations

 * Arista EOS User Security: [https://www.arista.com/en/um-eos/eos-user-security/](https://www.arista.com/en/um-eos/eos-user-security/)
