### PR TITLE
Add interface name type with regex pattern constraint

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -206,8 +206,8 @@ module openconfig-interfaces {
 
   typedef interface-full-id {
     type string {
-      pattern '(.*)\.([0-9]{*})';
-      oc-ext:posix-pattern '^(.*)\.([0-9]{*})$';
+      pattern '(.*)\.([0-9]*)';
+      oc-ext:posix-pattern '^(.*)\.([0-9]*)$';
     }
     description
       "This is a string which identifies an interface + subinterface

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -206,8 +206,8 @@ module openconfig-interfaces {
 
   typedef interface-full-id {
     type string {
-      pattern '(.*)\.([0-9]*)';
-      oc-ext:posix-pattern '^(.*)\.([0-9]*)$';
+      pattern '(.+)\.([0-9]+)';
+      oc-ext:posix-pattern '^(.+)\.([0-9]+)$';
     }
     description
       "This is a string which identifies an interface + subinterface

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.7.0";
+  oc-ext:openconfig-version "3.8.0";
+
+  revision "2024-04-10" {
+      description
+        "Add typedef interface-full-id.";
+      reference
+        "3.8.0";
+  }
 
   revision "2023-11-06" {
       description
@@ -195,6 +202,16 @@ module openconfig-interfaces {
       name a interface reference.  The id can be arbitrary but a
       useful convention is to use a combination of base interface
       name and subinterface index.";
+  }
+
+  typedef interface-full-id {
+    type string {
+      pattern '(.*)\.([0-9]{*})';
+      oc-ext:posix-pattern '^(.*)\.([0-9]{*})$';
+    }
+    description
+      "This is a string which identifies an interface + subinterface
+      index.";
   }
 
   // grouping statements

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -206,8 +206,8 @@ module openconfig-interfaces {
 
   typedef interface-full-id {
     type string {
-      pattern '(.+)\.([0-9]+)';
-      oc-ext:posix-pattern '^(.+)\.([0-9]+)$';
+      pattern '([^.]+)(\.[0-9]+)?';
+      oc-ext:posix-pattern '^([^.]+)(\.[0-9]+)?$';
     }
     description
       "This is a string which identifies an interface + subinterface

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -210,8 +210,10 @@ module openconfig-interfaces {
       oc-ext:posix-pattern '^([^.]+)(\.[0-9]+)?$';
     }
     description
-      "This is a string which identifies an interface + subinterface
-      index.";
+      "This string identifies an interface and optionally a subinterface
+      index.  If the subinterface index is specified, the value should
+      be equal to the /interfaces/interface/subinterfaces/subinterface/index 
+      being identified.";
   }
 
   // grouping statements

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -212,7 +212,7 @@ module openconfig-interfaces {
     description
       "This string identifies an interface and optionally a subinterface
       index.  If the subinterface index is specified, the value should
-      be equal to the /interfaces/interface/subinterfaces/subinterface/index 
+      be equal to the /interfaces/interface/subinterfaces/subinterface/index
       being identified.";
   }
 


### PR DESCRIPTION
### Change Scope

* This proposes a typedef for a fully qualified interface name with a specific pattern of the name followed by a subinterface index.  
* It's imagined that this would be used for interface-refs where it is necessary to point to a fully specified interfaces and subinterface.

See also https://github.com/openconfig/public/pull/573 for content on naming of subinterfaces.

