### PR TITLE
Add pf match rule for network-instance

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2023-07-16" {
+    description
+      "Add rule to match all packets received on a network-instance.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -274,13 +274,13 @@ submodule openconfig-pf-forwarding-policies {
   grouping pf-forwarding-policy-rule-ni-config {
     description
       "Forwarding policy rules for network-instance matching.";
-    leaf network-instance {
-      type leafref {
-        path "/network-instances/network-instance/config/name";
-      }
+
+    leaf input-match-all {
+      type boolean;
+      default false;
       description
-        "Reference to network-instance name used to match packets
-        for this rule.";
+        "If set to true, all packets received on a network instance
+        are matched by this rule.";
     }
   }
 

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -163,6 +163,25 @@ submodule openconfig-pf-forwarding-policies {
             uses oc-pmatch:ipv6-protocol-fields-top;
             uses oc-pmatch:transport-fields-top;
 
+            container network-instance {
+              description
+                "Container for parameters relating to match
+                rules for network-instance.";
+              container config {
+                description
+                  "Container for configuration parameters relating to
+                  match rules for network-instance.";
+                uses pf-forwarding-policy-rule-ni-config;
+              }
+              container state {
+                config false;
+                description
+                  "Container for state parameters relating to
+                  match rules for network-instance.";
+                uses pf-forwarding-policy-rule-ni-config;
+              }
+            }
+
             container action {
               description
                 "The forwarding policy action to be applied for
@@ -249,6 +268,19 @@ submodule openconfig-pf-forwarding-policies {
       type oc-yang:counter64;
       description
         "Bytes matched by the rule.";
+    }
+  }
+
+  grouping pf-forwarding-policy-rule-ni-config {
+    description
+      "Forwarding policy rules for network-instance matching.";
+    leaf network-instance {
+      type leafref {
+        path "/network-instances/network-instance/config/name";
+      }
+      description
+        "Reference to network-instance name used to match packets
+        for this rule.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* The operational use case is to match packets received on a network-instance and apply policy forwarding actions.
* This change only adds containers and leaves and is backwards compatible.

The following two paths are added
* `/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/network-instance/config/source-network-instance`
* `/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/network-instance/state/source-network-instance`


### Abbreviated Tree view
```
        +--rw policy-forwarding
        |  +--rw policies
        |  |  +--rw policy* [policy-id]
        |  |     +--rw rules
        |  |        +--rw rule* [sequence-id]
        |  |           +--rw network-instance
        |  |           |  +--rw config
        |  |           |  |  +--rw source-network-instance?   -> /network-instances/network-instance/config/name
        |  |           |  +--ro state
        |  |           |     +--ro source-network-instance?   -> /network-instances/network-instance/config/name
```

### Platform Implementations

* IOS XR Example configuration for [vrf-policy](https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/qos/b-ncs5500-qos-cli-reference/b-ncs5500-qos-cli-reference_chapter_010.html#wp2717587720)
* JunOS supports [firewall filter match conditions for routing-instance](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/topic-map/firewall-filter-match-conditions-and-actions-ptx.html)
