### PR TITLE
Addition of BFD sessions subtree under interface in openconfig-bfd.yang

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -508,6 +508,100 @@ module openconfig-bfd {
     uses bfd-session-microbfd-common;
   }
 
+  grouping bfd-interface-session-config {
+    description
+      "Configuration parameters for a BFD session on an interface.";
+
+    leaf local-address {
+      type oc-inet:ip-address;
+      description
+        "The local IP address used by the system for the single-hope BFD session
+        specified.";
+    }
+
+    leaf remote-address {
+      type oc-inet:ip-address;
+      description
+        "The remote IP destination that should be used by the system for
+        the single-hope BFD session specified.";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true then the single-hope BFD session is enabled
+        - if it is set to false, it is administratively disabled.";
+    }
+
+    leaf demand-mode {
+      type boolean;
+      description
+        "When this leaf is set to true then the single-hope BFD session 
+        is operating in demand-mode.";
+    }
+  }
+
+  grouping bfd-interface-session-state {
+    // placeholder
+    description
+      "Operational state parameters relating to the single-hope BFD session 
+      running on the interface.";
+  }
+
+  grouping bfd-interface-sessions-structural {
+    description
+      "Structural grouping for BFD sessions configuration on interface
+      and state parameters.";
+
+    container sessions {
+      description
+        "Parameters relating to BFD sessions associated with the interface.";
+
+      list session {
+        key "local-address";
+        key "remote-address";
+
+        description
+          "This list contains configuration and state parameters
+          relating to interface single-hope session.";
+        reference
+          "RFC5881 - Bidirectional Forwarding Detection
+          (BFD) for IPv4 and IPv6 (Single Hop).";
+
+        leaf local-address {
+          type leafref {
+            path "../config/local-address";
+          }
+          description
+            "A reference to the local-address for the BFD single-hop
+            session";
+        }
+        leaf remote-address {
+          type leafref {
+            path "../config/remote-address";
+          }
+          description
+            "A reference to the remote-address for the BFD single-hop
+            session";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the BFD single-hope session.";
+          uses bfd-interface-session-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the BFD single-hope session.";
+          uses bfd-interface-session-config;
+          uses bfd-interface-session-state;
+        }
+      }
+    }
+  }
+
   grouping bfd-interface-microbfd-structural {
     description
       "Structural grouping for micro-bfd configuration and state
@@ -650,6 +744,7 @@ module openconfig-bfd {
 
           uses oc-if:interface-ref;
 
+          uses bfd-interface-sessions-structural;
           uses bfd-interface-microbfd-structural;
           uses bfd-interface-peer-structural;
         }


### PR DESCRIPTION
Creation of a BFD single-hop session subtree at interface level, so that BFD sessions can be created besides routing protocols, as stated in [RFC-9127](https://datatracker.ietf.org/doc/rfc9127/).

### Change Scope

* Creation of BFD sessions subtree at interface level, witch allows the configuration of single-hop BFD sessions under the specified interface with well specified local-address and remote-address , outside the multiple BFD clients scope. Multiple BFD sessions can be created in the same interface.
* This change is backwards compatible.
### Platform Implementations

 * IPInfusion OcNOS implementation: OcNOS BFD yang model [ipi-bfd-interface.yang (https://github.com/IPInfusion/OcNOS/blob/OcNOS-SP-6.4.2/yang-files/ipi/bfd/ipi-bfd-interface.yang). Please refer to the bfd-interface-sessions-top grouping. Also, CLI configuration example can be faund in the [BFD Configuration Guide](https://docs.ipinfusion.com/service-provider/index.html#page/OcNOS-SP/BFD-Config/BaseBFDConfig.html#ww1051773)
 * RFC 9127 implementation: The [RFC 9127](https://datatracker.ietf.org/doc/rfc9127/) specifies at section 2.6 the yang.tree of the subtree for single-hop BFD sessions configuration that allows the creation of the sessions attached to a interface, represented as a list key. This was a inspiration for this pull-request. Also the actual OpenCOnfig model does not allow configuration of BFD sessions outside the multiple BFD clients scope, but this RFC states that it should be possible.
