### PR TITLE
Acl contribution

### DIFF
--- a/release/models/acl/openconfig-packet-match-types.yang
+++ b/release/models/acl/openconfig-packet-match-types.yang
@@ -371,4 +371,28 @@ module openconfig-packet-match-types {
       decimal notation, or using a type defined by the
       ETHERTYPE identity";
   }
+
+  typedef ipv4-prefix-mask-type {
+    type union {
+      type uint8 {
+        range 0..32;
+      }
+      type oc-inet:ipv4-address;
+    }
+    description
+      "The ipv4-prefix mask to be used in acl-entries. Can be in CIDR
+      formmat or wildcard bits.";
+  }
+
+  typedef ipv6-prefix-mask-type {
+    type union {
+      type uint8 {
+        range 0..128;
+      }
+      type oc-inet:ipv6-address;
+    }
+    description
+      "The ipv6-prefix mask to be used in acl-entries. Can be in CIDR
+      formmat or wildcard bits.";
+  }
 }

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -308,9 +308,15 @@ module openconfig-packet-match {
       for IPv4";
 
     leaf source-address {
-      type oc-inet:ipv4-prefix;
+      type oc-inet:ipv4-address;
       description
-        "Source IPv4 address prefix.";
+        "Source IPv4 address.";
+    }
+
+    leaf source-address-mask {
+      type oc-pkt-match-types:ipv4-prefix-mask-type;
+      description
+        "Source IPv4 address prefix mask.";
     }
 
     leaf source-address-prefix-set {
@@ -324,9 +330,15 @@ module openconfig-packet-match {
     }
 
     leaf destination-address {
-      type oc-inet:ipv4-prefix;
+      type oc-inet:ipv4-address;
       description
-        "Destination IPv4 address prefix.";
+        "Destination IPv4 address.";
+    }
+
+    leaf destination-address-mask {
+      type oc-pkt-match-types:ipv4-prefix-mask-type;
+      description
+        "Destination IPv4 address prefix mask.";
     }
 
     leaf destination-address-prefix-set {
@@ -378,9 +390,15 @@ module openconfig-packet-match {
       "Configuration data for IPv6 match fields";
 
     leaf source-address {
-      type oc-inet:ipv6-prefix;
+      type oc-inet:ipv6-address;
       description
-        "Source IPv6 address prefix.";
+        "Source IPv6 address.";
+    }
+
+    leaf source-address-mask {
+      type oc-pkt-match-types:ipv6-prefix-mask-type;
+      description
+        "Source IPv6 address prefix mask.";
     }
 
     leaf source-address-prefix-set {
@@ -400,9 +418,15 @@ module openconfig-packet-match {
     }
 
     leaf destination-address {
-      type oc-inet:ipv6-prefix;
+      type oc-inet:ipv6-address;
       description
-        "Destination IPv6 address prefix.";
+        "Destination IPv6 address.";
+    }
+
+    leaf destination-address-mask {
+      type oc-pkt-match-types:ipv6-prefix-mask-type;
+      description
+        "Destination IPv6 address prefix mask.";
     }
 
     leaf destination-address-prefix-set {


### PR DESCRIPTION
Added support for ACL entry netmask set with non-contiguous bits

This pull resquest is being created in the context of issue [1082](https://github.com/openconfig/public/issues/1082)

In the current OpenConfig, configuration of source-address and destination-address leaves in the /oc-acl:acl/acl-sets/acl-set/acl-entries/acl-entry/ipv4/config (or ipv6) xpath are only supported with netmasks that are left-contiguous, cause this leaves are defined with type oc-inet:ipv4-prefix or oc-inet:ipv6-prefix, which only allows CIDR mask format.

The contiguous mask is applicable when assigning an IP address to an interface, or while adding routes. However, it does not necessarily need to be contiguos for ACLs. ACL's should be capable of filtering based on any kinds of masks. This way multiple non consecutive ranges of networks can be covered in one shot.

### Change Scope

* Changed type of source-address and destination-address leaves (ipv4 and ipv6) to oc-inet:ipv4/6-address. Also created new leaves to represent the netmask for each address, allowing CIDR format or wildcard bits.
* Type of source and destination address were changed but this change is backwards compatible.

### Platform Implementations

* For CISCO, documentatin of this type of configuration can be found [here](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_data_acl/configuration/15-mt/sec-data-acl-15-mt-book.pdf) in "Wildcard Mask for Addresses in an Access List" section.
* JUNO OS from Junyper also have support to this, docs can be found [here](https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-policy-configuration.html) in "Understanding Wildcard Addresses" section.
* FortiOS from Fortinet also have support to this and an example is found in this [page](https://docs.fortinet.com/document/fortigate/7.4.3/administration-guide/838461/wildcard-addressing).
* Huawei documentation about this can be found [here](https://support.huawei.com/enterprise/en/doc/EDOC1100086647#EN-US_TOPIC_0173009747) in Table 1-4.

