### PR TITLE
Fix yang namespace URI to openconfig.net (#1111)

### DIFF
--- a/release/models/devices-manifest/openconfig-terminal-device-properties.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-properties.yang
@@ -10,7 +10,7 @@ module openconfig-terminal-device-properties {
   yang-version "1";
 
   // namespace
-  namespace "http://example.net/yang/openconfig-terminal-device-properties";
+  namespace "http://openconfig.net/yang/openconfig-terminal-device-properties";
   prefix "oc-opt-term-properties";
 
   import openconfig-extensions { prefix oc-ext; }
@@ -35,10 +35,16 @@ module openconfig-terminal-device-properties {
       the OTSi (OTSiMC). It also includes (optional) aspects such as
       filter characterization, CD and DGD tolerance.";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.1.2";
 
 
   // Revisions
+  revision "2024-05-15" {
+    description
+      "Fix yang namespace URI to openconfig.net.";
+      reference "0.1.2";
+  }
+
   revision "2023-12-13" {
     description
       "Add reference to the terminal-device-properties-guide.md doc for operational-modes.";

--- a/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
+++ b/release/models/devices-manifest/openconfig-terminal-device-property-types.yang
@@ -10,7 +10,7 @@ module openconfig-terminal-device-property-types {
   yang-version "1";
 
   // namespace
-  namespace "http://example.net/yang/openconfig-terminal-device-property-types";
+  namespace "http://openconfig.net/yang/openconfig-terminal-device-property-types";
   prefix "oc-opt-term-prop-types";
 
   import openconfig-extensions { prefix oc-ext; }
@@ -29,10 +29,16 @@ module openconfig-terminal-device-property-types {
       definitions of the set of modulation format, FEC codes and adjustment
       granularity types use in the reffered model.";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
 
 
   // Revisions
+  revision "2024-05-15" {
+    description
+      "Fix yang namespace URI to openconfig.net.";
+      reference "0.1.1";
+  }
+
   revision "2022-03-08" {
       description "Initial version to provide the initial set of identities
       used in the openconfig-terminal-device-properties model.";


### PR DESCRIPTION
The namespace URI in the devices-manifest module yangs is wrong.
It's pointing to example.net and should be fixed to openconfig.net

### Change Scope

 * Change made in the following yangs of devices-manifest model:
   - openconfig-terminal-device-properties.yang
   - openconfig-terminal-device-property-types.yang
 * This change is backwards compatible