### PR TITLE
Add BGP cumulative link-bandwidth

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,12 +24,18 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
@@ -38,6 +44,7 @@ submodule openconfig-bgp-common-multiprotocol {
       community for BGP multipath.";
     reference "9.7.0";
   }
+
   revision "2023-11-02" {
     description
       "Fix revision '2023-03-31': send-community-type was added to the

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,12 +21,18 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,19 +24,25 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
     description
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
-          reference "9.7.0";
+    reference "9.7.0";
   }
 
   revision "2023-11-02" {
@@ -698,17 +704,52 @@ submodule openconfig-bgp-common {
     description
       "Parameters controlling usage of  of DMZ Link-Bandwidth
       extended community in pultipath RIB/FIB formation";
+
     leaf enabled {
       type boolean;
       description
-      "When set to TRUE, BGP multiplepath shall distributed traffic
-      load among contributing routes proportionally to value of
-      Local Administrator subfield of link-bandwidth extended
-      community [draft-ietf-idr-link-bandwidth-07].
-      This leaf has no effect if BGP multi-path is disabled or
-      if maximum-path attribute of BGP multi-path value is set
-      to 1";
+        "When set to TRUE, BGP multiplepath shall distributed traffic
+        load among contributing routes proportionally to value of
+        Local Administrator subfield of link-bandwidth extended
+        community [draft-ietf-idr-link-bandwidth-07].
+        This leaf has no effect if BGP multi-path is disabled or
+        if maximum-path attribute of BGP multi-path value is set
+        to 1";
     }
+
+    leaf cumulative {
+      type boolean;
+      when "../enabled = 'TRUE'";
+      description
+        "When set to TRUE, and sending of link-bandwidth community values
+        is enabled, the system will sum the bgp link-bandwidth community
+        values for equal cost paths as defined in draft-ietf-bess-ebgp-dmz.";
+      reference
+        "https://datatracker.ietf.org/doc/draft-ietf-bess-ebgp-dmz/";
+    }
+
+    leaf non-transitive {
+      type boolean;
+      when "../enabled = 'TRUE'";
+      description
+        "When set to TRUE and sending of link-bandwidth community values is
+        enabled, the system will send the link-bandwidth community to eBGP
+        peers.";
+      reference
+        "https://datatracker.ietf.org/doc/draft-ietf-bess-ebgp-dmz/";
+    }
+
+    leaf equal {
+      type boolean;
+      when "../enabled = 'TRUE'";
+      description
+        "When set to TRUE, and sending of link-bandwidth community values
+        is enabled, the system divide the summed bandwidth equally across
+        available paths as defined in draft-ietf-bess-ebgp-dmz.";
+      reference
+        "https://datatracker.ietf.org/doc/draft-ietf-bess-ebgp-dmz/";
+    }
+
   }
 
   grouping bgp-common-use-multiple-paths-ebgp-config {

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,12 +27,18 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,12 +25,18 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,19 +68,25 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-06-13" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
     description
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
-          reference "9.7.0";
+    reference "9.7.0";
   }
 
   revision "2023-11-02" {


### PR DESCRIPTION
### Change Scope

* Extend configuration of BGP global and peer-groups to permit cumulative link bandwidth and transitive behavior as per [draft-ietf-bess-ebgp-dmz](https://datatracker.ietf.org/doc/draft-ietf-bess-ebgp-dmz/).   
* Also add link-bandwidth parameters to BGP neighbor configuration and state.  (Previously these were only defined at the global and peer-group levels)

* This change only adds leafs and is backwards compatible.

* Example flattened paths:
```
Prefix: /network-instances/network-instance/protocols/protocol/bgp/

global/afi-safis/afi-safi/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/cumulative=true
global/afi-safis/afi-safi/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/non-transitive=true
global/afi-safis/afi-safi/use-multiple-paths/ebgp/link-bandwidth-ext-community/config/equal=false
```

### Platform Implementations

On [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/bgp/24xx/configuration/guide/b-bgp-cg-8k-24xx/implementing-bgp.html#concept_j3g_jvv_njb), there is no special configuration needed other than `link-bandwidth-ext-community/config/enabled ` .  The OS implicitly sums up the link-bandwidth of ECMP bgp paths.

[Arista EOS](https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp#xx1418621) expects an 'aggregate' configuration option on top of enabling link-bandwidth to be added on a per neighbor basis.  They further support 'divide' and 'equal' options.

[JunOS](https://community.juniper.net/blogs/moshiko-nayman/2024/05/13/bgp-link-bandwidth-with-junos) expects configuration of a BGP policy statement to enable 'aggregate-bandwidth' and additional options for transitive/non-transitive and a 'divide-equal' option.    There is also a configuration item, set per bgp neighbor or peer to allow link-bandwidth community to be sent via eBGP (ie: allow sending  BGP link-bandwidth which was defined as non-transitive in [draft-ietf-idr-link-bandwidth](https://datatracker.ietf.org/doc/draft-ietf-idr-link-bandwidth/), but then updated by [draft-ietf-bess-ebgp-dmz](https://datatracker.ietf.org/doc/draft-ietf-bess-ebgp-dmz/) to be transitive.

### Tree view
This common stanza of changes is added at each level of BGP configuration:
bgp/global
bgp/peer-group
bgp/neighbor
bgp/global/afi-safis
bgp/peer-group/afi-safis
bgp/neighbor/afi-safis

```diff
diff -u ~/old-tree.txt ~/new-tree.txt
--- /Users/dloher/old-tree.txt  2024-06-13 17:48:44
+++ /Users/dloher/new-tree.txt  2024-06-13 17:48:23
@@ -3593,9 +3593,15 @@
         |     |  |  |  +--rw ebgp
         |     |  |  |  |  +--rw link-bandwidth-ext-community
         |     |  |  |  |  |  +--rw config
-        |     |  |  |  |  |  |  +--rw enabled?   boolean
+        |     |  |  |  |  |  |  +--rw enabled?          boolean
+        |     |  |  |  |  |  |  +--rw cumulative?       boolean
+        |     |  |  |  |  |  |  +--rw non-transitive?   boolean
+        |     |  |  |  |  |  |  +--rw equal?            boolean
         |     |  |  |  |  |  +--ro state
-        |     |  |  |  |  |     +--ro enabled?   boolean
+        |     |  |  |  |  |     +--ro enabled?          boolean
+        |     |  |  |  |  |     +--ro cumulative?       boolean
+        |     |  |  |  |  |     +--ro non-transitive?   boolean
+        |     |  |  |  |  |     +--ro equal?            boolean
         |     |  |  |  |  +--rw config
         |     |  |  |  |  |  +--rw allow-multiple-as?   boolean
         |     |  |  |  |  |  +--rw maximum-paths?       uint32
@@ -3605,9 +3611,15 @@
         |     |  |  |  +--rw ibgp
         |     |  |  |     +--rw link-bandwidth-ext-community
         |     |  |  |     |  +--rw config
-        |     |  |  |     |  |  +--rw enabled?   boolean
+        |     |  |  |     |  |  +--rw enabled?          boolean
+        |     |  |  |     |  |  +--rw cumulative?       boolean
+        |     |  |  |     |  |  +--rw non-transitive?   boolean
+        |     |  |  |     |  |  +--rw equal?            boolean
         |     |  |  |     |  +--ro state
-        |     |  |  |     |     +--ro enabled?   boolean
+        |     |  |  |     |     +--ro enabled?          boolean
+        |     |  |  |     |     +--ro cumulative?       boolean
+        |     |  |  |     |     +--ro non-transitive?   boolean
+        |     |  |  |     |     +--ro equal?            boolean
         |     |  |  |     +--rw config
         |     |  |  |     |  +--rw maximum-paths?   uint32
         |     |  |  |     +--ro state
```