### PR TITLE
Refactor gRPC service modeling

### DIFF
--- a/release/models/gnmi/.spec.yml
+++ b/release/models/gnmi/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-gnmi
+  docs:
+    - yang/gnmi/openconfig-gnmi.yang
+    - yang/gnmi/openconfig-gnmi-types.yang
+  build:
+    - yang/gnmi/openconfig-gnmi.yang
+  run-ci: true

--- a/release/models/gnmi/openconfig-gnmi-types.yang
+++ b/release/models/gnmi/openconfig-gnmi-types.yang
@@ -1,0 +1,43 @@
+module openconfig-gnmi-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/gnmi/types";
+  prefix "oc-gnmit";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  import openconfig-grpc-types {
+    prefix oc-grpct;
+  }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state relating to gRPC
+    services running on a network device. The GRPC_SERVICE identity is used
+    to create an extensible list of services that can be instantiated, with
+    a base set defined in this module. New services can extend the identity
+    to be included in the list.";
+
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision 2024-04-23 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GNMI {
+    base oc-grpct:GRPC_SERVICE;
+    description
+      "gNMI: gRPC Network Management Interface";
+  }
+
+}

--- a/release/models/gnmi/openconfig-gnmi.yang
+++ b/release/models/gnmi/openconfig-gnmi.yang
@@ -1,7 +1,7 @@
-module openconfig-gnsi {
+module openconfig-gnmi {
   yang-version "1";
-  namespace "http://openconfig.net/yang/gnsi";
-  prefix "oc-gnsi";
+  namespace "http://openconfig.net/yang/gnmi";
+  prefix "oc-gnmi";
 
   import openconfig-extensions {
     prefix oc-ext;
@@ -19,8 +19,8 @@ module openconfig-gnsi {
     prefix oc-grpc-common;
   }
 
-  import openconfig-gnsi-types {
-    prefix oc-gnsit;
+  import openconfig-gnmi-types {
+    prefix oc-gnmit;
   }
 
   organization
@@ -41,11 +41,11 @@ module openconfig-gnsi {
     reference "0.1.0";
   }
 
-  grouping gnsi-base {
+  grouping gnmi-base {
     description
       "";
 
-    container gnsi {
+    container gnmi {
       description
         "";
 
@@ -55,8 +55,8 @@ module openconfig-gnsi {
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
           "/oc-sys-grpc:grpc-server/oc-sys-grpc:services" {
-    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnsit:GNMI'";
+    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnmit:GNMI'";
 
-    uses gnsi-base;
+    uses gnmi-base;
   }
 }

--- a/release/models/gnoi/openconfig-gnoi-types.yang
+++ b/release/models/gnoi/openconfig-gnoi-types.yang
@@ -1,0 +1,39 @@
+module openconfig-gnoi-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/gnoi/types";
+  prefix "oc-gnoi-types";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  import openconfig-grpc-types {
+    prefix oc-grpct;
+  }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module contain";
+
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision 2024-04-23 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GNOI {
+    base oc-grpct:GRPC_SERVICE;
+    description
+      "gNOI: gRPC Network Operations Interface";
+  }
+
+}

--- a/release/models/gnoi/openconfig-gnoi.yang
+++ b/release/models/gnoi/openconfig-gnoi.yang
@@ -1,7 +1,7 @@
-module openconfig-gnsi {
+module openconfig-gnoi {
   yang-version "1";
-  namespace "http://openconfig.net/yang/gnsi";
-  prefix "oc-gnsi";
+  namespace "http://openconfig.net/yang/gnoi";
+  prefix "oc-gnoi";
 
   import openconfig-extensions {
     prefix oc-ext;
@@ -19,12 +19,12 @@ module openconfig-gnsi {
     prefix oc-grpc-common;
   }
 
-  import openconfig-gnsi-types {
-    prefix oc-gnsit;
+  import openconfig-gnoi-types {
+    prefix oc-gnoi-types;
   }
 
   organization
-    "OpenConfig Working group";
+    "OpenConfig working group";
   contact
     "www.openconfig.net";
 
@@ -41,11 +41,11 @@ module openconfig-gnsi {
     reference "0.1.0";
   }
 
-  grouping gnsi-base {
+  grouping gnoi-base {
     description
       "";
 
-    container gnsi {
+    container gnoi {
       description
         "";
 
@@ -55,8 +55,8 @@ module openconfig-gnsi {
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
           "/oc-sys-grpc:grpc-server/oc-sys-grpc:services" {
-    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnsit:GNMI'";
+    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnoi-types:GNOI'";
 
-    uses gnsi-base;
+    uses gnoi-base;
   }
 }

--- a/release/models/gnpsi/.spec.yml
+++ b/release/models/gnpsi/.spec.yml
@@ -1,0 +1,7 @@
+- name: openconfig-gnpsi
+  docs:
+    - yang/gnpsi/openconfig-gnpsi.yang
+    - yang/gnpsi/openconfig-gnpsi-types.yang
+  build:
+    - yang/gnpsi/openconfig-gnpsi.yang
+  run-ci: true

--- a/release/models/gnpsi/openconfig-gnpsi-types.yang
+++ b/release/models/gnpsi/openconfig-gnpsi-types.yang
@@ -1,0 +1,38 @@
+module openconfig-gnpsi-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/gnpsi/types";
+  prefix "oc-gnpsit";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  import openconfig-grpc-types {
+    prefix oc-grpct;
+  }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "";
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision 2024-04-23 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GNPSI {
+    base oc-grpct:GRPC_SERVICE;
+    description
+      "gNMI: gRPC Network Management Interface";
+  }
+
+}

--- a/release/models/gnpsi/openconfig-gnpsi.yang
+++ b/release/models/gnpsi/openconfig-gnpsi.yang
@@ -1,7 +1,7 @@
-module openconfig-gnsi {
+module openconfig-gnpsi {
   yang-version "1";
-  namespace "http://openconfig.net/yang/gnsi";
-  prefix "oc-gnsi";
+  namespace "http://openconfig.net/yang/gnpsi";
+  prefix "oc-gnpsi";
 
   import openconfig-extensions {
     prefix oc-ext;
@@ -19,8 +19,8 @@ module openconfig-gnsi {
     prefix oc-grpc-common;
   }
 
-  import openconfig-gnsi-types {
-    prefix oc-gnsit;
+  import openconfig-gnpsi-types {
+    prefix oc-gnpsit;
   }
 
   organization
@@ -41,11 +41,11 @@ module openconfig-gnsi {
     reference "0.1.0";
   }
 
-  grouping gnsi-base {
+  grouping gnpsi-base {
     description
       "";
 
-    container gnsi {
+    container gnpsi {
       description
         "";
 
@@ -55,8 +55,8 @@ module openconfig-gnsi {
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
           "/oc-sys-grpc:grpc-server/oc-sys-grpc:services" {
-    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnsit:GNMI'";
+    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gnpsit:GNPSI'";
 
-    uses gnsi-base;
+    uses gnpsi-base;
   }
 }

--- a/release/models/gnsi/.spec.yml
+++ b/release/models/gnsi/.spec.yml
@@ -1,4 +1,13 @@
 - name: openconfig-system-gnsi
+  docs:
+    - yang/system/openconfig-system.yang
+    - yang/gnsi/openconfig-gnsi.yang
+    - yang/gnsi/openconfig-gnsi-types.yang
+    - yang/gnsi/openconfig-gnsi-acctz.yang
+    - yang/gnsi/openconfig-gnsi-authz.yang
+    - yang/gnsi/openconfig-gnsi-certz.yang
+    - yang/gnsi/openconfig-gnsi-credentialz.yang
+    - yang/gnsi/openconfig-gnsi-pathz.yang
   build:
     - yang/system/openconfig-system.yang
     - yang/gnsi/openconfig-gnsi.yang

--- a/release/models/gnsi/openconfig-gnsi-acctz.yang
+++ b/release/models/gnsi/openconfig-gnsi-acctz.yang
@@ -3,22 +3,30 @@ module openconfig-gnsi-acctz {
   namespace "https://github.com/openconfig/yang/gnsi/acctz";
   prefix oc-gnsi-acctz;
 
-  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
   import openconfig-system {
     prefix oc-sys;
   }
+
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
+
   import openconfig-types {
     prefix oc-types;
   }
+
   import openconfig-yang-types {
     prefix oc-yang;
   }
+
   import openconfig-gnsi {
     prefix oc-gnsi;
   }
+
   organization
     "OpenConfig Working Group";
 
@@ -205,41 +213,44 @@ module openconfig-gnsi-acctz {
     }
   }
 
-  grouping grpc-server-acctz-counters {
+  grouping acctz-counters {
     description
       "A collection of counters from the gNSI.acctz module.";
 
-    container acctz-counters {
+    container counters {
       config false;
       description
         "A collection of counters from the gNSI.acctz module
         for acctz clients and sources.";
 
-      container state {
+      leaf last-cleared {
+        type oc-types:timeticks64;
         description
-          "Operational state relating to acctz-counters.";
-
-        leaf counters-last-cleared {
-          type oc-types:timeticks64;
-          description
-            "The last time that the counters were cleared (reset to
-            zero). This value is reported as nanoseconds since epoch
-            (January 1st, 1970 00:00:00 GMT).";
-        }
-
-        uses client-counters;
+          "The last time that the counters were cleared (reset to
+          zero). This value is reported as nanoseconds since epoch
+          (January 1st, 1970 00:00:00 GMT).";
       }
 
+      uses client-counters;
       uses source-counters;
     }
   }
 
-  // Augments section.
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
-    when "config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+  grouping acctz-base {
     description
-      "Counters collected by the gNSI.acctz module.";
+      "";
 
-    uses grpc-server-acctz-counters;
+    container acctz {
+      description
+        "";
+
+      uses acctz-counters;
+    }
+  }
+
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services/oc-gnsi:gnsi" {
+
+    uses acctz-base;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-authz.yang
+++ b/release/models/gnsi/openconfig-gnsi-authz.yang
@@ -3,22 +3,30 @@ module openconfig-gnsi-authz {
   namespace "https://github.com/openconfig/yang/gnsi/authz";
   prefix oc-gnsi-authz;
 
-  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
   import openconfig-system {
     prefix oc-sys;
   }
+
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
+
   import openconfig-types {
     prefix oc-types;
   }
+
   import openconfig-yang-types {
     prefix oc-yang;
   }
+
   import openconfig-gnsi {
     prefix oc-gnsi;
   }
+
   organization
     "OpenConfig Working Group";
 
@@ -31,6 +39,12 @@ module openconfig-gnsi-authz {
     authorization policies installed on a networking device.";
 
   oc-ext:openconfig-version "0.4.0";
+
+  revision 2024-04-23 {
+    description
+      "";
+    reference "";
+  }
 
   revision 2024-02-13 {
     description
@@ -191,8 +205,6 @@ module openconfig-gnsi-authz {
     }
   }
 
-  // Augments section.
-
   augment "/oc-sys:system/oc-sys:aaa/oc-sys:authorization/" +
     "oc-sys:state" {
       description
@@ -201,12 +213,21 @@ module openconfig-gnsi-authz {
       uses grpc-server-authz-policy-state;
   }
 
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
-    when "config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+  grouping authz-base {
     description
-      "Counters collected while evaluating access to a gRPC server using
-      the gNSI.authz authorization policy.";
+      "";
 
-    uses grpc-server-authz-policy-success-failure-counters;
+    container authz {
+      description
+        "";
+
+      uses grpc-server-authz-policy-success-failure-counters;
+    }
+  }
+
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services/oc-gnsi:gnsi" {
+
+    uses authz-base;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -3,22 +3,30 @@ module openconfig-gnsi-certz {
   namespace "https://github.com/openconfig/yang/gnsi/certz";
   prefix oc-gnsi-certz;
 
-  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
   import openconfig-system {
     prefix oc-sys;
   }
+
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
+
   import openconfig-types {
     prefix oc-types;
   }
+
   import openconfig-yang-types {
     prefix oc-yang;
   }
+
   import openconfig-gnsi {
     prefix oc-gnsi;
   }
+
   organization
     "OpenConfig Working Group";
 
@@ -31,6 +39,12 @@ module openconfig-gnsi-certz {
     installed on a networking device.";
 
   oc-ext:openconfig-version "0.6.0";
+
+  revision 2024-04-23 {
+    description
+      "";
+    reference "";
+  }
 
   revision 2024-03-05 {
     description
@@ -194,22 +208,23 @@ module openconfig-gnsi-certz {
     }
   }
 
-  // Augments section.
-
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
-          "oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+  grouping certz-base {
     description
-      "A gRPC server credentials freshness information.";
+      "";
 
-    uses grpc-server-credentials-state;
+    container certz {
+      description
+        "";
+
+      uses grpc-server-credentials-state;
+      uses grpc-server-certz-counters;
+
+    }
   }
 
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
-          "oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
-    uses grpc-server-certz-counters;
-    description
-      "gNSI certz server access counters.";
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services/oc-gnsi:gnsi" {
+
+    uses certz-base;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-credentialz.yang
+++ b/release/models/gnsi/openconfig-gnsi-credentialz.yang
@@ -3,22 +3,30 @@ module openconfig-gnsi-credentialz {
   namespace "https://github.com/openconfig/yang/gnsi/credentialz";
   prefix oc-gnsi-credz;
 
-  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
   import openconfig-system {
     prefix oc-sys;
   }
+
   import openconfig-types {
     prefix oc-types;
   }
+
   import openconfig-yang-types {
     prefix oc-yang;
   }
+
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
+
   import openconfig-gnsi {
     prefix oc-gnsi;
   }
+
   organization
     "OpenConfig Working Group";
 
@@ -40,6 +48,12 @@ module openconfig-gnsi-credentialz {
       /system/aaa/authentication/users/user/state/password-hashed";
 
   oc-ext:openconfig-version "0.6.0";
+
+  revision 2024-04-23 {
+    description
+      "";
+    reference "";
+  }
 
   revision 2024-02-13 {
     description
@@ -256,17 +270,18 @@ module openconfig-gnsi-credentialz {
     }
   }
 
-  // Augments section.
-
-  augment "/oc-sys:system" {
-    when "oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" +
-        "/oc-sys-grpc:config[contains(oc-sys-grpc:services, 'oc-gnsi:GNSI')]" +
-        "/oc-sys-grpc:enable = 'true'";
+  grouping credentialz-base {
     description
-      "Console credentials freshness data.";
+      "";
 
-    uses console-config-state;
+    container credentialz {
+      description
+        "";
+
+      uses console-config-state;
+    }
   }
+
   augment "/oc-sys:system/oc-sys:ssh-server/oc-sys:state" {
     when "../../oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" +
         "/oc-sys-grpc:config[contains(oc-sys-grpc:services, 'oc-gnsi:GNSI')]" +
@@ -298,5 +313,11 @@ module openconfig-gnsi-credentialz {
 
     uses user-console-credentials-version;
     uses user-ssh-credentials-version;
+  }
+
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services/oc-gnsi:gnsi" {
+  
+    uses credentialz-base;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-pathz.yang
+++ b/release/models/gnsi/openconfig-gnsi-pathz.yang
@@ -3,19 +3,26 @@ module openconfig-gnsi-pathz {
   namespace "https://github.com/openconfig/yang/gnsi/pathz";
   prefix oc-gnsi-pathz;
 
-  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
   import openconfig-system {
     prefix oc-sys;
   }
+
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
+
   import openconfig-types {
     prefix oc-types;
   }
+
   import openconfig-yang-types {
     prefix oc-yang;
   }
+
   import openconfig-gnsi {
     prefix oc-gnsi;
   }
@@ -33,6 +40,12 @@ module openconfig-gnsi-pathz {
     device.";
 
   oc-ext:openconfig-version "0.3.0";
+
+  revision 2024-04-23 {
+    description
+      "";
+    reference "";
+  }
 
   revision 2024-02-13 {
     description
@@ -295,37 +308,23 @@ module openconfig-gnsi-pathz {
     }
   }
 
-  // Augments section.
-
-  augment "/oc-sys:system" {
-    when "oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" +
-        "/oc-sys-grpc:config[contains(oc-sys-grpc:services, 'oc-gnsi:GNSI')]" +
-        "/oc-sys-grpc:enable = 'true'";
+  grouping pathz-base {
     description
-      "Collection of OpenConfig-path-based authorization policies that
-      have been installed on the device using the gNSI OpenConfig-path-
-      based authorization policy management service.
-      Each policy listed here is identified by its status (either ACTIVE
-          or SANDBOX) and has its version and creation date/time listed.";
+      "";
 
-    uses system-gnmi-pathz-policies;
+    container pathz {
+      description
+        "";
+
+      uses grpc-server-gnmi-pathz-policy-state;
+      uses gnmi-pathz-policy-success-failure-counters;
+      uses system-gnmi-pathz-policies;
+    }
   }
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" +
-          "/oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
-    description
-      "A gNMI server OpenConfig-path-based authorization policy freshness
-      information.";
 
-    uses grpc-server-gnmi-pathz-policy-state;
-  }
-  augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
-    when "oc-sys-grpc:config[contains(oc-sys-grpc:services, 'oc-gnsi:GNSI')]" +
-        "/oc-sys-grpc:enable = 'true'";
-    description
-      "A gNMI server OpenConfig-path-based authorization policy
-      success/failure counters.";
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services/oc-gnsi:gnsi" {
 
-    uses gnmi-pathz-policy-success-failure-counters;
+    uses pathz-base;
   }
 }

--- a/release/models/gnsi/openconfig-gnsi-types.yang
+++ b/release/models/gnsi/openconfig-gnsi-types.yang
@@ -1,0 +1,43 @@
+module openconfig-gnsi-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/gnsi/types";
+  prefix "oc-gnsit";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  import openconfig-grpc-types {
+    prefix oc-grpct;
+  }
+
+  organization
+    "OpenConfig Working Group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module defines a set of extensions that provide gNSI (the gRPC
+    Network Security Interface) specific extensions to the OpenConfig data models.
+    Specifically, the parameters for the configuration of the service, and
+    configuration and state are added.
+
+    The gNSI protobufs and documentation are published at
+    https://github.com/openconfig/gnsi.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision 2024-04-23 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GNSI {
+    base "oc-grpct:GRPC_SERVICE";
+    description
+      "gNSI: gRPC Network Security Interface";
+  }
+}

--- a/release/models/gribi/.spec.yml
+++ b/release/models/gribi/.spec.yml
@@ -1,6 +1,7 @@
 - name: openconfig-gribi
   docs:
     - yang/gribi/openconfig-gribi.yang
+    - yang/gribi/openconfig-gribi-types.yang
   build:
     - yang/gribi/openconfig-gribi.yang
   run-ci: true

--- a/release/models/gribi/openconfig-gribi-types.yang
+++ b/release/models/gribi/openconfig-gribi-types.yang
@@ -1,0 +1,39 @@
+module openconfig-gribi-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/gribi/types";
+  prefix "oc-gribit";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  import openconfig-grpc-types {
+    prefix oc-grpct;
+  }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "";
+
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision 2024-04-23 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GRIBI {
+    base oc-grpct:GRPC_SERVICE;
+    description
+      "gNMI: gRPC Network Management Interface";
+  }
+
+}

--- a/release/models/gribi/openconfig-gribi.yang
+++ b/release/models/gribi/openconfig-gribi.yang
@@ -1,12 +1,27 @@
 module openconfig-gribi {
   yang-version "1";
-
+  namespace "http://openconfig.net/yang/gribi";
   prefix "oc-gribi";
 
-  namespace "http://openconfig.net/yang/gribi";
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
 
-  import openconfig-extensions { prefix oc-ext; }
-  import openconfig-system-grpc { prefix oc-grpc; }
+  import openconfig-system {
+    prefix oc-sys;
+  }
+
+  import openconfig-system-grpc {
+    prefix oc-sys-grpc;
+  }
+
+  import openconfig-grpc-services-common {
+    prefix oc-grpc-common;
+  }
+
+  import openconfig-gribi-types {
+    prefix oc-gribit;
+  }
 
   organization
     "OpenConfig Working Group";
@@ -15,7 +30,7 @@ module openconfig-gribi {
     "www.openconfig.net";
 
   description
-    "This module defines a set of exdtensions that provide gRIBI (the gRPC
+    "This module defines a set of extensions that provide gRIBI (the gRPC
     RIB Interface) specific extensions to the OpenConfig data models.
     Specifically, the parameters for the configuration of the service, and
     configuration and state are added.
@@ -23,7 +38,13 @@ module openconfig-gribi {
     The gRIBI protobufs and documentation are published at
     https://github.com/openconfig/gribi.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision 2024-04-23 {
+    description
+      "";
+    reference "0.2.0";
+  }
 
   revision 2021-04-06 {
     description
@@ -31,9 +52,23 @@ module openconfig-gribi {
     reference "0.1.0";
   }
 
-  identity GRIBI {
-    base "oc-grpc:GRPC_SERVICE";
+  grouping gribi-base {
     description
-      "gRIBI: gRPC Routing Information Base Interface";
+      "";
+
+    container gribi {
+      description
+        "";
+
+      uses oc-grpc-common:common-services;
+    }
   }
+
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services" {
+    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-gribit:GRIBI'";
+
+    uses gribi-base;
+  }
+
 }

--- a/release/models/grpc/openconfig-grpc-services-common.yang
+++ b/release/models/grpc/openconfig-grpc-services-common.yang
@@ -1,0 +1,57 @@
+module openconfig-grpc-services-common {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/grpc/common";
+  prefix "oc-grpc-common";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "";
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision 2024-03-10 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  grouping common-config {
+    description
+      "";
+
+    leaf enable {
+      type boolean;
+      description
+        "";
+    }
+  }
+
+  grouping common-services {
+    description
+      "";
+
+    container config {
+      description
+        "";
+
+      uses common-config;
+    }
+
+    container state {
+      description
+        "";
+
+      config false;
+
+      uses common-config;
+    }
+  }
+}

--- a/release/models/grpc/openconfig-grpc-types.yang
+++ b/release/models/grpc/openconfig-grpc-types.yang
@@ -1,0 +1,32 @@
+module openconfig-grpc-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/grpc/types";
+  prefix "oc-grpct";
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "";
+
+  oc-ext:openconfig-version "0.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2024-04-23" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GRPC_SERVICE {
+    description
+      "Base identity for a gRPC-based service.";
+  }
+}

--- a/release/models/p4rt/.spec.yml
+++ b/release/models/p4rt/.spec.yml
@@ -1,6 +1,7 @@
 - name: openconfig-p4rt
   docs:
     - yang/p4rt/openconfig-p4rt.yang
+    - yang/p4rt/openconfig-p4rt-types.yang
     - yang/interfaces/openconfig-interfaces.yang
     - yang/platform/openconfig-platform.yang
   build:

--- a/release/models/p4rt/openconfig-p4rt-types.yang
+++ b/release/models/p4rt/openconfig-p4rt-types.yang
@@ -1,0 +1,31 @@
+module openconfig-p4rt-types {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/p4rt/types";
+  prefix "oc-p4rt-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-grpc-types { prefix oc-grpct; }
+
+  organization
+    "OpenConfig Working Group";
+
+  contact
+    "www.openconfig.net";
+
+  description
+    "";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2024-03-10 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity P4RT {
+    base "oc-grpct:GRPC_SERVICE";
+    description
+      "P4RT: P4 Runtime (P4RT) Service.";
+  }
+}

--- a/release/models/p4rt/openconfig-p4rt.yang
+++ b/release/models/p4rt/openconfig-p4rt.yang
@@ -1,14 +1,35 @@
 module openconfig-p4rt {
   yang-version "1";
-
+  namespace "http://openconfig.net/yang/p4rt";
   prefix "oc-p4rt";
 
-  namespace "http://openconfig.net/yang/p4rt";
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
 
-  import openconfig-extensions { prefix oc-ext; }
-  import openconfig-interfaces { prefix oc-if; }
-  import openconfig-platform { prefix oc-platform; }
-  import openconfig-system-grpc { prefix oc-grpc; }
+  import openconfig-interfaces {
+    prefix oc-if;
+  }
+
+  import openconfig-platform {
+    prefix oc-platform;
+  }
+
+  import openconfig-system {
+    prefix oc-sys;
+  }
+
+  import openconfig-system-grpc {
+    prefix oc-sys-grpc;
+  }
+
+  import openconfig-grpc-services-common {
+    prefix oc-grpc-common;
+  }
+
+  import openconfig-p4rt-types {
+    prefix oc-p4rt-types;
+  }
 
   organization
     "OpenConfig Working Group";
@@ -26,7 +47,13 @@ module openconfig-p4rt {
     The P4RT protocol specification is linked from https://p4.org/specs/
     under the P4Runtime heading.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision 2024-04-23 {
+    description
+      "Detach P4RT identity to common types module";
+    reference "2.0.0";
+  }
 
   revision 2023-12-13 {
     description
@@ -58,20 +85,6 @@ module openconfig-p4rt {
       "Initial revision.";
     reference "0.1.0";
   }
-
-  // extension statements
-
-  // feature statements
-
-  // identity statements
-
-  identity P4RT {
-    base "oc-grpc:GRPC_SERVICE";
-    description
-      "P4RT: P4 Runtime (P4RT) Service.";
-  }
-
-  // grouping statements
 
   grouping p4rt-interface-config {
     description
@@ -134,9 +147,17 @@ module openconfig-p4rt {
       https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-write-rpc";
   }
 
-  // data definition statements
+  grouping p4rt-base {
+    description
+      "";
 
-  // augment statements
+    container p4rt {
+      description
+        "";
+
+      uses oc-grpc-common:common-services;
+    }
+  }
 
   augment "/oc-if:interfaces/oc-if:interface/oc-if:config" {
     description
@@ -170,8 +191,11 @@ module openconfig-p4rt {
     uses p4rt-ic-config;
   }
 
+  augment "/oc-sys:system/oc-sys-grpc:grpc-servers" +
+          "/oc-sys-grpc:grpc-server/oc-sys-grpc:services" {
+    when "../oc-sys-grpc:config/oc-sys-grpc:services = 'oc-p4rt-types:P4RT'";
+
+    uses p4rt-base;
+  }
+
 }
-
-  // rpc statements
-
-  // notification statements

--- a/release/models/system/openconfig-system-grpc.yang
+++ b/release/models/system/openconfig-system-grpc.yang
@@ -8,6 +8,7 @@ module openconfig-system-grpc {
   import openconfig-system { prefix oc-sys; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-network-instance { prefix oc-ni; }
+  import openconfig-grpc-types { prefix oc-grpct; }
 
   organization
     "OpenConfig working group";
@@ -22,9 +23,16 @@ module openconfig-system-grpc {
     to be included in the list.";
 
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2024-04-23" {
+    description
+      "Refactoring of grpc-server tree including detachment of
+      per-service constructs and identities into separate models.";
+    reference "2.0.0";
+  }
 
   revision "2022-04-19" {
     description
@@ -45,15 +53,16 @@ module openconfig-system-grpc {
     reference "0.1.0";
   }
 
-  identity GRPC_SERVICE {
+  grouping grpc-services {
     description
-      "Base identity for a gRPC-based service.";
-  }
+      "Grouping for gRPC service-specific configuration and state.";
 
-  identity GNMI {
-    base GRPC_SERVICE;
-    description
-      "gNMI: gRPC Network Management Interface";
+    container services {
+      description
+        "Anchor point for gRPC service specific data.  It is expected
+        that gRPC service specific modules augment per-service
+        configuration/state into this location.";
+    }
   }
 
   grouping grpc-service-structural {
@@ -97,6 +106,8 @@ module openconfig-system-grpc {
             "Operational state relating to the gRPC service.";
           uses grpc-server-config;
         }
+
+        uses grpc-services;
       }
     }
   }
@@ -122,19 +133,23 @@ module openconfig-system-grpc {
 
     leaf-list services {
       type identityref {
-        base GRPC_SERVICE;
+        base oc-grpct:GRPC_SERVICE;
       }
       description
-        "The gRPC service definitions that should be enabled for the
-        specified server. A target may support only specific
-        sets of services being enabled on the same server (e.g.,
-        it may be possible to run gNMI and gNOI services on the same
-        port, but not to run gRIBI and gNMI on the same port).
+        "The gRPC service definitions that are allowed for the specified
+        server. A target may support only specific sets of services to
+        be allowed on the same server (e.g., it may be possible to run
+        gNMI and gNOI services on the same port, but not to run gRIBI
+        and gNMI on the same port).
 
         The set of gRPC services that are available to be configured is
         defined through the GRPC_SERVICE identity, which can be extended
         for each protocol that is based on gRPC that is available on the
-        device.";
+        device.
+
+        NOTE: This leaf-list is for allowed services on a given server
+        instance.  Per service enablement/disablement is provided as a
+        common construct available to each service model.";
     }
 
     leaf enable {


### PR DESCRIPTION
  * (A) release/models/gnmi/openconfig-gnmi.yang
  * (A) release/models/gnmi/openconfig-gnmi-types.yang
  * (A) release/models/gnoi/openconfig-gnoi.yang
  * (A) release/models/gnoi/openconfig-gnoi-types.yang
  * (A) release/models/gnpsi/openconfig-gnpsi.yang
  * (A) release/models/gnpsi/openconfig-gnpsi-types.yang
  * (M) release/models/gribi/openconfig-gribi.yang
  * (A) release/models/gribi/openconfig-gribi-types.yang
  * (A) release/models/p4rt/openconfig-p4rt-types.yang
  * (M) release/models/p4rt/openconfig-p4rt.yang
  * (M) release/models/gnsi/openconfig-gnsi.yang
  * (M) release/models/gnsi/openconfig-gnsi-acctz.yang
  * (M) release/models/gnsi/openconfig-gnsi-authz.yang
  * (M) release/models/gnsi/openconfig-gnsi-certz.yang
  * (M) release/models/gnsi/openconfig-gnsi-credentialz.yang
  * (M) release/models/gnsi/openconfig-gnsi-pathz.yang
  * (A) release/models/gnsi/openconfig-gnsi-types.yang
  * (A) release/models/grpc/openconfig-grpc-services-common.yang
  * (A) release/models/grpc/openconfig-grpc-types.yang
  * (M) release/models/system/openconfig-system-grpc.yang
    - Refactor gRPC service modeling into modular augment approach that
      is determined by "allowed services" per endpoint
    - Relocate service identities to per-service types modules
    - Added structure of per-service containers to contain per-service
      config/state

### Change Scope

**NOTE: WORK IN PROGRESS, SOLICITING EARLY FEEDBACK**

* Initial refactor of gRPC service modeling
  - Addition of per-service categories
  - Detach common types into types modules for reuse and expansion
  - Addition of common gRPC constructs that each service must implement to
    satisfy the consistent API
  - Modular anchor point to add additional services

Intent is to restructure first to modular approach so that each gRPC service
can have consistent modeling w/o scattering constructs in various subtrees.

### Platform Implementations

N/A: Refactor for purpose of new implementation sustainability/growth
