### PR TITLE
Configuration to control ACL set/entry counter allocation

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,7 +34,14 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.3.4";
+
+  revision "2024-06-03" {
+    description
+      "Add configuration control for statistics collection per
+      ACL-set and per ACL entry.";
+    reference "1.3.4";
+  }
 
   revision "2023-02-06" {
     description
@@ -233,6 +240,12 @@ module openconfig-acl {
       and reported per ACL entry.";
   }
 
+  identity NONE {
+    base ACL_COUNTER_CAPABILITY;
+    description
+      "ACL counters are not incremented.";
+  }
+
   // grouping statements
 
   // input interface
@@ -405,6 +418,16 @@ module openconfig-acl {
         Entry.";
     }
 
+    leaf counter {
+      type identityref {
+        base ACL_COUNTER_CAPABILITY;
+      }
+      description
+        "Specify the counter resources that should be allocated to
+        the ACL entry. This setting overrides configuration at the
+        ACL set level.";
+    }
+
   }
 
   grouping access-list-entries-state {
@@ -527,6 +550,15 @@ module openconfig-acl {
         "Description, or comment, for the ACL set";
     }
 
+    leaf counter {
+      type identityref {
+        base ACL_COUNTER_CAPABILITY;
+      }
+      description
+        "Specify the counter resources that should be allocated to
+        the ACL entries of the ACL set. This setting can be overridden
+        on a per ACL entry basis.";
+    }
   }
 
   grouping acl-set-state {
@@ -891,7 +923,8 @@ module openconfig-acl {
       }
       description
         "System reported indication of how ACL counters are reported
-        by the target";
+        by the target. If the setting is not the same for all ACL
+        entries of all ACL sets, no value is returned.";
     }
   }
   grouping acl-top {


### PR DESCRIPTION
This code is a Contribution to the OpenConfig Public project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.

Change Scope

At present, the allocation of system resources needed to provide counters for packets matching ACL entries cannot be controlled through configuration. This PR aims to fill this gap by introducing the following new paths:
acl/acl-sets/acl-set/config/counter
acl/acl-sets/acl-set/state/counter
acl/acl-sets/acl-set/acl-entries/acl-entry/config/counter
acl/acl-sets/acl-set/acl-entries/acl-entry/state/counter

The permitted values are: NONE, INTERFACE_ONLY, AGGREGATE_ONLY and INTERFACE_AGGREGATE. These are the same values as supported by the existing ACL_COUNTER_CAPABILITY except now NONE has been added as well, in order to allow the operator to disable stats collection for specific ACL sets or ACL entries in order to conserve limited resources.

The description for /acl/state/counter-capability has been amended to recommend that no value should be returned in state if the support of counters is not uniformly configured for all ACL sets and all ACL entries.

Implementations

Many vendors support some form of configuration control for ACL counters.
Arista: https://www.arista.com/en/um-eos/eos-acls-and-route-maps
Nokia: https://documentation.nokia.com/srlinux/24-3/books/acl-policy-based-routing/access-control-lists.html

