### PR TITLE
Adding NTP auth-key reference for NTP server config

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -51,7 +51,7 @@ module openconfig-system {
 
   revision "2024-07-15" {
     description
-      "Add auth key reference in ntp server configuration.";
+      "Added auth key reference in ntp server configuration.";
     reference "2.0.1";
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -748,6 +748,15 @@ module openconfig-system {
       description
         "Source address to use on outgoing NTP packets";
     }
+
+    leaf key-id {
+      type leafref {
+        //path "/oc-sys:system/oc-sys:ntp/oc-sys:ntp-keys/oc-sys:ntp-key/oc-sys:key-id";
+        path "../../../../ntp-keys/ntp-key/key-id";
+      }
+      description
+        "Reference to NTP authentication key for this server.";
+    }
   }
 
   grouping system-ntp-server-state {

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,12 +47,12 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.1.0";
 
   revision "2024-07-15" {
     description
       "Added auth key reference in ntp server configuration.";
-    reference "2.0.1";
+    reference "2.1.0";
   }
 
   revision "2023-12-20" {

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,7 +47,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "2.0.1";
+
+  revision "2024-07-15" {
+    description
+      "Add auth key reference in ntp server configuration.";
+    reference "2.0.1";
+  }
 
   revision "2023-12-20" {
     description
@@ -751,7 +757,6 @@ module openconfig-system {
 
     leaf key-id {
       type leafref {
-        //path "/oc-sys:system/oc-sys:ntp/oc-sys:ntp-keys/oc-sys:ntp-key/oc-sys:key-id";
         path "../../../../ntp-keys/ntp-key/key-id";
       }
       description


### PR DESCRIPTION
Related to https://github.com/openconfig/public/issues/380

Issue :
NTP model has key-list, but there is no way to reference the same from
ntp servers.

Fix :
Added a new leafref in server config container to reference configured key.

## Tree view
```diff
      +--rw system
      |  +--rw ntp
      |  +--rw servers
      |     +--rw server* [address]
      |        +--rw address    -> ../config/address
      |        +--rw config
      |        |  +--rw address?            oc-inet:host
      |        |  +--rw port?               oc-inet:port-number
      |        |  +--rw version?            uint8
      |        |  +--rw association-type?   enumeration
      |        |  +--rw iburst?             boolean
      |        |  +--rw prefer?             boolean
      |        |  +--rw network-instance?   oc-ni:network-instance-ref
      |        |  +--rw source-address?     oc-inet:ip-address
+     |        |  +--rw key-id?             -> ../../../../ntp-keys/ntp-key/key-id
      |        +--ro state
      |           +--ro address?            oc-inet:host
      |           +--ro port?               oc-inet:port-number
      |           +--ro version?            uint8
      |           +--ro association-type?   enumeration
      |           +--ro iburst?             boolean
      |           +--ro prefer?             boolean
      |           +--ro network-instance?   oc-ni:network-instance-ref
      |           +--ro source-address?     oc-inet:ip-address
+     |           +--ro key-id?             -> ../../../../ntp-keys/ntp-key/key-id
      |           +--ro stratum?            uint8
      |           +--ro root-delay?         int64
      |           +--ro root-dispersion?    int64
      |           +--ro offset?             int64
      |           +--ro poll-interval?      uint32
```