### PR TITLE
jakesnyder-1097 adding INACTIVE to client_state #1098

### DIFF
--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -27,7 +27,7 @@ module openconfig-wifi-types {
   revision "2024-04-25" {
     description
       "Adding INACTIVE client_state"
-    reference "1.1.3"
+    reference "1.1.3";
   }
 
   revision "2023-09-01" {

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -22,7 +22,13 @@ module openconfig-wifi-types {
     that are used in the openconfig-wifi modules. It can be
     imported by any module to make use of these types.";
 
-  oc-ext:openconfig-version "1.1.2";
+  oc-ext:openconfig-version "1.1.3";
+
+  revision "2024-04-25" {
+    description
+      "Adding INACTIVE client_state"
+    reference "1.1.3"
+  }
 
   revision "2023-09-01" {
     description
@@ -152,6 +158,13 @@ module openconfig-wifi-types {
     description
       "This client has been blacklisted, through either L2 (MAC) or higher-level
       (signature) mechanisms.";
+  }
+
+  identity INACTIVE {
+    base CLIENT_STATE;
+    description
+      "Client is no longer active in the 802.11 state machine. Client data
+      remains in the client state, but client is no longer active on AP.";
   }
 
   identity AP_STATE {

--- a/release/models/wifi/openconfig-wifi-types.yang
+++ b/release/models/wifi/openconfig-wifi-types.yang
@@ -26,7 +26,7 @@ module openconfig-wifi-types {
 
   revision "2024-04-25" {
     description
-      "Adding INACTIVE client_state"
+      "Adding INACTIVE client_state";
     reference "1.1.3";
   }
 


### PR DESCRIPTION
### Change Scope

* Added state to indicate that client is no longer active in the 802.11 state machine, but still present in client data.
* This change is backwards compatible
### Platform Implementations

 * Implementation A: Aruba purges client data after a period of time, but retains it in the table to reduce impact of adding it back in for quick events such as roaming, but issues arise because there is no state to map this to.  Need a way to reconcile this to ensure interoperability between vendor specific implementations.

Unsure if other vendors implement this, this is related to how things work under the hood.

