### PR TITLE
Clarify /network-instances/network-instance/tables 

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -24,7 +24,14 @@ submodule openconfig-network-instance-l2 {
     Layer 2 network instance configuration and operational state
     parameters.";
 
-  oc-ext:openconfig-version "4.4.0";
+  oc-ext:openconfig-version "4.4.1";
+
+  revision "2024-02-27" {
+    description
+      "Clarify that tables are created only by the system and not
+      users.";
+    reference "4.4.1";
+  }
 
   revision "2024-02-27" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -643,9 +643,8 @@ module openconfig-network-instance {
 	            removal of the table should not require additional or
 	            explicit configurations.
 
-              Users are not expected to create or delete tables.
-              Instead a user may configure table-connections which
-              reference these tables.";
+              Users cannot create or delete tables.  Instead a user may
+              configure table-connections which reference these tables.";
 
             leaf protocol {
               type leafref {

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -48,7 +48,14 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.4.0";
+  oc-ext:openconfig-version "4.4.1";
+
+  revision "2024-02-27" {
+    description
+      "Clarify that tables are created only by the system and not
+      users.";
+    reference "4.4.1";
+  }
 
   revision "2024-02-27" {
     description
@@ -608,7 +615,8 @@ module openconfig-network-instance {
         container tables {
           description
             "The routing tables that are managed by this network
-            instance";
+            instance.  Tables are created and removed by the system.
+            Users do not create tables.";
 
           list table {
             key "protocol address-family";
@@ -633,7 +641,11 @@ module openconfig-network-instance {
               address families enabled, the protocol=BGP,
               address-family=IPv4 table is created by the system. The
 	            removal of the table should not require additional or
-	            explicit configurations";
+	            explicit configurations.
+
+              Users are not expected to create or delete tables.
+              Instead a user may configure table-connections which
+              reference these tables.";
 
             leaf protocol {
               type leafref {


### PR DESCRIPTION
### Change Scope

* Explicitly state that users cannot create or delete `/network-instances/network-instance/tables/table` nodes.
* This change is a minor clarification and backwards compatible.

