### PR TITLE
Adding support for configuration of ECMP of next hops for a static LSP

### DIFF
--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,16 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2024-06-19" {
+    description
+      "Added support with backward compatibility to configure ECMP
+      of next-hops for the same LSP name. Also marked attributes
+      push-label, next-hop and interface as deprecated under egress,
+      transit and ingress config";
+    reference "3.6.0";
+  }
 
   revision "2023-12-14" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -24,7 +24,16 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2024-06-19" {
+    description
+      "Added support with backward compatibility to configure ECMP
+      of next-hops for the same LSP name. Also marked attributes
+      push-label, next-hop and interface as deprecated under egress,
+      transit and ingress config";
+    reference "3.6.0";
+  }
 
   revision "2023-12-14" {
     description
@@ -156,36 +165,126 @@ submodule openconfig-mpls-static {
 
   // grouping statements
 
-  grouping static-lsp-common-config {
+  grouping static-lsp-nexthop-index {
     description
-      "common definitions for static LSPs";
+      "Next hop index definition for static LSPs";
 
-    leaf next-hop {
+    leaf index {
+      type uint32;
+      description
+        "An user-specified identifier utilised to uniquely reference
+        the next-hop entry in the next-hop list. The value of this
+        index has no semantic meaning other than for referencing
+        the entry.";
+    }
+  }
+
+  grouping static-lsp-nexthop-common-config {
+    description
+      "Common definition of next hop configuration for static LSPs";
+
+    leaf ip-address {
       type inet:ip-address;
       description
-        "next hop IP address for the LSP";
-    }
-
-    leaf incoming-label {
-      type oc-mplst:mpls-label;
-      description
-        "label value on the incoming packet";
+        "Next hop IP address for the LSP";
     }
 
     leaf push-label {
       type oc-mplst:mpls-label;
       description
-        "label value to push at the current hop for the
+        "Label value to push at the current hop for the
         LSP";
     }
 
     // interface-ref
     uses oc-if:interface-ref-common;
+  }
+
+  grouping static-lsp-common-config {
+    description
+      "Common definitions for static LSPs";
+
+    leaf incoming-label {
+      type oc-mplst:mpls-label;
+      description
+        "Label value on the incoming packet";
+    }
+
+    leaf next-hop {
+      type inet:ip-address;
+      status deprecated;
+      description
+        "Next hop IP address for the LSP";
+    }
+
+    leaf push-label {
+      type oc-mplst:mpls-label;
+      status deprecated;
+      description
+        "Label value to push at the current hop for the
+        LSP";
+    }
+
+    // interface-ref
+    uses oc-if:interface-ref-common {
+      status deprecated;
+    }
 
     leaf metric {
       type uint8;
       description
-        "Specifies metric value used for the MPLS route";
+        "Specifies metric value used for the MPLS route.";
+    }
+  }
+
+  grouping static-lsp-nexthops-common {
+    description
+      "MPLS Static LSP next-hops configuration";
+
+    container lsp-next-hops {
+      description
+        "Configuration and state parameters relating to the
+        next-hops that are to be utilised for the MPLS static
+        route being specified";
+
+      list lsp-next-hop {
+        key "index";
+
+        description
+          "A list of next-hops to be utilised for the MPLS
+          static route being specified.";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "A reference to the index of the current next-hop.
+            The index is intended to be a user-specified value
+            which can be used to reference the next-hop in
+            question, without any other semantics being
+            assigned to it.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the next-hop
+            entry";
+
+          uses static-lsp-nexthop-index;
+          uses static-lsp-nexthop-common-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the
+            next-hop entry";
+
+          uses static-lsp-nexthop-index;
+          uses static-lsp-nexthop-common-config;
+        }
+      }
     }
   }
 
@@ -227,6 +326,8 @@ submodule openconfig-mpls-static {
         uses static-lsp-ingress-config;
         uses static-lsp-ingress-state;
       }
+
+      uses static-lsp-nexthops-common;
     }
   }
 
@@ -268,6 +369,8 @@ submodule openconfig-mpls-static {
         uses static-lsp-transit-config;
         uses static-lsp-transit-state;
       }
+
+      uses static-lsp-nexthops-common;
     }
   }
 
@@ -309,6 +412,8 @@ submodule openconfig-mpls-static {
         uses static-lsp-egress-config;
         uses static-lsp-egress-state;
       }
+
+      uses static-lsp-nexthops-common;
     }
   }
 

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,16 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2024-06-19" {
+    description
+      "Added support with backward compatibility to configure ECMP
+      of next-hops for the same LSP name. Also marked attributes
+      push-label, next-hop and interface as deprecated under egress,
+      transit and ingress config";
+    reference "3.6.0";
+  }
 
   revision "2023-12-14" {
     description

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -70,7 +70,16 @@ module openconfig-mpls {
                +------+      |ROUTING|      +-----+
                              +-------+
     ";
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2024-06-19" {
+    description
+      "Added support with backward compatibility to configure ECMP
+      of next-hops for the same LSP name. Also marked attributes
+      push-label, next-hop and interface as deprecated under egress,
+      transit and ingress config";
+    reference "3.6.0";
+  }
 
   revision "2023-12-14" {
     description


### PR DESCRIPTION
### Change Scope

* (M) release/models/mpls/openconfig-mpls-static.yang
* (M) release/models/mpls/openconfig-mpls.yang

Currently, model supports configuration of only a single next hop for a given LSP name. We are adding support to configure multiple next hops by adding a new container `next-hops` to support backward compatibility. The incoming-label and metric will be used from existing config itself as its common to all next-hops.

```  +--rw network-instances
     +--rw network-instance* [name]
        +--rw mpls
           +--rw lsps
              +--rw static-lsps
                 +--rw static-lsp* [name]
                    +--rw name       -> ../config/name
                    +--rw config
                    |  +--rw name?   string
                    +--ro state
                    |  +--ro name?   string
                    +--rw ingress
                    |  +--rw config
                    |  |  +--rw incoming-label?   oc-mplst:mpls-label
                    |  |  x--rw next-hop?         inet:ip-address
                    |  |  x--rw push-label?       oc-mplst:mpls-label
                    |  |  +--rw interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--rw metric?           uint8
                    |  +--ro state
                    |  |  +--ro incoming-label?   oc-mplst:mpls-label
                    |  |  x--ro next-hop?         inet:ip-address
                    |  |  x--ro push-label?       oc-mplst:mpls-label
                    |  |  +--ro interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--ro metric?           uint8
                    |  +--rw lsp-next-hops                                                                                                                                   [36/9557]
                    |     +--rw lsp-next-hop* [index]
                    |        +--rw index     -> ../config/index
                    |        +--rw config
                    |        |  +--rw index?          uint32
                    |        |  +--rw ip-address?     inet:ip-address
                    |        |  +--rw push-label?     oc-mplst:mpls-label
                    |        |  +--rw interface?      -> /oc-if:interfaces/interface/name
                    |        |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |        +--ro state
                    |           +--ro index?          uint32
                    |           +--ro ip-address?     inet:ip-address
                    |           +--ro push-label?     oc-mplst:mpls-label
                    |           +--ro interface?      -> /oc-if:interfaces/interface/name
                    |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    +--rw transit
                    |  +--rw config
                    |  |  +--rw incoming-label?   oc-mplst:mpls-label
                    |  |  x--rw next-hop?         inet:ip-address
                    |  |  x--rw push-label?       oc-mplst:mpls-label
                    |  |  +--rw interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--rw metric?           uint8
                    |  +--ro state
                    |  |  +--ro incoming-label?   oc-mplst:mpls-label
                    |  |  x--ro next-hop?         inet:ip-address
                    |  |  x--ro push-label?       oc-mplst:mpls-label
                    |  |  +--ro interface?        -> /oc-if:interfaces/interface/name
                    |  |  +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |  |  +--ro metric?           uint8
                    |  +--rw lsp-next-hops
                    |     +--rw lsp-next-hop* [index]
                    |        +--rw index     -> ../config/index
                    |        +--rw config
                    |        |  +--rw index?          uint32
                    |        |  +--rw ip-address?     inet:ip-address
                    |        |  +--rw push-label?     oc-mplst:mpls-label
                    |        |  +--rw interface?      -> /oc-if:interfaces/interface/name
                    |        |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    |        +--ro state
                    |           +--ro index?          uint32
                    |           +--ro ip-address?     inet:ip-address
                    |           +--ro push-label?     oc-mplst:mpls-label
                    |           +--ro interface?      -> /oc-if:interfaces/interface/name
                    |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                    +--rw egress
                       +--rw config
                       |  +--rw incoming-label?   oc-mplst:mpls-label
                       |  x--rw next-hop?         inet:ip-address
                       |  x--rw push-label?       oc-mplst:mpls-label
                       |  +--rw interface?        -> /oc-if:interfaces/interface/name
                       |  +--rw subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                       |  +--rw metric?           uint8
                       +--ro state
                       |  +--ro incoming-label?   oc-mplst:mpls-label
                       |  x--ro next-hop?         inet:ip-address
                       |  x--ro push-label?       oc-mplst:mpls-label
                       |  +--ro interface?        -> /oc-if:interfaces/interface/name
                       |  +--ro subinterface?     -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                       |  +--ro metric?           uint8
                       +--rw lsp-next-hops
                          +--rw lsp-next-hop* [index]
                             +--rw index     -> ../config/index
                             +--rw config
                             |  +--rw index?          uint32
                             |  +--rw ip-address?     inet:ip-address
                             |  +--rw push-label?     oc-mplst:mpls-label
                             |  +--rw interface?      -> /oc-if:interfaces/interface/name
                             |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                             +--ro state
                                +--ro index?          uint32
                                +--ro ip-address?     inet:ip-address
                                +--ro push-label?     oc-mplst:mpls-label
                                +--ro interface?      -> /oc-if:interfaces/interface/name
                                +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
```

### Platform Implementations

 *  Arista: https://www.arista.com/en/um-eos/eos-mpls-commands#xx1141474
    CLI configuration: mpls static top-label top_tag[ bgp peer [peer IP]] [DEST_INTF] NEXTHOP_ADDR ACTION [PRIORITY]

