### PR TITLE
Replace backtick with apostrophe in interfaces model descriptions

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.7.0";
+  oc-ext:openconfig-version "3.7.1";
+
+  revision "2024-04-04" {
+      description
+        "Use single quotes in descriptions.";
+      reference
+        "3.7.1";
+  }
 
   revision "2023-11-06" {
       description
@@ -520,7 +527,7 @@ module openconfig-interfaces {
       units milliseconds;
       default 0;
       description
-        "Maximum time an interface can remain damped since the last link down event no matter how unstable it has been prior to this period of stability. In a damped state, the interface’s state change will not be advertised.";
+        "Maximum time an interface can remain damped since the last link down event no matter how unstable it has been prior to this period of stability. In a damped state, the interface's state change will not be advertised.";
     }
 
     leaf decay-half-life {
@@ -528,7 +535,7 @@ module openconfig-interfaces {
       units milliseconds;
       default 0;
         description
-          "The amount of time after which an interface’s penalty is decreased by half. Decay-half-time should not be more than max-suppress-time.";
+          "The amount of time after which an interface's penalty is decreased by half. Decay-half-time should not be more than max-suppress-time.";
     }
 
     leaf suppress-threshold {


### PR DESCRIPTION
Replace backtick with apostrophe in description fields.