### PR TITLE
Add interfaces layer property to openconfig-interfaces model

### DIFF
--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -1,0 +1,52 @@
+module openconfig-if-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces/types";
+
+  prefix "oc-if-types";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Types associated with a interface";
+
+  oc-ext:openconfig-version "3.7.1";
+
+  revision "2024-03-14" {
+    description
+      "Add layer types";
+    reference "3.7.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+  identity interface_layer {
+    description
+      "A base identity which can be extended to indicate different
+      layers supported by an interface.";
+  }
+
+  identity L2 {
+    base interface_layer;
+    description
+      "Layer 2 Switching/Bridging interface";
+  }
+
+  identity L3 {
+    base interface_layer;
+    description
+      "Layer 3 Routing interface";
+  }
+}

--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -32,20 +32,20 @@ module openconfig-if-types {
   oc-ext:origin "openconfig";
 
   // identity statements
-  identity interface_layer {
+  identity INTERFACE_LAYER {
     description
       "A base identity which can be extended to indicate different
       layers supported by an interface.";
   }
 
   identity L2 {
-    base interface_layer;
+    base INTERFACE_LAYER;
     description
       "Layer 2 Switching/Bridging interface";
   }
 
   identity L3 {
-    base interface_layer;
+    base INTERFACE_LAYER;
     description
       "Layer 3 Routing interface";
   }

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -13,6 +13,7 @@ module openconfig-interfaces {
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-transport-types { prefix oc-opt-types; }
+  import openconfig-if-types { prefix oc-if-types; }
 
   // meta
   organization "OpenConfig working group";
@@ -51,7 +52,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.7.0";
+  oc-ext:openconfig-version "3.8.0";
+
+  revision "2024-04-03" {
+      description
+        "Add layer leaf to interface to indicate the layer at which the interface operates.";
+      reference
+        "3.8.0";
+  }
 
   revision "2023-11-06" {
       description
@@ -342,6 +350,23 @@ module openconfig-interfaces {
         datastore.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifAlias";
+    }
+
+    leaf enabled {
+      type boolean;
+      default "true";
+      description
+        "This leaf contains the configured, desired state of the
+        interface.
+        Systems that implement the IF-MIB use the value of this
+        leaf in the 'running' datastore to set
+        IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+        has been initialized, as described in RFC 2863.
+        Changes in this leaf in the 'running' datastore are
+        reflected in ifAdminStatus, but if ifAdminStatus is
+        changed over SNMP, this leaf is not affected.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
     }
 
     leaf enabled {

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -358,10 +358,12 @@ module openconfig-interfaces {
       description
         "This leaf contains the configured, desired state of the
         interface.
+
         Systems that implement the IF-MIB use the value of this
         leaf in the 'running' datastore to set
         IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
         has been initialized, as described in RFC 2863.
+
         Changes in this leaf in the 'running' datastore are
         reflected in ifAdminStatus, but if ifAdminStatus is
         changed over SNMP, this leaf is not affected.";
@@ -369,25 +371,21 @@ module openconfig-interfaces {
         "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
     }
 
-    leaf enabled {
-      type boolean;
-      default "true";
+    leaf layer {
+      type identityref {
+        base oc-if-types:interface_layer;
+      }
       description
-        "This leaf contains the configured, desired state of the
-        interface.
+        "The network layer of the interface.
 
-        Systems that implement the IF-MIB use the value of this
-        leaf in the 'running' datastore to set
-        IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
-        has been initialized, as described in RFC 2863.
-
-        Changes in this leaf in the 'running' datastore are
-        reflected in ifAdminStatus, but if ifAdminStatus is
-        changed over SNMP, this leaf is not affected.";
-      reference
-        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+        When an interface entry is created and the name of the
+        interface requires the interface to operate on a specific
+        network layer, the server MAY initialize the layer leaf
+        with a valid layer value.
+        If a client tries to set the layer of an interface to a
+        value that can never be used by the system, the server
+        MUST reject the request.";
     }
-
   }
 
   grouping interface-phys-config {

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -373,7 +373,7 @@ module openconfig-interfaces {
 
     leaf layer {
       type identityref {
-        base oc-if-types:interface_layer;
+        base oc-if-types:INTERFACE_LAYER;
       }
       description
         "The network layer of the interface.


### PR DESCRIPTION
### Change Scope
The proposal is to add an additional "layer" leaf to interface
This is to explicitly specify the interface layer.
```
interfaces
   +-- interface[name]
           +-- config
           +     +-- name
           +     +-- type
           |     +-- layer <<< new leaf
           +-- state
                 +-- layer
```
- The layer can by Layer2 or Layer3
- This change is backward compatible
   When the 'layer" is not specified, the behavior is the same as if the "layer" is not defined in the previous model.

pyang tree output 

```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw name                  -> ../config/name
        +--rw config
        |  +--rw name?            string
        |  +--rw type             identityref
        |  +--rw mtu?             uint16
        |  +--rw loopback-mode?   oc-opt-types:loopback-mode-type
        |  +--rw description?     string
        |  +--rw enabled?         boolean
        |  +--rw layer?           identityref
        +--ro state
        |  +--ro name?            string
        |  +--ro type             identityref
        |  +--ro mtu?             uint16
        |  +--ro loopback-mode?   oc-opt-types:loopback-mode-type
        |  +--ro description?     string
        |  +--ro enabled?         boolean
        |  +--ro layer?           identityref
        |  +--ro ifindex?         uint32
        |  +--ro admin-status     enumeration
        |  +--ro oper-status      enumeration
        |  +--ro last-change?     oc-types:timeticks64
        |  +--ro logical?         boolean
        |  +--ro management?      boolean
        |  +--ro cpu?             boolean
```

### Rationale

Currently in openconfig-interface, there is no “layer” information for an interface,
while L2 (switching) / L3 (routing) child configs are all mixed across the interface model.
- Example L2 config : switch-vlan, dot1x, etc
- Example L3 config : proxy-arp, ip addressed, dhcp, etc

Since the interface can mix and match both L2 and L3 config, the model user could have the impression that any given interface can operate concurrently in both the switching and routing mode. This is not true across vendors. Commonly an interface either operates in L2 or L3 mode, and it requires explicit configuration to toggle the interface layer.

The lack of the “layer” affects both the model user and the target device :
- Currently the model user would need to infer the interface layer.
  * Via the interface "name"
     The interface name may suggest its operating layer.
     For example, when the interface name is like vl12, Vlan12, lo100,
     the user can infer these interfaces are logical, and thus are used for routing.
     But such naming semantics is rather vendor specific

  * Via the interface "type"
     Some specific interface types could also suggest its operarting layer.
     For example, the type "iana:softwareLoopback" is a lookback, and thus deemed for routing.
     Though commonly, the interface type refers more to the underlying medium/technology.
     For example, the type "iana:ethernetCsmacd" only means the inteface is an ethernet link,
     it does not tell whether such ethernet interface serves for switching or routing.

- Oppositely, the target device also needs to infer the model user’s intent.
   Take the above ethernet interface as example. The interface may support either L2 or L3 functionality.  
   . If the user ever touches the L3-ish config, like ip (or dhcp, etc), then toggle the interface to L3
   . If the user ever touches the L2-ish config, like vlan (or dot1q, etc), then toggle the interface to L2.

These guess works are not straight-forward nor unreliable.
Thus the proposal is to add a new config leaf “interfaces/interface/config/layer” to eliminate such uncertainty/ambiguity.
Though to emphasize again, the new "layer" config is optional.  If the "layer" is not specified, the behavior remains the same as the current behavior.


### Platform Implementations

 * Cisco NXOS:
     * [Configure Layer2 Interfaces](https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/104x/configuration/interfaces/cisco-nexus-9000-series-nx-os-interfaces-configuration-guide-release-104x/m_configuring_layer_2_interfaces_9x.html)
     * [Configure Layer 3 Interfaces](https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/104x/configuration/interfaces/cisco-nexus-9000-series-nx-os-interfaces-configuration-guide-release-104x/m_configuring_layer_3_interfaces_9x.html)
 * Arista:
     * [Configure Layer2 Interfaces](https://www.arista.com/en/um-eos/eos-layer-2-configuration)
     * [Configure Layer3 Interfaces](https://www.arista.com/en/um-eos/eos-layer-3-configuration)
