### PR TITLE
Add media-channel expected-power to openconfig-channel-monitor

### DIFF
--- a/release/models/optical-transport/openconfig-channel-monitor.yang
+++ b/release/models/optical-transport/openconfig-channel-monitor.yang
@@ -26,7 +26,7 @@ module openconfig-channel-monitor {
     channel monitor (OCM) for optical transport line system
     elements such as wavelength routers (ROADMs) and amplifiers.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.5.0";
 
   revision "2024-04-04" {
     description

--- a/release/models/optical-transport/openconfig-channel-monitor.yang
+++ b/release/models/optical-transport/openconfig-channel-monitor.yang
@@ -31,7 +31,7 @@ module openconfig-channel-monitor {
   revision "2024-04-04" {
     description
       "Add new leaf media-channel target-power.";
-    reference "0.4.1";
+    reference "0.5.0";
   }
 
   revision "2019-10-24" {

--- a/release/models/optical-transport/openconfig-channel-monitor.yang
+++ b/release/models/optical-transport/openconfig-channel-monitor.yang
@@ -26,7 +26,13 @@ module openconfig-channel-monitor {
     channel monitor (OCM) for optical transport line system
     elements such as wavelength routers (ROADMs) and amplifiers.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2024-04-04" {
+    description
+      "Add new leaf media-channel target-power.";
+    reference "0.4.1";
+  }
 
   revision "2019-10-24" {
     description
@@ -170,7 +176,7 @@ module openconfig-channel-monitor {
     }
   }
 
-leaf target-power {
+    leaf target-power {
       type decimal64 {
         fraction-digits 2;
       }
@@ -179,7 +185,6 @@ leaf target-power {
         "Target optical power over the specified spectrum";
     }
   }
-
 
   grouping media-channel-spectrum-power-top {
     description

--- a/release/models/optical-transport/openconfig-channel-monitor.yang
+++ b/release/models/optical-transport/openconfig-channel-monitor.yang
@@ -170,6 +170,16 @@ module openconfig-channel-monitor {
     }
   }
 
+leaf target-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Target optical power over the specified spectrum";
+    }
+  }
+
 
   grouping media-channel-spectrum-power-top {
     description

--- a/release/models/optical-transport/openconfig-channel-monitor.yang
+++ b/release/models/optical-transport/openconfig-channel-monitor.yang
@@ -174,7 +174,6 @@ module openconfig-channel-monitor {
       description
         "Average measured optical power over the specified spectrum";
     }
-  }
 
     leaf target-power {
       type decimal64 {


### PR DESCRIPTION
Reference: https://github.com/openconfig/public/issues/1066
This change is backwards compatible.