### PR TITLE
Updates to network-instance EVPN models for EVPN/Vxlan support

### DIFF
--- a/release/models/network-instance/openconfig-evpn-types.yang
+++ b/release/models/network-instance/openconfig-evpn-types.yang
@@ -25,7 +25,14 @@ module openconfig-evpn-types {
     policy. It can be imported by modules that make use of EVPN
     attributes";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2024-05-08" {
+    description
+      "Add new redistribute-type enumeration for configuring the types of routes
+      to be redistributed in either a MACRVRF or IPVRF.";
+    reference "0.3.0";
+  }
 
   revision "2021-06-21" {
     description
@@ -151,6 +158,28 @@ module openconfig-evpn-types {
       "Integrated Routing and Bridging interface.  It connects an IP-
       VRF to a BD or subnet";
     reference "draft-ietf-bess-evpn-inter-subnet-forwarding-10";
+  }
+
+  identity EVPN_REDISTRIBUTE_TYPE {
+    description "Base identity for a type of evpn route to redistribute";
+  }
+
+  identity REDISTRIBUTE_LEARNED {
+    base EVPN_REDISTRIBUTE_TYPE;
+    description
+      "Redistribute dynamically learned routes";
+  }
+
+  identity REDISTRIBUTE_STATIC {
+    base EVPN_REDISTRIBUTE_TYPE;
+    description
+      "Redistribute statically configured routes";
+  }
+
+  identity REDISTRIBUTE_CONNECTED {
+    base EVPN_REDISTRIBUTE_TYPE;
+    description
+      "Redistribute connected routes";
   }
 
   typedef evi-id {

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,17 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2024-05-08" {
+   description
+     "Add redistribute type leaf list to EVI config to support configuration of
+      various types of route distribution (for both L2 and L3).
+      Add new vni-list leaf list to EVI config to support VLAN-aware-bundle MACVRFs.
+      Add new local-endpoint-vnis config container to Vxlan connection point to allow
+      configuration of local VNI-to-VLAN and VNI-to-VRF maps";
+   reference   "0.9.0";
+  }
 
   revision "2024-04-03" {
    description
@@ -555,6 +565,14 @@ module openconfig-evpn {
             draft-ietf-bess-rfc7432bis-05 BGP MPLS-Based
              Ethernet VPN";
     }
+
+    leaf-list redistribute {
+      type identityref {
+        base oc-evpn-types:EVPN_REDISTRIBUTE_TYPE;
+      }
+      description
+        "Which types of MACs to redistribute on this EVI";
+    }
   }
 
   grouping evpn-import-export-config {
@@ -645,10 +663,25 @@ module openconfig-evpn {
       Using Ethernet VPN";
 
     leaf vni {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_BASED' or
+            ../../../config/service-type = 'oc-evpn-types:VLAN_BUNDLE'" {
+        description
+          "For VLAN-based and VLAN-bundle EVIs, use a single VNI";
+      }
       type oc-evpn-types:vni-id;
       description
         "Virtual Network Identifier (VNI) associated to the EVI. This VNI is used for
         ingress and egress in the VXLAN domain.";
+    }
+
+    leaf-list vni-list {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_AWARE'" {
+        description
+          "For VLAN-aware-bundle EVIs, use a list of VNIs";
+      }
+      type oc-evpn-types:vni-id;
+      description
+        "List of VNIs participating in a VLAN-aware-bundle EVI";
     }
 
     leaf overlay-endpoint-network-instance {
@@ -993,11 +1026,45 @@ module openconfig-evpn {
           config false;
           description
             "Container for state parameters related to this L2VNI or L3VNI";
+          uses evpn-endpoint-vni-config;
           uses evpn-endpoint-vni-state;
         }
 
         uses ipv4-top;
         uses ipv6-top;
+      }
+    }
+
+    container local-endpoint-vnis {
+      description
+        "Top level container for local configuration related to Layer 2 virtual
+        network identifiers (L2VNIs) and Layer 3 virtual network identifiers
+        (L3VNIs) in the default network instance";
+
+      list local-endpoint-vni {
+        key "vni";
+        description "List of L2VNIs and L3VNIs configured on the local VTEP";
+
+        leaf vni {
+          type leafref {
+            path '../config/vni';
+          }
+          description "L2VNI or L3VNI Identifier";
+        }
+
+        container config {
+          description
+            "Container for configuration parameters related to this local L2VNI or
+            L3VNI";
+          uses evpn-endpoint-vni-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Container for state parameters related to this local L2VNI or L3VNI";
+          uses evpn-endpoint-vni-config;
+        }
       }
     }
   }
@@ -1144,15 +1211,51 @@ module openconfig-evpn {
     }
   }
 
-  grouping evpn-endpoint-vni-state {
+  grouping evpn-endpoint-vni-config {
     description
-      "Grouping for L2VNI and L3VNI state information learned on the
-      local VXLAN Tunnel End Point from remote VTEPs";
+      "Grouping for L2VNI and L3VNI configuration parameters";
 
     leaf vni {
       type oc-evpn-types:evi-id;
       description "L2VNI or L3VNI Identifier";
     }
+
+    leaf vni-type {
+      type enumeration {
+        enum L2 {
+          description
+            "This is a Layer 2 service virtual network identifier (L2VNI)
+            that is used for communication within the same subnet or
+            broadcast domain";
+        }
+        enum L3 {
+          description
+            "This is a Layer 3 service virtual network identifier (L3VNI)
+            or VRF VNI that is used for communication between subnets";
+        }
+      }
+      description "The type of virtual network identfier";
+    }
+
+    leaf bridge-domain {
+      type uint32;
+      description
+        "This reflects the configured VLAN or Bridge Domain that maps to this
+        L2VNI in the VXLAN fabric";
+    }
+
+    leaf l3-vrf-name {
+      type string;
+      description
+        "This refects the configured VRF instance that maps to this L3VNI
+        that is used for routing between subnets in the VXLAN fabric";
+    }
+  }
+
+  grouping evpn-endpoint-vni-state {
+    description
+      "Grouping for L2VNI and L3VNI state information learned on the
+      local VXLAN Tunnel End Point from remote VTEPs";
 
     leaf multidestination-traffic {
       type union {
@@ -1185,23 +1288,6 @@ module openconfig-evpn {
       description
         "Indicates whether the learning mode for this VNI is either
         control-plane or data-plane";
-    }
-
-    leaf vni-type {
-      type enumeration {
-        enum L2 {
-          description
-            "This is a Layer 2 service virtual network identifier (L2VNI)
-            that is used for communication within the same subnet or
-            broadcast domain";
-        }
-        enum L3 {
-          description
-            "This is a Layer 3 service virtual network identifier (L3VNI)
-            or VRF VNI that is used for communication between subnets";
-        }
-      }
-      description "The type of virtual network identfier";
     }
 
     leaf vni-state {
@@ -1237,20 +1323,5 @@ module openconfig-evpn {
         "Operational status of the SVI mapped to the L3VNI that is used for
         routing between subnets in the VXLAN fabric";
     }
-
-    leaf bridge-domain {
-      type uint32;
-      description
-        "This reflects the configured VLAN or Bridge Domain that maps to this
-        L2VNI in the VXLAN fabric";
-    }
-
-    leaf l3-vrf-name {
-      type string;
-      description
-        "This refects the configured VRF instance that maps to this L3VNI
-        that is used for routing between subnets in the VXLAN fabric";
-    }
-
   }
 }


### PR DESCRIPTION
### Change Scope

This change seeks to accomplish 3 goals:
* Add support for configuring VLAN-aware-bundle MACVRFs, in addition to the currently supported VLAN-based MACVRFs
* Add support for configuring local VLAN-to-VNI and VRF-to-VNI mappings for VXLAN
* Add support for configuring the type(s) of MACs/IP prefixes to redistribute over EVPN for both MACVRFs and IPVRFs

#### Support for VLAN-aware-bundle MACVRFs

The EVPN EVI configuration in the existing network-instance model contains a “service-type” leaf used for configuring the type of MACVRF that the EVI represents.  EVPN supports 3 different service types, VLAN-based, VLAN-bundle, and VLAN-aware-bundle, but per https://www.openconfig.net/docs/models/evpn_use_cases/, the existing Openconfig model only supports the VLAN-based service type (“In the current version of EVPN Model in Openconfig, VLAN_BASED is supported”).

The existing EVI model only supports configuring a single VNI per-EVI (network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/vni/), while configuring a VLAN-aware-bundle MACVRF requires the ability to configure all of the VNIs contained in the bundle.

To that effect, this change proposes the addition of an additional “vni-list” leaf list, which will allow the configuration of an arbitrary number of VNIs per-MACVRF.  This new “vni-list” member will be made conditional on the service-type of the MACVRF being VLAN_AWARE.  The existing “vni” member will be made conditional on the service type of the MACVRF being VLAN_BASED or VLAN_AWARE.

Because only VLAN-based MACVRFs are currently supported, and the existing tree will not change for those types of MACVRFs, this change is fully backwards compatible.

New tree state after proposed change (additions in **bold**):
<pre>
module: openconfig-network-instance
+--rw network-instances
   +--rw network-instance* [name]
      +--rw evpn
         +--rw evpn-instances
            +--rw evpn-instance* [evi]
               +--rw vxlan
               |  +--rw config
               |  |  +--rw vni?                               oc-evpn-types:vni-id
              <b> |  |  +--rw vni-list*                          oc-evpn-types:vni-id</b>
               |  |  +--rw overlay-endpoint-network-instance? -> ...
               |  |  +--rw overlay-endpoint?                  -> ...
               |  |  +--rw host-reachability-bgp?             boolean 
               |  |  +--rw multicast-group?                   oc-inet:ip-address
               |  |  +--rw multicast-mask?                    oc-inet:ip-address
               |  +--ro state
               |  |  +--ro vni?                               oc-evpn-types:vni-id
               <b>|  |  +--ro vni-list*                          oc-evpn-types:vni-id</b>
               |  |  +--ro overlay-endpoint-network-instance? -> ...
               |  |  +--ro overlay-endpoint?                  -> ...
               |  +--ro host-reachability-bgp?                boolean
               |  +--ro multicast-group?                      oc-inet:ip-address
               |  +--ro multicast-mask?                       oc-inet:ip-address
               +--rw anycast-source-interface
                  +--rw config
                  |     ...
                  +--ro state
                        ...
</pre>
New Yang Paths:
* network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/config/vni-list/
* network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/status/vni-list/

#### Support for configuring local VLAN-to-VNI and VRF-to-VNI mappings

The existing endpoint-vnis subtree for VXLAN endpoints is read-only, and seems intended for reporting state “learned on the local VXLAN Tunnel End Point from remote VTEPs in the default network instance” (see https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-network-instance.html).

To support the configuration of local VLAN-to-VNI and VRF-to-VNI mappings on a VTEP, this change proposes the addition of a “local-endpoint-vnis” subtree, which will be congruent with the existing “endpoint-vnis” subtree, but be read/write, and allow the configuration of local VLAN-to-VNI and VRF-to-VNI mappings.

It will specifically contain support for configuring the VNI, VNI type (L2 or L3), and either the bridge-domain (for L2 VNIs) or l3-vrf-name (for L3 VNIs).

Because this is a new subtree being added, this change is fully backwards compatible.

New tree state after proposed change (additions in **bold**):
<pre>
module: openconfig-network-instance
+--rw network-instances
   +--rw network-instance* [name]
      +--rw connection-points
         +--rw connection-point* [connection-point-id]
            +--rw endpoints
               +--rw endpoint* [endpoint-id]
                  +--rw vxlan
                     <b>+--rw local-endpoint-vnis
                        +--rw local-endpoint-vni* [vni]
                           +--rw vni       -> ../config/vni
                              +--rw config
                              |  +--rw vni?             oc-evpn-types:evi-id
                              |  +--rw vni-type?        enumeration
                              |  +--rw bridge-domain?   uint32
                              |  +--rw l3-vrf-name?     string
                              +--ro state
                                 +--ro vni?             oc-evpn-types:evi-id
                                 +--ro vni-type?        enumeration
                                 +--ro bridge-domain?   uint32
                                 +--ro l3-vrf-name?     string</b>
</pre>

New Yang Paths:
* network-instances/network-instance/connection-points/connection-point/endpoints/endpoint/vxlan/local-endpoint-vnis/…

#### Support for configuring the type(s) of EVPN route redistribution for MACVRFs and IPVRFs

MACVRFs and IPVRFs can be configured to redistribute different types of MACs and IP Prefixes to their peers.  For instance, a MACVRF might be configured to redistribute routes for dynamic MACs learned in the associated local VLANs, but not static MACs configured in those same VLANs.

To support the ability to configure these distribution settings, this change proposes the addition of a “redistribute” leaf list to the EVI subtree, along with a new identity type for types of redistributions to support.  This initial proposal has 3 types of redistributions defined, REDISTRIBUTE_LEARNED and REDISTRIBUTE_STATIC, for redistributing dynamically learned and statically configured MACs, respectively, into a MACVRF, and REDISTRIBUTE_CONNECTED, for redistributing connected IP routes into an IPVRF.  Additional types of redistribution could be added in later changes.

Because this is a new leaf being added, this change is fully backwards compatible.

New tree state after proposed change (additions in **bold**):
<pre>
module: openconfig-network-instance
+--rw network-instances
   +--rw network-instance* [name]
      +--rw evpn
         +--rw evpn-instances
            +--rw evpn-instance* [evi]
               +--rw evi                     -> ../config/evi
                  +--rw config
                  |  +--rw evi?                    string
                  |  +--rw encapsulation-type?     identityref
                  |  +--rw service-type?           identityref
                  |  +--rw multicast-group?        oc-inet:ipaddress
                  |  +--rw multicast-mask?         oc-inet:ipaddress
                  |  +--rw replication-mode?       enumeration
                  |  +--rw route-distinguisher?    union
                  |  +--rw control-word-enabled?   boolean
                  <b>|  +--rw redistribute*           oc-evpn-types:redistribute-type</b>
                  +--ro state
                  |  +--ro evi?                    string
                  |  +--ro encapsulation-type?     identityref
                  |  +--ro service-type?           identityref
                  |  +--ro multicast-group?        oc-inet:ip-address
                  |  +--ro multicast-mask?         oc-inet:ip-address
                  |  +--ro replication-mode?       enumeration
                  |  +--ro route-distinguisher?    union
                  |  +--ro control-word-enabled?   boolean
                  <b>|  +--ro redistribute*           oc-evpn-types:redistribute-type</b>
</pre>

New Yang Paths:
* network-instances/network-instance/evpn/evpn-instances/evpn-instance/config/redistribute
* network-instances/network-instance/evpn/evpn-instances/evpn-instance/status/redistribute

### Platform Implementations

#### Arista EOS:

**VLAN-aware-bundle configuration:**
https://www.arista.com/en/um-eos/eos-evpn-overview#xx1247264
<pre>
router bgp 65002
...
   vlan-aware-bundle foo
      rd 1.1.1.11:1213
      route-target both 12:13
      redistribute learned
      vlan 12-13
</pre>

**VLAN-to-VNI and VRF-to-VNI mapping:**
https://www.arista.com/en/um-eos/eos-vxlan-configuration#xx1152323
<pre>
interface Vxlan1
   vxlan udp-port 4789
   vxlan vlan 200 vni 658120
   vxlan vlan 100 vni 100
   vxlan vrf test vni 12345
</pre>

**Redistribution config:**
https://www.arista.com/en/um-eos/eos-sample-configurations#xx1247650
<pre>
router bgp 65002
   vlan 10
      rd 1.1.1.11:1010
      route-target both 1010:1010
      redistribute learned
   !
   vlan 11
      rd 1.1.1.11:1011
      route-target both 1011:1011
      redistribute learned
      redistribute static
   !
   vrf red
   ...
      redistribute connected
</pre>
