### PR TITLE
Add gratuitous-arp-accepted and unsolicited-na-accepted

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,7 +44,7 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.5.2";
+  oc-ext:openconfig-version "3.6.0";
 
   revision "2024-05-28" {
     description

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -620,14 +620,14 @@ revision "2023-06-30" {
         "RFC 4862: IPv6 Stateless Address Autoconfiguration";
     }
 
-    leaf unsolicited-na-accepted {
+    leaf learn-unsolicited {
       type boolean;
-      default true;
       description
-        "When set to true unsolicited neighbor advertisements
-        will be accepted and the ARP table will be updated.";
+        "When set to true neighbors will be learned from unsolicited
+        neighbor advertisements.";
       reference
-        "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+        "RFC 9131: Routers Creating Cache Entries upon
+        Receiving Unsolicited Neighbor Advertisements";
     }
 
     uses ip-common-global-config;

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -488,10 +488,8 @@ revision "2023-06-30" {
 
    leaf gratuitous-arp-accepted {
      type boolean;
-     default false;
      description
-        "When set to true, gratuitous neighbor advertisements
-        will be accepted.";
+        "When set to true, gratuitous ARPs will be accepted.";
      reference
       "RFC 826: An Ethernet Address Resolution Protocol";
     }
@@ -623,13 +621,12 @@ revision "2023-06-30" {
 
     leaf unsolicited-na-accepted {
       type boolean;
-      default false;
+      default true;
       description
         "When set to true unsolicited neighbor advertisements
         will be accepted.";
       reference
-        "RFC 9131: Gratuitous Neighbor Discovery: Creating
-        Neighbor Cache Entries on First-Hop Routers";
+        "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
     }
 
     uses ip-common-global-config;

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -637,8 +637,8 @@ revision "2023-06-30" {
       }
       default "NONE";
       description
-        "When set to true neighbors will be learned from unsolicited
-        neighbor advertisements.";
+        "Sets if neighbors should be learned from unsolicited neighbor
+        advertisements for global or link local addresses or both.";
       reference
         "RFC 9131: Routers Creating Cache Entries upon
         Receiving Unsolicited Neighbor Advertisements";

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -49,7 +49,7 @@ module openconfig-if-ip {
   revision "2024-05-28" {
     description
       "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted for IPv6";
-    reference "3.5.2";
+    reference "3.6.0";
   }
 
   revision "2024-03-13" {
@@ -489,7 +489,8 @@ revision "2023-06-30" {
    leaf gratuitous-arp-accepted {
      type boolean;
      description
-        "When set to true, gratuitous ARPs will be accepted.";
+        "When set to true, gratuitous ARPs will be accepted and
+        the ARP table will be updated";
      reference
       "RFC 826: An Ethernet Address Resolution Protocol";
     }
@@ -624,7 +625,7 @@ revision "2023-06-30" {
       default true;
       description
         "When set to true unsolicited neighbor advertisements
-        will be accepted.";
+        will be accepted and the ARP table will be updated";
       reference
         "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
     }

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -48,7 +48,7 @@ module openconfig-if-ip {
 
   revision "2024-05-28" {
     description
-      "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted for IPv6";
+      "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted for IPv6.";
     reference "3.6.0";
   }
 
@@ -490,7 +490,7 @@ revision "2023-06-30" {
      type boolean;
      description
         "When set to true, gratuitous ARPs will be accepted and
-        the ARP table will be updated";
+        the ARP table will be updated.";
      reference
       "RFC 826: An Ethernet Address Resolution Protocol";
     }
@@ -625,7 +625,7 @@ revision "2023-06-30" {
       default true;
       description
         "When set to true unsolicited neighbor advertisements
-        will be accepted and the ARP table will be updated";
+        will be accepted and the ARP table will be updated.";
       reference
         "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
     }

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -44,7 +44,13 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.5.1";
+  oc-ext:openconfig-version "3.5.2";
+
+  revision "2024-05-28" {
+    description
+      "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted for IPv6";
+    reference "3.5.2";
+  }
 
   revision "2024-03-13" {
     description
@@ -480,6 +486,16 @@ revision "2023-06-30" {
        "RFC 791: Internet Protocol";
     }
 
+   leaf gratuitous-arp-accepted {
+     type boolean;
+     default false;
+     description
+        "When set to true, gratuitous neighbor advertisements
+        will be accepted.";
+     reference
+      "RFC 826: An Ethernet Address Resolution Protocol";
+    }
+
     uses ip-common-global-config;
 
 
@@ -603,6 +619,17 @@ revision "2023-06-30" {
         transmission with no follow-up retransmissions.";
       reference
         "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+    }
+
+    leaf unsolicited-na-accepted {
+      type boolean;
+      default false;
+      description
+        "When set to true unsolicited neighbor advertisements
+        will be accepted.";
+      reference
+        "RFC 9131: Gratuitous Neighbor Discovery: Creating
+        Neighbor Cache Entries on First-Hop Routers";
     }
 
     uses ip-common-global-config;

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -621,7 +621,21 @@ revision "2023-06-30" {
     }
 
     leaf learn-unsolicited {
-      type boolean;
+      type enumeration {
+        enum NONE {
+          value 0;
+        }
+        enum GLOBAL {
+          value 1;
+        }
+        enum LINK_LOCAL {
+          value 2;
+        }
+        enum BOTH {
+          value 3;
+        }
+      }
+      default "NONE";
       description
         "When set to true neighbors will be learned from unsolicited
         neighbor advertisements.";


### PR DESCRIPTION
### Change Scope

Two new boolean leaf values will be added to paths below,

- `interfaces/interface/subinterfaces/subinterface/ipv4/config/`
- `interfaces/interface/subinterfaces/subinterface/ipv6/config/`.

**A. Yang tree for IPv4**
```
/oc-if:interfaces/oc-if:interface/oc-if:subinterfaces/oc-if:subinterface:
    +--rw ipv4
       +--rw config
       |  +--rw enabled?                     boolean
       |  +--rw mtu?                         uint16
       |  +--rw dhcp-client?                 boolean
       |  +--rw gratuitous-arp-accepted?     boolean       <<<new
       +--ro state
          +--ro enabled?                     boolean
          +--ro mtu?                         uint16
          +--ro dhcp-client?                 boolean
          +--ro gratuitous-arp-accepted?     boolean       <<<new
          +--ro counters
```

**B. Yang tree for IPv6**
```
/oc-if:interfaces/oc-if:interface/oc-if:subinterfaces/oc-if:subinterface:
    +--rw ipv6
       +--rw config
       |  +--rw enabled?                     boolean
       |  +--rw mtu?                         uint32
       |  +--rw dup-addr-detect-transmits?   uint32
       |  +--rw dhcp-client?                 boolean
       |  +--rw unsolicited-na-accepted?     boolean    <<<new
       +--ro state
          +--ro enabled?                     boolean
          +--ro mtu?                         uint32
          +--ro dup-addr-detect-transmits?   uint32
          +--ro dhcp-client?                 boolean
          +--ro unsolicited-na-accepted?     boolean    <<<new
          +--ro counters
```
As the name suggests these will be used to toggle if the device will accept (and process) or reject the gratuitous arp updates.

This change is backwards compatible

### Platform Implementations

**A. Implementation for IPv4**

**Arista**

These commands configure interface ethernet 2/1 to accept gratuitous ARP request packets.
```
switch(config)# interface ethernet 2/1
switch(config-if-Et2/1)# arp gratuitous accept
switch(config-if-Et2/1)#
```

**B. Implementation for IPv6**

**Arista**
```
switch(config-if-Et1/1)#ipv6 nd na unsolicited accept
   
switch#show ipv6 interface et1/1
. . .
  ND unsolicited NAs are accepted
```