### PR TITLE
Updates to network-instance EVPN models for VLAN-aware-bundle support

### DIFF
--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,14 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2024-06-07" {
+   description
+      "Add new vni-list leaf list to EVI config to support VLAN-aware-bundle
+      MACVRFs.  Make existing vni leaf conditional on MACVRF type being VLAN-based";
+   reference   "0.9.0";
+  }
 
   revision "2024-04-03" {
    description
@@ -645,10 +652,25 @@ module openconfig-evpn {
       Using Ethernet VPN";
 
     leaf vni {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_BASED' or
+            ../../../config/service-type = 'oc-evpn-types:VLAN_BUNDLE'" {
+        description
+          "For VLAN-based and VLAN-bundle EVIs, use a single VNI";
+      }
       type oc-evpn-types:vni-id;
       description
         "Virtual Network Identifier (VNI) associated to the EVI. This VNI is used for
         ingress and egress in the VXLAN domain.";
+    }
+
+    leaf-list vni-list {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_AWARE'" {
+        description
+          "For VLAN-aware-bundle EVIs, use a list of VNIs";
+      }
+      type oc-evpn-types:vni-id;
+      description
+        "List of VNIs participating in a VLAN-aware-bundle EVI";
     }
 
     leaf overlay-endpoint-network-instance {


### PR DESCRIPTION
### Change Scope

This is part 1 of splitting the original PR #1108 into 3 separate PRs.  This one targets the changes to add VLAN-aware-bundle support.

The EVPN EVI configuration in the existing network-instance model contains a “service-type” leaf used for configuring the type of MACVRF that the EVI represents. EVPN supports 3 different service types, VLAN-based, VLAN-bundle, and VLAN-aware-bundle, but per https://www.openconfig.net/docs/models/evpn_use_cases/, the existing Openconfig model only supports the VLAN-based service type (“In the current version of EVPN Model in Openconfig, VLAN_BASED is supported”).

The existing EVI model only supports configuring a single VNI per-EVI (network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/vni/), while configuring a VLAN-aware-bundle MACVRF requires the ability to configure all of the VNIs contained in the bundle.

To that effect, this change proposes the addition of an additional “vni-list” leaf list, which will allow the configuration of an arbitrary number of VNIs per-MACVRF. This new “vni-list” member will be made conditional on the service-type of the MACVRF being VLAN_AWARE. The existing “vni” member will be made conditional on the service type of the MACVRF being VLAN_BASED or VLAN_AWARE.

Because only VLAN-based MACVRFs are currently supported, and the existing tree will not change for those types of MACVRFs, this change is fully backwards compatible.

New tree state after proposed change (additions in <b>bold</b>):

<pre>
module: openconfig-network-instance
+--rw network-instances
   +--rw network-instance* [name]
      +--rw evpn
         +--rw evpn-instances
            +--rw evpn-instance* [evi]
               +--rw vxlan
               |  +--rw config
               |  |  +--rw vni?                               oc-evpn-types:vni-id
               <b>|  |  +--rw vni-list*                          oc-evpn-types:vni-id</b>
               |  |  +--rw overlay-endpoint-network-instance? -> ...
               |  |  +--rw overlay-endpoint?                  -> ...
               |  |  +--rw host-reachability-bgp?             boolean 
               |  |  +--rw multicast-group?                   oc-inet:ip-address
               |  |  +--rw multicast-mask?                    oc-inet:ip-address
               |  +--ro state
               |  |  +--ro vni?                               oc-evpn-types:vni-id
               <b>|  |  +--ro vni-list*                          oc-evpn-types:vni-id</b>
               |  |  +--ro overlay-endpoint-network-instance? -> ...
               |  |  +--ro overlay-endpoint?                  -> ...
               |  +--ro host-reachability-bgp?                boolean
               |  +--ro multicast-group?                      oc-inet:ip-address
               |  +--ro multicast-mask?                       oc-inet:ip-address
               +--rw anycast-source-interface
                  +--rw config
                  |     ...
                  +--ro state
                        ...
</pre>

New Yang Paths:

* network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/config/vni-list/
* network-instances/network-instance/evpn/evpn-instances/evpn-instance/vxlan/status/vni-list/

### Platform Implementations

#### Arista EOS:
VLAN-aware-bundle configuration:
https://www.arista.com/en/um-eos/eos-evpn-overview#xx1247264

<pre>
router bgp 65002
...
   vlan-aware-bundle foo
      rd 1.1.1.11:1213
      route-target both 12:13
      redistribute learned
      vlan 12-13
</pre>