### PR TITLE
Add bridge-id to interfaces

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.7.1";
+  oc-ext:openconfig-version "3.8.0";
+
+  revision "2024-04-28" {
+      description
+        "Add bridge-id to interfaces.";
+      reference
+        "3.8.0";
+  }
 
   revision "2024-04-04" {
       description
@@ -451,6 +458,15 @@ module openconfig-interfaces {
         "Sets the loopback type on the interface. Setting the
         mode to something besides NONE activates the loopback in
         the specified mode.";
+    }
+
+    leaf bridge-id {
+      type leafref {
+        path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+      }
+      description
+        "Specify the logical bridge interface to which
+        this interface belongs.";
     }
 
     uses interface-common-config;


### PR DESCRIPTION
### Change Scope

/interfaces/interface/config/bridge-id

* Introduce a new leaf to specify an interface's bridge membership.
* Bridge interfaces are modeled as interfaces themselves, meaning the bridge-id is a leafref to an interface of type [bridge](https://github.com/openconfig/yang/blob/65fb9ff7590595be1ddeafef8fbaac37cb4c0671/standard/ietf/RFC/iana-if-type.yang#L1176).

### Platform Implementations

- [Linux Bridge](https://man7.org/linux/man-pages/man8/brctl.8.html) - set up, maintain, and inspect the ethernet bridge configuration in the Linux kernel.

The intent is to bridge two or more interfaces on the same device using a Linux ethernet bridge. Network traffic coming in on any of these ports will be forwarded to the other ports transparently.
