### PR TITLE
Remove unused top-level 'messages' container

### DIFF
--- a/release/models/system/openconfig-messages.yang
+++ b/release/models/system/openconfig-messages.yang
@@ -32,12 +32,18 @@ module openconfig-messages {
     /yang/system/openconfig-system.yang model, rather it provies the
     Operator with an alternative method of consuming messages.";
 
-  oc-ext:openconfig-version "0.0.1";
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2024-07-15 {
+    description
+      "Remove unused top-level messages container.";
+    reference "0.1.0";
+  }
 
   revision "2018-08-13" {
-      description
-        "Initial draft.";
-      reference "0.0.1";
+    description
+      "Initial draft.";
+    reference "0.0.1";
   }
 
   // identity statements
@@ -217,5 +223,4 @@ module openconfig-messages {
     uses debug-messages-top;
     }
   }
-  uses messages-top;
 }


### PR DESCRIPTION
* (M) system/openconfig-messages.yang
    - Remove unused `uses` of the top-level `messages` container

### Change Scope

It was noticed that a top-level `uses` has existed in `openconfig-messages`
since initial commit.  This has resulted in the following paths being exposed.

* `/system/messages`
* `/messages`

```
$ pyang openconfig-messages.yang -f tree
module: openconfig-messages
  +--rw messages
     +--rw config
     |  +--rw severity?   oc-log:syslog-severity
     +--ro state
     |  +--ro severity?   oc-log:syslog-severity
     |  +--ro message
     |     +--ro msg?        string
     |     +--ro priority?   uint8
     |     +--ro app-name?   string
     |     +--ro procid?     string
     |     +--ro msgid?      string
     +--rw debug-entries
        +--rw debug-service* [service]
           +--rw service    -> ../config/service
           +--rw config
           |  +--rw service?   identityref
           |  +--rw enabled?   boolean
           +--ro state
              +--ro service?   identityref
              +--ro enabled?   boolean
```

While the latter is unintended.  This change while backwards incompatible
(removing an entire subtree) was never intended and should mostly be unused by
implementations (if they were using it is incorrect).

The initial publish of this module was also incorrectly tagged at `0.0.1` so
this is the first bump to `0.1.0` to indicate we are still within the minor
version scope.

### Platform Implementations

N/A: This is for cleanup of an unintended result of initial modeling
