### PR TITLE
Use reference of servers in /system/aaa/server-groups. Move the actual server list to top level of /system/aaa.

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -91,6 +91,7 @@ submodule openconfig-aaa-radius {
 
     leaf auth-port {
       type oc-inet:port-number;
+      status deprecated;
       default 1812;
       description
         "Port number for authentication requests";

--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,13 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2024-05-03" {
+    description
+      "Deprecate auth-port and make the port a common key for aaa servers";
+      reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -91,7 +91,6 @@ submodule openconfig-aaa-radius {
 
     leaf auth-port {
       type oc-inet:port-number;
-      status deprecated;
       default 1812;
       description
         "Port number for authentication requests";

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -91,7 +91,6 @@ submodule openconfig-aaa-tacacs {
 
     leaf port {
       type oc-inet:port-number;
-      status deprecated;
       default 49;
       description
         "The port number on which to contact the TACACS server";

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -91,6 +91,7 @@ submodule openconfig-aaa-tacacs {
 
     leaf port {
       type oc-inet:port-number;
+      status deprecated;
       default 49;
       description
         "The port number on which to contact the TACACS server";

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,13 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2024-05-03" {
+    description
+      "Deprecate port and make it a common key for aaa servers";
+      reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -12,6 +12,7 @@ module openconfig-aaa {
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-aaa-types { prefix oc-aaa-types; }
+  import openconfig-network-instance { prefix "oc-ni"; }
 
   include openconfig-aaa-tacacs;
   include openconfig-aaa-radius;
@@ -100,6 +101,7 @@ module openconfig-aaa {
   grouping aaa-servergroup-common-config {
     description
       "Configuration data for AAA server groups";
+    status deprecated;
 
     leaf name {
       type string;
@@ -120,6 +122,7 @@ module openconfig-aaa {
   grouping aaa-servergroup-common-state {
     description
       "Operational state data for AAA server groups";
+    status deprecated;
 
     //TODO: add list of group members as opstate
   }
@@ -127,6 +130,7 @@ module openconfig-aaa {
   grouping aaa-servergroup-common-top {
     description
       "Top-level grouping for AAA server groups";
+    status deprecated;
 
     container server-groups {
       description
@@ -151,7 +155,9 @@ module openconfig-aaa {
           description
             "Configuration data for each server group";
 
-          uses aaa-servergroup-common-config;
+          uses aaa-servergroup-common-config {
+            status deprecated;
+          }
         }
 
         container state {
@@ -160,11 +166,17 @@ module openconfig-aaa {
           description
             "Operational state data for each server group";
 
-          uses aaa-servergroup-common-config;
-          uses aaa-servergroup-common-state;
+          uses aaa-servergroup-common-config {
+            status deprecated;
+          }
+          uses aaa-servergroup-common-state {
+            status deprecated;
+          }
         }
 
-        uses aaa-server-top;
+        uses aaa-server-top {
+          status deprecated;
+        }
       }
     }
   }
@@ -172,6 +184,7 @@ module openconfig-aaa {
   grouping aaa-server-config {
     description
       "Common configuration data for AAA servers";
+    status deprecated;
 
     leaf name {
       type string;
@@ -193,6 +206,62 @@ module openconfig-aaa {
         server";
     }
   }
+
+  grouping aaa-server-config-data {
+    description
+      "Common configuration data for AAA servers";
+
+    leaf name {
+      type string;
+      description
+        "Name assigned to the server";
+    }
+
+
+    leaf address {
+      type oc-inet:ip-address;
+      description "Address of the authentication server";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description "Port of the authentication server";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description "Network-instance of the authentication server";
+    }
+
+    leaf type {
+      type identityref {
+        base oc-aaa-types:AAA_SERVER_TYPE;
+      }
+      description
+        "AAA server type";
+    }
+
+    leaf timeout {
+      type uint16;
+      units seconds;
+      description
+        "Set the timeout in seconds on responses from the AAA
+        server";
+    }
+
+    list server-group {
+      key "name";
+      description
+        "List of the server groups this server belongs to";
+
+      leaf name {
+        type string;
+        description
+          "Server group name";
+      }
+    }
+  }
+
 
   grouping aaa-server-state {
     description
@@ -251,9 +320,83 @@ module openconfig-aaa {
 
   }
 
+  grouping aaa-server-list-top {
+    description
+      "Top-level grouping for list of AAA servers";
+
+    container servers {
+      description
+        "Enclosing container the list of servers";
+
+      list server {
+        key "address port network-instance type";
+        description
+          "List of AAA servers";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to the configured address of the AAA server";
+        }
+
+        leaf port {
+          type leafref {
+            path "../config/port";
+          }
+          description
+            "Reference to the configured port of the AAA server";
+        }
+
+        leaf network-instance {
+          type leafref {
+            path "../config/network-instance";
+          }
+          description
+            "Reference to the configured network-instance of the AAA server";
+        }
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "AAA server type";
+        }
+
+        container config {
+          description
+            "Configuration data ";
+
+          uses aaa-server-config-data;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state data ";
+
+          uses aaa-server-config-data;
+          uses aaa-server-state;
+        }
+
+        uses aaa-tacacs-server-top {
+          when "config/type = 'oc-aaa:TACACS'";
+        }
+
+        uses aaa-radius-server-top {
+          when "config/type = 'oc-aaa:RADIUS'";
+        }
+      }
+    }
+  }
+
   grouping aaa-server-top {
     description
       "Top-level grouping for list of AAA servers";
+    status deprecated;
 
     container servers {
       description
@@ -276,7 +419,9 @@ module openconfig-aaa {
           description
             "Configuration data ";
 
-          uses aaa-server-config;
+          uses aaa-server-config {
+            status deprecated;
+          }
         }
 
         container state {
@@ -285,7 +430,9 @@ module openconfig-aaa {
           description
             "Operational state data ";
 
-          uses aaa-server-config;
+          uses aaa-server-config {
+            status deprecated;
+          }
           uses aaa-server-state;
         }
 
@@ -834,7 +981,10 @@ module openconfig-aaa {
       uses aaa-authentication-top;
       uses aaa-authorization-top;
       uses aaa-accounting-top;
-      uses aaa-servergroup-common-top;
+      uses aaa-servergroup-common-top {
+        status deprecated;
+      }
+      uses aaa-server-list-top;
 
     }
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -116,34 +116,6 @@ module openconfig-aaa {
         "AAA server type -- all servers in the group must be of this
         type";
     }
-
-    list servers {
-      key "address port network-instance type";
-
-      leaf address {
-        type leafref {
-          path "/system/aaa/servers/server/address";
-        }
-      }
-
-      leaf port {
-        type leafref {
-          path "deref(../address)/../port";
-        }
-      }
-
-      leaf network-instance {
-        type leafref {
-          path "deref(../port)/../network-instance";
-        }
-      }
-
-      leaf type {
-        type leafref {
-          path "deref(../network-instance)/../type";
-        }
-      }
-    }
   }
 
   grouping aaa-servergroup-common-state {
@@ -151,6 +123,113 @@ module openconfig-aaa {
       "Operational state data for AAA server groups";
 
     //TODO: add list of group members as opstate
+  }
+
+  grouping aaa-servergroup-member-config {
+    description
+      "Common configuration data for server group member";
+
+    leaf address {
+      type leafref {
+        path "../../../../../../servers/server/address";
+      }
+      description
+        "Reference to the configured address of the server group member";
+    }
+
+    leaf port {
+      type leafref {
+        path "deref(../address)/../port";
+      }
+      description
+        "Reference to the configured port of the server group member";
+    }
+
+    leaf network-instance {
+      type leafref {
+        path "deref(../port)/../network-instance";
+      }
+      description
+        "Reference to the configured network-instance of the server group member";
+    }
+
+    leaf type {
+      type leafref {
+        path "deref(../network-instance)/../type";
+      }
+      description
+        "Reference to the configured type of the server group member";
+    }
+  }
+
+  grouping aaa-servergroup-member-state {
+    description
+      "Operational state data for server group member";
+  }
+
+  grouping aaa-servergroup-member-top {
+    description
+      "Top-level grouping for list of AAA servers";
+
+    container group-members {
+      description
+        "Enclosing container for server group members";
+
+      list group-member {
+        key "address port network-instance type";
+        description
+          "List of server group members";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to the configured address of the server group member";
+        }
+
+        leaf port {
+          type leafref {
+            path "../config/port";
+          }
+          description
+            "Reference to the configured port of the server group member";
+        }
+
+        leaf network-instance {
+          type leafref {
+            path "../config/network-instance";
+          }
+          description
+            "Reference to the configured network-instance of the server group member";
+        }
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "Reference to the configured type of the server group member";
+        }
+
+        container config {
+          description
+            "Configuration data ";
+
+          uses aaa-servergroup-member-config;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state data ";
+
+          uses aaa-servergroup-member-config;
+          uses aaa-servergroup-common-state;
+        }
+      }
+    }
   }
 
   grouping aaa-servergroup-common-top {
@@ -192,6 +271,8 @@ module openconfig-aaa {
           uses aaa-servergroup-common-config;
           uses aaa-servergroup-common-state;
         }
+
+        uses aaa-servergroup-member-top;
 
         uses aaa-server-top {
           status deprecated;
@@ -266,18 +347,6 @@ module openconfig-aaa {
       description
         "Set the timeout in seconds on responses from the AAA
         server";
-    }
-
-    list server-group {
-      key "name";
-      description
-        "List of the server groups this server belongs to";
-
-      leaf name {
-        type string;
-        description
-          "Server group name";
-      }
     }
   }
 

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -101,7 +101,6 @@ module openconfig-aaa {
   grouping aaa-servergroup-common-config {
     description
       "Configuration data for AAA server groups";
-    status deprecated;
 
     leaf name {
       type string;
@@ -117,12 +116,39 @@ module openconfig-aaa {
         "AAA server type -- all servers in the group must be of this
         type";
     }
+
+    list servers {
+      key "address port network-instance type";
+
+      leaf address {
+        type leafref {
+          path "/system/aaa/servers/server/address";
+        }
+      }
+
+      leaf port {
+        type leafref {
+          path "deref(../address)/../port";
+        }
+      }
+
+      leaf network-instance {
+        type leafref {
+          path "deref(../port)/../network-instance";
+        }
+      }
+
+      leaf type {
+        type leafref {
+          path "deref(../network-instance)/../type";
+        }
+      }
+    }
   }
 
   grouping aaa-servergroup-common-state {
     description
       "Operational state data for AAA server groups";
-    status deprecated;
 
     //TODO: add list of group members as opstate
   }
@@ -130,7 +156,6 @@ module openconfig-aaa {
   grouping aaa-servergroup-common-top {
     description
       "Top-level grouping for AAA server groups";
-    status deprecated;
 
     container server-groups {
       description
@@ -156,7 +181,6 @@ module openconfig-aaa {
             "Configuration data for each server group";
 
           uses aaa-servergroup-common-config {
-            status deprecated;
           }
         }
 
@@ -167,10 +191,8 @@ module openconfig-aaa {
             "Operational state data for each server group";
 
           uses aaa-servergroup-common-config {
-            status deprecated;
           }
           uses aaa-servergroup-common-state {
-            status deprecated;
           }
         }
 
@@ -981,10 +1003,8 @@ module openconfig-aaa {
       uses aaa-authentication-top;
       uses aaa-authorization-top;
       uses aaa-accounting-top;
-      uses aaa-servergroup-common-top {
-        status deprecated;
-      }
       uses aaa-server-list-top;
+      uses aaa-servergroup-common-top;
 
     }
   }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -33,7 +33,13 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2024-05-03" {
+    description
+      "Use reference of servers in server groups";
+      reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -180,8 +180,7 @@ module openconfig-aaa {
           description
             "Configuration data for each server group";
 
-          uses aaa-servergroup-common-config {
-          }
+          uses aaa-servergroup-common-config;
         }
 
         container state {
@@ -190,10 +189,8 @@ module openconfig-aaa {
           description
             "Operational state data for each server group";
 
-          uses aaa-servergroup-common-config {
-          }
-          uses aaa-servergroup-common-state {
-          }
+          uses aaa-servergroup-common-config;
+          uses aaa-servergroup-common-state;
         }
 
         uses aaa-server-top {


### PR DESCRIPTION
(M) system/openconfig-aaa-radius.yang
(M) system/openconfig-aaa-tacacs.yang
(M) system/openconfig-aaa.yang

**Change Scope:**

Add port, network-instance, type to aaa server as extra keys.
Deprecate port/authen-port from aaa-tacacs and aaa-radius config. Move it to server config as one of the keys.
Deprecate the server list in the “server-groups” container and move “servers” up to the top level for aaa.
Add a list of server ref matching the top level server list in the “server-groups” container.
This is a slow change which keeps the original nodes and marks them as deprecated.

**Platform Implementations:**

Arista AAA configuration:
Servers with the same host/port can be configured in different VRFs(network-instance).
One server can be added to multiple server groups.


```
(config)#radius-server host 1.2.3.4 vrf mgmt-vrf auth-port 123
RADIUS host 1.2.3.4 with auth-port 123 and acct-port 1813 created in vrf mgmt-vrf
(config)#radius-server host 1.2.3.4 vrf mgmt-vrf-2 auth-port 123
RADIUS host 1.2.3.4 with auth-port 123 and acct-port 1813 created in vrf mgmt-vrf-2
(config)#aaa group server radius rad-grp-1
(config-sg-radius-rad-grp-1)#server 1.2.3.4 vrf mgmt-vrf auth-port 123
(config-sg-radius-rad-grp-1)#server 1.2.3.4 vrf mgmt-vrf-2 auth-port 123
(config-sg-radius-rad-grp-1)#exit
(config)#aaa group server radius rad-grp-2
(config-sg-radius-rad-grp-2)#server 1.2.3.4 vrf mgmt-vrf auth-port 123
(config-sg-radius-rad-grp-2)#exit
(config)#show radius
…
RADIUS server-group: rad-grp-1
     0: 1.2.3.4, authentication port 123, accounting port 1813 (VRF mgmt-vrf)
     1: 1.2.3.4, authentication port 123, accounting port 1813 (VRF mgmt-vrf-2)

RADIUS server-group: rad-grp-2
     0: 1.2.3.4, authentication port 123, accounting port 1813 (VRF mgmt-vrf)
…
```

Arista [documentation](https://www.arista.com/en/um-eos/eos-user-security#xx1347513:~:text=root%20of%20trust%3E-,Server%20Groups,-A%20server%20group)

**Pyang output for the new model**:
***please note that the old nodes has been removed from this output for easy review. In the actual change they are marked as deprecated.**

```
module: openconfig-system
  +--rw system
     +--rw aaa
        +--rw config
        +--ro state
        ...<unchanged part>

        +--rw servers
        |  +--rw server* [address port network-instance type]
        |     +--rw address             -> ../config/address
        |     +--rw port                -> ../config/port
        |     +--rw network-instance    -> ../config/network-instance
        |     +--rw type                -> ../config/type
        |     +--rw config
        |     |  +--rw name?               string
        |     |  +--rw address?            oc-inet:ip-address
        |     |  +--rw port?               oc-inet:port-number
        |     |  +--rw network-instance?   oc-ni:network-instance-ref
        |     |  +--rw type?               identityref
        |     |  +--rw timeout?            uint16
        |     +--ro state
        |     |  +--ro name?                  string
        |     |  +--ro address?               oc-inet:ip-address
        |     |  +--ro port?                  oc-inet:port-number
        |     |  +--ro network-instance?      oc-ni:network-instance-ref
        |     |  +--ro type?                  identityref
        |     |  +--ro timeout?               uint16
        |     |  +--ro connection-opens?      oc-yang:counter64
        |     |  +--ro connection-closes?     oc-yang:counter64
        |     |  +--ro connection-aborts?     oc-yang:counter64
        |     |  +--ro connection-failures?   oc-yang:counter64
        |     |  +--ro connection-timeouts?   oc-yang:counter64
        |     |  +--ro messages-sent?         oc-yang:counter64
        |     |  +--ro messages-received?     oc-yang:counter64
        |     |  +--ro errors-received?       oc-yang:counter64
        |     +--rw tacacs
        |     |  +--rw config
        |     |  |  x--rw port?                oc-inet:port-number
        |     |  |  +--rw secret-key?          oc-types:routing-password
        |     |  |  +--rw secret-key-hashed?   oc-aaa-types:crypt-password-type
        |     |  |  +--rw source-address?      oc-inet:ip-address
        |     |  +--ro state
        |     |     x--ro port?                oc-inet:port-number
        |     |     +--ro secret-key?          oc-types:routing-password
        |     |     +--ro secret-key-hashed?   oc-aaa-types:crypt-password-type
        |     |     +--ro source-address?      oc-inet:ip-address
        |     +--rw radius
        |        +--rw config
        |        |  x--rw auth-port?             oc-inet:port-number
        |        |  +--rw acct-port?             oc-inet:port-number
        |        |  +--rw secret-key?            oc-types:routing-password
        |        |  +--rw secret-key-hashed?     oc-aaa-types:crypt-password-type
        |        |  +--rw source-address?        oc-inet:ip-address
        |        |  +--rw retransmit-attempts?   uint8
        |        +--ro state
        |           x--ro auth-port?             oc-inet:port-number
        |           +--ro acct-port?             oc-inet:port-number
        |           +--ro secret-key?            oc-types:routing-password
        |           +--ro secret-key-hashed?     oc-aaa-types:crypt-password-type
        |           +--ro source-address?        oc-inet:ip-address
        |           +--ro retransmit-attempts?   uint8
        |           +--ro counters
        |              +--ro retried-access-requests?   oc-yang:counter64
        |              +--ro access-accepts?            oc-yang:counter64
        |              +--ro access-rejects?            oc-yang:counter64
        |              +--ro timeout-access-requests?   oc-yang:counter64
        +--rw server-groups
           +--rw server-group* [name]
              +--rw name             -> ../config/name
              +--rw config
              |  +--rw name?   string
              |  +--rw type?   identityref
              +--ro state
              |  +--ro name?   string
              |  +--ro type?   identityref
              +--rw group-members
                 +--rw group-member* [address port network-instance type]
                    +--rw address             -> ../config/address
                    +--rw port                -> ../config/port
                    +--rw network-instance    -> ../config/network-instance
                    +--rw type                -> ../config/type
                    +--rw config
                    |  +--rw address?            -> ../../../../../../servers/server/address
                    |  +--rw port?               -> deref(../address)/../port
                    |  +--rw network-instance?   -> deref(../port)/../network-instance
                    |  +--rw type?               -> deref(../network-instance)/../type
                    +--ro state
                       +--ro address?            -> ../../../../../../servers/server/address
                       +--ro port?               -> deref(../address)/../port
                       +--ro network-instance?   -> deref(../port)/../network-instance
                       +--ro type?               -> deref(../network-instance)/../type
```