### PR TITLE
Deprecate /components/component/state/id leaf

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,13 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.25.0";
+  oc-ext:openconfig-version "0.26.0";
+
+  revision "2024-05-08" {
+    description
+      "Deprecate component id leaf";
+    reference "0.26.0";
+  }
 
   revision "2024-01-30" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.25.0";
+  oc-ext:openconfig-version "0.26.0";
+
+  revision "2024-05-08" {
+    description
+      "Deprecate component id leaf";
+    reference "0.26.0";
+  }
 
   revision "2024-01-30" {
     description
@@ -404,6 +410,7 @@ module openconfig-platform {
 
     leaf id {
       type string;
+      status deprecated;
       description
         "Unique identifier assigned by the system for the
         component";


### PR DESCRIPTION
    * (M) release/models/platform/openconfig-platform.yang
    * (M) release/models/platform/openconfig-platform-common.yang
      - Commence deprecation of undefined/duplicate 'id' leaf
      - Increment model to version 0.26.0


### Change Scope

Commence deprecation of undefined intent and duplicate use of the following leaf:

  `/components/component/state/id`

### Platform Implementations

This leaf was introduced at inception of the component modeling and is defined as follows:

  `Unique identifier assigned by the system for the component`

If we observe implementations today, this is duplicate content of more well defined leafs

_Arista EOS:_

`/components/component[name=SwitchChip11000]/state/id: SwitchAsic11000`

_Nokia SRL_

`/components/component[name=TempSensor-Supervisor1]/state/id: TempSensor-Supervisor1`

_JUNOS_

`/components/component[name=CHASSIS0]/state/id: JN8461229AJD`

So either we have a duplication of the `name` key or the `serial-no`.  Unless
we have proper intent and usage here, we have an unnecessary leaf so either we
clean up the description to provide some other unique data if it exists or we
commence the deprecation process to remove in the next major global release.
