### PR TITLE
Updates to network instance models for VLAN-VNI and VRF-VNI mappings

### DIFF
--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,14 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2024-06-07" {
+   description
+      "Add new vni-list leaf list to EVI config to support VLAN-aware-bundle
+      MACVRFs.  Make existing vni leaf conditional on MACVRF type being VLAN-based";
+   reference   "0.9.0";
+  }
 
   revision "2024-04-03" {
    description
@@ -645,10 +652,25 @@ module openconfig-evpn {
       Using Ethernet VPN";
 
     leaf vni {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_BASED' or
+            ../../../config/service-type = 'oc-evpn-types:VLAN_BUNDLE'" {
+        description
+          "For VLAN-based and VLAN-bundle EVIs, use a single VNI";
+      }
       type oc-evpn-types:vni-id;
       description
         "Virtual Network Identifier (VNI) associated to the EVI. This VNI is used for
         ingress and egress in the VXLAN domain.";
+    }
+
+    leaf-list vni-list {
+      when "../../../config/service-type = 'oc-evpn-types:VLAN_AWARE'" {
+        description
+          "For VLAN-aware-bundle EVIs, use a list of VNIs";
+      }
+      type oc-evpn-types:vni-id;
+      description
+        "List of VNIs participating in a VLAN-aware-bundle EVI";
     }
 
     leaf overlay-endpoint-network-instance {

--- a/release/models/network-instance/openconfig-evpn.yang
+++ b/release/models/network-instance/openconfig-evpn.yang
@@ -40,7 +40,14 @@ module openconfig-evpn {
     domains, this is not currently supported and requires an extension
     of the model.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2024-06-07" {
+   description
+      "Add new local-endpoint-vnis config container to Vxlan connection point to allow
+      configuration of local VNI-to-VLAN and VNI-to-VRF maps";
+   reference   "0.10.0";
+  }
 
   revision "2024-06-07" {
    description
@@ -1015,11 +1022,45 @@ module openconfig-evpn {
           config false;
           description
             "Container for state parameters related to this L2VNI or L3VNI";
+          uses evpn-endpoint-vni-config;
           uses evpn-endpoint-vni-state;
         }
 
         uses ipv4-top;
         uses ipv6-top;
+      }
+    }
+
+    container local-endpoint-vnis {
+      description
+        "Top level container for local configuration related to Layer 2 virtual
+        network identifiers (L2VNIs) and Layer 3 virtual network identifiers
+        (L3VNIs) in the default network instance";
+
+      list local-endpoint-vni {
+        key "vni";
+        description "List of L2VNIs and L3VNIs configured on the local VTEP";
+
+        leaf vni {
+          type leafref {
+            path '../config/vni';
+          }
+          description "L2VNI or L3VNI Identifier";
+        }
+
+        container config {
+          description
+            "Container for configuration parameters related to this local L2VNI or
+            L3VNI";
+          uses evpn-endpoint-vni-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Container for state parameters related to this local L2VNI or L3VNI";
+          uses evpn-endpoint-vni-config;
+        }
       }
     }
   }
@@ -1166,15 +1207,51 @@ module openconfig-evpn {
     }
   }
 
-  grouping evpn-endpoint-vni-state {
+  grouping evpn-endpoint-vni-config {
     description
-      "Grouping for L2VNI and L3VNI state information learned on the
-      local VXLAN Tunnel End Point from remote VTEPs";
+      "Grouping for L2VNI and L3VNI configuration parameters";
 
     leaf vni {
       type oc-evpn-types:evi-id;
       description "L2VNI or L3VNI Identifier";
     }
+
+    leaf vni-type {
+      type enumeration {
+        enum L2 {
+          description
+            "This is a Layer 2 service virtual network identifier (L2VNI)
+            that is used for communication within the same subnet or
+            broadcast domain";
+        }
+        enum L3 {
+          description
+            "This is a Layer 3 service virtual network identifier (L3VNI)
+            or VRF VNI that is used for communication between subnets";
+        }
+      }
+      description "The type of virtual network identfier";
+    }
+
+    leaf bridge-domain {
+      type uint32;
+      description
+        "This reflects the configured VLAN or Bridge Domain that maps to this
+        L2VNI in the VXLAN fabric";
+    }
+
+    leaf l3-vrf-name {
+      type string;
+      description
+        "This refects the configured VRF instance that maps to this L3VNI
+        that is used for routing between subnets in the VXLAN fabric";
+    }
+  }
+
+  grouping evpn-endpoint-vni-state {
+    description
+      "Grouping for L2VNI and L3VNI state information learned on the
+      local VXLAN Tunnel End Point from remote VTEPs";
 
     leaf multidestination-traffic {
       type union {
@@ -1207,23 +1284,6 @@ module openconfig-evpn {
       description
         "Indicates whether the learning mode for this VNI is either
         control-plane or data-plane";
-    }
-
-    leaf vni-type {
-      type enumeration {
-        enum L2 {
-          description
-            "This is a Layer 2 service virtual network identifier (L2VNI)
-            that is used for communication within the same subnet or
-            broadcast domain";
-        }
-        enum L3 {
-          description
-            "This is a Layer 3 service virtual network identifier (L3VNI)
-            or VRF VNI that is used for communication between subnets";
-        }
-      }
-      description "The type of virtual network identfier";
     }
 
     leaf vni-state {
@@ -1259,20 +1319,5 @@ module openconfig-evpn {
         "Operational status of the SVI mapped to the L3VNI that is used for
         routing between subnets in the VXLAN fabric";
     }
-
-    leaf bridge-domain {
-      type uint32;
-      description
-        "This reflects the configured VLAN or Bridge Domain that maps to this
-        L2VNI in the VXLAN fabric";
-    }
-
-    leaf l3-vrf-name {
-      type string;
-      description
-        "This refects the configured VRF instance that maps to this L3VNI
-        that is used for routing between subnets in the VXLAN fabric";
-    }
-
   }
 }


### PR DESCRIPTION
### Change Scope

This is part 2 of splitting the original PR #1108 into 3 separate PRs. This one targets the changes to add the ability to configure local VLAN-to-VNI and VRF-to-VNI mappings.

The existing endpoint-vnis subtree for VXLAN endpoints is read-only, and seems intended for reporting state “learned on the local VXLAN Tunnel End Point from remote VTEPs in the default network instance” (see https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-network-instance.html).

To support the configuration of local VLAN-to-VNI and VRF-to-VNI mappings on a VTEP, this change proposes the addition of a “local-endpoint-vnis” subtree, which will be congruent with the existing “endpoint-vnis” subtree, but be read/write, and allow the configuration of local VLAN-to-VNI and VRF-to-VNI mappings.

It will specifically contain support for configuring the VNI, VNI type (L2 or L3), and either the bridge-domain (for L2 VNIs) or l3-vrf-name (for L3 VNIs).

Because this is a new subtree being added, this change is fully backwards compatible.

New tree state after proposed change (additions in <b>bold</b>):

<pre>
module: openconfig-network-instance
+--rw network-instances
   +--rw network-instance* [name]
      +--rw connection-points
         +--rw connection-point* [connection-point-id]
            +--rw endpoints
               +--rw endpoint* [endpoint-id]
                  +--rw vxlan<b>
                     +--rw local-endpoint-vnis
                        +--rw local-endpoint-vni* [vni]
                           +--rw vni       -> ../config/vni
                              +--rw config
                              |  +--rw vni?             oc-evpn-types:evi-id
                              |  +--rw vni-type?        enumeration
                              |  +--rw bridge-domain?   uint32
                              |  +--rw l3-vrf-name?     string
                              +--ro state
                                 +--ro vni?             oc-evpn-types:evi-id
                                 +--ro vni-type?        enumeration
                                 +--ro bridge-domain?   uint32
                                 +--ro l3-vrf-name?     string</b>
</pre>

New Yang Paths:

* network-instances/network-instance/connection-points/connection-point/endpoints/endpoint/vxlan/local-endpoint-vnis/…

### Platform Implementations

#### Arista EOS

VLAN-to-VNI and VRF-to-VNI mapping:
https://www.arista.com/en/um-eos/eos-vxlan-configuration#xx1152323

<pre>
interface Vxlan1
   vxlan udp-port 4789
   vxlan vlan 200 vni 658120
   vxlan vlan 100 vni 100
   vxlan vrf test vni 12345
</pre>