### PR TITLE
Add worklow to close stale issue/pr

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '42 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          days-before-stale: 180
+          days-before-close: 14


### PR DESCRIPTION
We have a lot of very old issues and PR's which have not been actioned by the submitters or OC operators.  This workflow will automatically comment on issues and PR's which have no activity for > 180 days.  If no update (comment, commit,etc)  is made within 14 days, the issue/PR will be closed.  

The goal is to trigger a response from requestors who are still looking to actively contribute to OpenConfig.

Note that such closed issues and PR's may be reopened if desired.

This was discussed quite a while ago at an OC Operators meeting without objection.