### PR TITLE
Add aft encapsulation-headers

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -281,46 +281,46 @@ submodule openconfig-aft-common {
             }
 
             container state {
-              description 
+              description
                 "State parameters relating to encapsulation headers.";
               uses aft-common-nexthop-encap-headers-state;
             }
 
             container gre {
-              description 
+              description
                 "Container of nodes for GRE encapsulation.";
               container state {
-                description 
+                description
                   "State parameters relating to GRE encapsulation headers.";
                 uses aft-common-entry-nexthop-gre-state;
               }
             }
 
             container ip {
-              description 
+              description
                 "Container of nodes for IP encapsulation.";
               container state {
-                description 
+                description
                   "State parameters relating to IP encapsulation headers.";
                 uses aft-common-entry-nexthop-ip-state;
               }
             }
 
             container mpls {
-              description 
+              description
                 "Container of nodes for IP encapsulation.";
               container state {
-                description 
+                description
                   "State parameters relating to MPLS encapsulation headers.";
                 uses aft-common-entry-nexthop-mpls-state;
               }
             }
 
             container udp {
-              description 
+              description
                 "Container of nodes for UDP encapsulation.";
               container state {
-                description 
+                description
                   "State parameters relating to UDP encapsulation headers.";
                 uses aft-common-entry-nexthop-udp-state;
               }
@@ -338,7 +338,7 @@ submodule openconfig-aft-common {
       "Operational state parameters relating to encapsulation headers.";
     leaf index {
       type uint8;
-      description 
+      description
         "A pointer to an entry in an ordered list of encapsulation headers.";
     }
   }
@@ -459,7 +459,7 @@ submodule openconfig-aft-common {
 
          Note: a swap operation is reflected by entries in the
          popped-mpls-label-stack and pushed-mpls-label-stack nodes.
-         
+
          This node is deprecated and the encap-headers/encap-header tree
          should be used instead.";
     }
@@ -593,8 +593,8 @@ submodule openconfig-aft-common {
       type oc-inet:port-number;
       description
         "Source UDP port number to use for the UDP header of the encapsulated
-        packet. 
-        
+        packet.
+
         When the payload packet is MPLS, then RFC 7510 - Encapsulating MPLS
         in UDP should be followed.";
       reference

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -501,10 +501,14 @@ submodule openconfig-aft-common {
 
     leaf encapsulate-header {
       type oc-aftt:encapsulation-header-type;
+      status deprecated;
       description
         "When forwarding a packet to the specified next-hop the local
         system performs an encapsulation of the packet - adding the
-        specified header type.";
+        specified header type.
+        
+        This node is deprecated and encap-headers/encap-header/state/type
+        should be used instead.";
     }
 
     leaf decapsulate-header {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -368,25 +368,15 @@ submodule openconfig-aft-common {
     }
 
     leaf-list pushed-mpls-label-stack {
-      type oc-mplst:mpls-label;
+      type oc-mplst:pushed-mpls-label-stack;
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
-        next-hop
-        - the stack is encoded as a leaf list whereby the order of the
-          entries is such that the first entry in the list is the
-          label at the bottom of the stack to be pushed.
+         next-hop. See the description of the type 
+         oc-mplst:pushed-mpls-label-stack for encoding rules.
 
-        To this end, a packet which is to forwarded to a device using
-        a service label of 42, and a transport label of 8072 will be
-        represented with a label stack list of [42, 8072].
-
-        The MPLS label stack list is ordered by the user, such that no
-        system re-ordering of leaves is permitted by the system.
-
-        A swap operation is reflected by entries in the
-        popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
-
+         Note: a swap operation is reflected by entries in the
+         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
     }
 
     leaf encapsulate-header {
@@ -464,9 +454,7 @@ submodule openconfig-aft-common {
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "The source IP address for the MPLS in UDP encapsulation may be
-        expressed using this leaf (src-ip) or if may be derived from
-        '../../interface-ref/state/subinterface'";
+        "The source IP address for the MPLS in UDP encapsulation.";
     }
 
     leaf dst-ip {
@@ -481,13 +469,13 @@ submodule openconfig-aft-common {
         "Destination IP address to use for the encapsulated packet.";
     }
 
-    leaf ttl {
+    leaf ip-ttl {
       type uint8;
       description
-        "This leaf reflects the configured/default TTL value that is used in the
-         outer header during packet encapsulation. When this leaf is not set,
-         the TTL value of the inner packet is copied over as the outer packet's
-         TTL value during encapsulation.";
+        "This leaf reflects the configured/default IP TTL value that is used
+         in the outer header during packet encapsulation. When this leaf is
+         not set, the TTL value of the inner packet is copied over as the
+         outer packet's IP TTL value during encapsulation.";
     }
 
     leaf-list pushed-mpls-label-stack {
@@ -495,16 +483,16 @@ submodule openconfig-aft-common {
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
-        next-hop
-        - the stack is encoded as a leaf list where the first entry in the
-          list is the label at the bottom of the stack to be pushed.
+         next-hop.  The stack is encoded as a leaf list where the first
+         entry in the list is the label at the bottom of the stack to be
+         pushed.
 
-        For example, a packet with a label stack of two labels, the bottom
-        label being 42 and the top label being 8072 will be represented with
-        a leaf-list of [42, 8072].
+         For example, a packet with a label stack of two labels, the bottom
+         label being 42 and the top label being 8072 will be represented with
+         a leaf-list of [42, 8072].
 
-        The MPLS label stack list is ordered by the user, such that no
-        system re-ordering of leaves is permitted by the system.";
+         The MPLS label stack list is ordered by the user, such that no
+         system re-ordering of leaves is permitted by the system.";
     }
 
   }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -349,6 +349,17 @@ submodule openconfig-aft-common {
               }
             }
 
+            container vxlan {
+              when "../state/type = 'oc-aftt:VXLAN'";
+              description
+                "Container of nodes for VXLAN encapsulation.";
+              container state {
+                description
+                  "State parameters relating to VXLAN encapsulation headers.";
+                uses aft-common-entry-nexthop-vxlan-state;
+              }
+            }
+
           }
         }
 
@@ -415,18 +426,26 @@ submodule openconfig-aft-common {
 
     leaf vni-label {
       type oc-evpn-types:evi-id;
+      status deprecated;
       description
         "Where applicable, the next hop label representing the virtual
         network identifier (VNI) for the forwarding entry. This leaf is
         applicable only to next-hops which include VXLAN encapsulation
-        header information";
+        header information.
+        
+        This leaf is deprecated.  The encap-headers/encap-header/xvlan tree
+        should be used instead.";
     }
 
     leaf tunnel-src-ip-address {
       type oc-inet:ip-address;
+      status deprecated;
       description
         "Where applicable this represents the vxlan tunnel source ip address.
-        For VXLAN this represents the source VTEP ip address";
+        For VXLAN this represents the source VTEP ip address.
+
+        This leaf is deprecated.  The encap-headers/encap-header/xvlan tree
+        should be used instead.";
     }
   }
 
@@ -661,6 +680,27 @@ submodule openconfig-aft-common {
          in the outer header during packet encapsulation. When this leaf is
          not set, the TTL value of the inner packet is copied over as the
          outer packet's IP TTL value during encapsulation.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-vxlan-state {
+    description
+      "VXLAN encapsulation applied on top of a packet.";
+
+    leaf vni-label {
+      type oc-evpn-types:evi-id;
+      description
+        "Where applicable, the next hop label representing the virtual
+        network identifier (VNI) for the forwarding entry. This leaf is
+        applicable only to next-hops which include VXLAN encapsulation
+        header information";
+    }
+
+    leaf tunnel-src-ip-address {
+      type oc-inet:ip-address;
+      description
+        "Where applicable this represents the vxlan tunnel source ip address.
+        For VXLAN this represents the source VTEP ip address";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -262,8 +262,20 @@ submodule openconfig-aft-common {
             "Container for packet encapsulation headers.  When present, this
             container indicates that encapsulation of the packet matching the
             next-hop is performed using a stack of one or more packets defined
-            in the list encap-header.";
+            in the list encap-header.
+            
+            Each entry in the list must indicate an encapsulation type and 
+            populate a container with the parameters for that encapsulation
+            header.";
           list encap-header {
+            description
+              "A list of headers added on top of a packet.  The first entry
+              in the list is the inner-most packet at the bottom of the
+              stack.
+
+              For example, in an encapsulation stack with MPLS in UDP, the
+              first index in the list is the MPLS packet and the second
+              index is UDP.";
             key "index";
 
             leaf index {
@@ -272,12 +284,13 @@ submodule openconfig-aft-common {
               }
               description
                 "A unique index identifying an encapsulation header in a stack
-                of encapsulation headers. The first entry in the list is the
-                inner-most packet at the bottom of the stack.
+                of encapsulation headers.";
+            }
 
-                For example, in an encapsulation stack with MPLS in UDP, the
-                first, index in the list is the MPLS packet and the second
-                index is UDP.";
+            leaf type {
+              type oc-aftt:encapsulation-header-type;
+              description
+                "Defines which type of packet header should be used.";
             }
 
             container state {
@@ -287,6 +300,7 @@ submodule openconfig-aft-common {
             }
 
             container gre {
+              when "../type = 'oc-aftt:GRE'";
               description
                 "Container of nodes for GRE encapsulation.";
               container state {
@@ -296,9 +310,21 @@ submodule openconfig-aft-common {
               }
             }
 
-            container ip {
+            container ipv4 {
+              when "../type = 'oc-aftt:IPV4'";
               description
-                "Container of nodes for IP encapsulation.";
+                "Container of nodes for IPv4 encapsulation.";
+              container state {
+                description
+                  "State parameters relating to IP encapsulation headers.";
+                uses aft-common-entry-nexthop-ip-state;
+              }
+            }
+
+            container ipv6 {
+              when "../type = 'oc-aftt:IPV6'";
+              description
+                "Container of nodes for IPv6 encapsulation.";
               container state {
                 description
                   "State parameters relating to IP encapsulation headers.";
@@ -307,8 +333,9 @@ submodule openconfig-aft-common {
             }
 
             container mpls {
+              when "../type = 'oc-aftt:MPLS'";
               description
-                "Container of nodes for IP encapsulation.";
+                "Container of nodes for MPLS encapsulation.";
               container state {
                 description
                   "State parameters relating to MPLS encapsulation headers.";
@@ -317,6 +344,8 @@ submodule openconfig-aft-common {
             }
 
             container udp {
+              when "../type = 'oc-aftt:UDPV4' or " +
+              "../type = 'oc-aftt:UDPV6'";
               description
                 "Container of nodes for UDP encapsulation.";
               container state {
@@ -325,6 +354,7 @@ submodule openconfig-aft-common {
                 uses aft-common-entry-nexthop-udp-state;
               }
             }
+
           }
         }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -463,10 +463,17 @@ submodule openconfig-aft-common {
         "Destination IP address to use for the encapsulated packet.";
     }
 
-    leaf dscp {
+    leaf ip-dscp {
       type oc-inet:dscp;
       description
         "Destination IP address to use for the encapsulated packet.";
+    }
+
+    leaf traffic-class {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS traffic class (TC) bits, formerly known as the
+         EXP bits.";
     }
 
     leaf ip-ttl {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -563,7 +563,7 @@ submodule openconfig-aft-common {
 
         A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
-        
+
         This node must be supported in addition to the
         encap-headers/encap-header tree.  A future release of OpenConfig
         will deprecate this node in favor of the

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -223,14 +223,15 @@ submodule openconfig-aft-common {
 
         container ip-in-ip {
           description
-            "When specified, the packet has an IP-in-IP header applied to it before
-            forwarding to the specified next-hop.  This node is deprecated and
-            the encap-headers/encap-header tree should be used instead.";
-          status deprecated;
+            "When specified, the packet has an IP-in-IP header applied to it
+            before forwarding to the specified next-hop.
 
+            This node must be supported in addition to the
+            encap-headers/encap-header tree.  A future release of OpenConfig
+            will deprecate this node in favor of the
+            encap-headers/encap-header subtree.";
           container state {
             config false;
-            status deprecated;
             description
               "State parameters relating to IP-in-IP encapsulation.";
             uses aft-common-entry-nexthop-ip-state;
@@ -244,15 +245,15 @@ submodule openconfig-aft-common {
             it before forwarding to the specified next-hop.
             encapsulate-header leaf should be set to GRE for this
             to apply.
-            This node is deprecated and the encap-headers/encap-header tree
-            should be used instead.";
-          status deprecated;
 
+            This node must be supported in addition to the
+            encap-headers/encap-header tree.  A future release of OpenConfig
+            will deprecate this node in favor of the
+            encap-headers/encap-header subtree.";
           container state {
             config false;
             description
               "State parameters relating to GRE encapsulation.";
-            status deprecated;
             uses aft-common-entry-nexthop-gre-state;
           }
         }
@@ -426,26 +427,28 @@ submodule openconfig-aft-common {
 
     leaf vni-label {
       type oc-evpn-types:evi-id;
-      status deprecated;
       description
         "Where applicable, the next hop label representing the virtual
         network identifier (VNI) for the forwarding entry. This leaf is
         applicable only to next-hops which include VXLAN encapsulation
         header information.
 
-        This leaf is deprecated.  The encap-headers/encap-header/xvlan tree
-        should be used instead.";
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
     }
 
     leaf tunnel-src-ip-address {
       type oc-inet:ip-address;
-      status deprecated;
       description
         "Where applicable this represents the vxlan tunnel source ip address.
         For VXLAN this represents the source VTEP ip address.
 
-        This leaf is deprecated.  The encap-headers/encap-header/xvlan tree
-        should be used instead.";
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
     }
   }
 
@@ -490,44 +493,47 @@ submodule openconfig-aft-common {
     leaf pop-top-label {
       type boolean;
       default false;
-      status deprecated;
       description
         "Flag that controls pop action, i.e., the top-most MPLS label
-         should be popped from the packet when switched by the system.
+        should be popped from the packet when switched by the system.
 
         The top-most MPLS label associated with pop action is equal to
         the label key used in 'mpls' AFT 'label-entry' list.
 
-        This node is deprecated and the encap-headers/encap-header tree
-        should be used instead.";
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
     }
 
     leaf-list pushed-mpls-label-stack {
       type oc-mplst:mpls-label-stack;
       ordered-by user;
-      status deprecated;
       description
         "The MPLS label stack imposed when forwarding packets to the
-         next-hop. See the description of the type
-         oc-mplst:mpls-label-stack for encoding rules.
+        next-hop. See the description of the type
+        oc-mplst:mpls-label-stack for encoding rules.
 
-         Note: a swap operation is reflected by entries in the
-         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
+        Note: a swap operation is reflected by entries in the
+        popped-mpls-label-stack and pushed-mpls-label-stack nodes.
 
-         This node is deprecated and the encap-headers/encap-header tree
-         should be used instead.";
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
     }
 
     leaf encapsulate-header {
       type oc-aftt:encapsulation-header-type;
-      status deprecated;
       description
         "When forwarding a packet to the specified next-hop the local
         system performs an encapsulation of the packet - adding the
         specified header type.
 
-        This node is deprecated and encap-headers/encap-header/state/type
-        should be used instead.";
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
     }
 
     leaf decapsulate-header {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -653,20 +653,6 @@ submodule openconfig-aft-common {
         "The value of the MPLS traffic class (TC) bits, formerly known as the
          EXP bits.";
     }
-    uses aft-common-entry-mpls-stack;
-
-  }
-
-  grouping aft-common-entry-mpls-stack {
-      description
-        "A definition for an MPLS label stack represented by a leaf-list.
-
-        MPLS label stack imposed when forwarding packets to the
-        next-hop. See the description of the type
-        oc-mplst:mpls-label-stack for encoding rules.
-
-        Note: a swap operation is reflected by entries in the
-        popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
 
     leaf-list mpls-label-stack {
       type oc-mplst:mpls-label;
@@ -679,7 +665,10 @@ submodule openconfig-aft-common {
         For example, a packet with a label stack of two labels, the bottom
         label being 42 and the top label being 8072 will be represented with
         a leaf-list of [42, 8072].  The resulting packet, starting with the
-        beginning of the packet will be '[8072][42][Payload]'.";
+        beginning of the packet will be '[8072][42][Payload]'.
+
+        Note: a swap operation is reflected by entries in the
+        popped-mpls-label-stack and the pushed-mpls-label-stack";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -432,7 +432,7 @@ submodule openconfig-aft-common {
         network identifier (VNI) for the forwarding entry. This leaf is
         applicable only to next-hops which include VXLAN encapsulation
         header information.
-        
+
         This leaf is deprecated.  The encap-headers/encap-header/xvlan tree
         should be used instead.";
     }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -25,9 +25,9 @@ submodule openconfig-aft-common {
 
   oc-ext:openconfig-version "2.7.0";
 
-  revision "2024-07-18" {
+  revision "2024-09-05" {
     description
-        "Add container for mpls-in-udp under next-hops aft entry state.";
+        "Add encapsulate-stack under aft next-hops.";
       reference "2.7.0";
   }
 
@@ -377,12 +377,12 @@ submodule openconfig-aft-common {
     }
 
     leaf-list pushed-mpls-label-stack {
-      type oc-mplst:pushed-mpls-label-stack;
+      type oc-mplst:mpls-label-stack;
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
          next-hop. See the description of the type
-         oc-mplst:pushed-mpls-label-stack for encoding rules.
+         oc-mplst:mpls-label-stack for encoding rules.
 
          Note: a swap operation is reflected by entries in the
          popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
@@ -520,12 +520,12 @@ submodule openconfig-aft-common {
     }
 
     leaf-list pushed-mpls-label-stack {
-      type oc-mplst:pushed-mpls-label-stack;
+      type oc-mplst:mpls-label-stack;
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
          next-hop. See the description of the type
-         oc-mplst:pushed-mpls-label-stack for encoding rules.
+         oc-mplst:mpls-label-stack for encoding rules.
 
          Note: a swap operation is reflected by entries in the
          popped-mpls-label-stack and pushed-mpls-label-stack nodes.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2024-09-05" {
     description
-        "Add encapsulate-stack under aft next-hops.";
+        "Add encap-headers to AFT model.";
       reference "2.7.0";
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -471,12 +471,16 @@ submodule openconfig-aft-common {
     leaf pop-top-label {
       type boolean;
       default false;
+      status deprecated;
       description
         "Flag that controls pop action, i.e., the top-most MPLS label
          should be popped from the packet when switched by the system.
 
         The top-most MPLS label associated with pop action is equal to
-        the label key used in 'mpls' AFT 'label-entry' list.";
+        the label key used in 'mpls' AFT 'label-entry' list.
+
+        This node is deprecated and the encap-headers/encap-header tree
+        should be used instead.";
     }
 
     leaf-list pushed-mpls-label-stack {
@@ -572,6 +576,17 @@ submodule openconfig-aft-common {
       description
         "The value of the MPLS traffic class (TC) bits, formerly known as the
          EXP bits.";
+    }
+
+    leaf pop-top-label {
+      type boolean;
+      default false;
+      description
+        "Flag that controls pop action, i.e., the top-most MPLS label
+         should be popped from the packet when switched by the system.
+
+        The top-most MPLS label associated with pop action is equal to
+        the label key used in 'mpls' AFT 'label-entry' list.";
     }
 
     leaf-list pushed-mpls-label-stack {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -490,16 +490,6 @@ submodule openconfig-aft-common {
          TTL value during encapsulation.";
     }
 
-    leaf flow-label {
-      type oc-inet:ipv6-flow-label;
-      description
-        "If IPv6 UDP encapsulation is used, this leaf represents a static
-        assignment for an IPv6 flow label.  If unspecified, the system may
-        set the flow label using it's own logic.";
-      reference
-        "RFC 6437 - IPv6 Flow Label Specification";
-    }
-
     leaf-list pushed-mpls-label-stack {
       type oc-mplst:mpls-label;
       ordered-by user;

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -238,6 +238,19 @@ submodule openconfig-aft-common {
           }
         }
 
+        container mpls-in-udp {
+          description
+            "When specified, the packet has an MPLS in UDP header applied to it before
+            forwarding to the specified next-hop.";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to MPLS-in-UDP encapsulation.";
+            uses aft-common-entry-nexthop-mplsudp-state;
+          }
+        }
+
         uses oc-if:interface-ref-state;
       }
     }
@@ -436,6 +449,70 @@ submodule openconfig-aft-common {
          the TTL value of the inner packet is copied over as the outer packet's
          TTL value during encapsulation.";
     }
+  }
+
+  grouping aft-common-entry-nexthop-mplsudp-state {
+    description
+      "MPLS in UDP encapsulation applied on a IPv4 or IPv6 next-hop.";
+
+    leaf src-ip {
+      type oc-inet:ip-address;
+      description
+        "The source IP address for the MPLS in UDP encapsulation may be
+        expressed using this leaf (src-ip) or if may be derived from
+        '../../interface-ref/state/subinterface'";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+
+    leaf dscp {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+
+    leaf ttl {
+      type uint8;
+      description
+        "This leaf reflects the configured/default TTL value that is used in the
+         outer header during packet encapsulation. When this leaf is not set,
+         the TTL value of the inner packet is copied over as the outer packet's
+         TTL value during encapsulation.";
+    }
+
+    leaf flow-label {
+      type uint32 {
+        range 0..1048575;
+      }
+      description
+        "If IPv6 UDP encapsulation is used, this leaf represents a static
+        assignment for an IPv6 flow label.  If unspecified, the system may
+        set the flow label using it's own logic.";
+      reference
+        "RFC 6437 - IPv6 Flow Label Specification";
+    }
+
+    leaf-list pushed-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      ordered-by user;
+      description
+        "The MPLS label stack imposed when forwarding packets to the
+        next-hop
+        - the stack is encoded as a leaf list where the first entry in the
+          list is the label at the bottom of the stack to be pushed.
+
+        For example, a packet with a label stack of two labels, the bottom
+        label being 42 and the top label being 8072 will be represented with
+        a leaf-list of [42, 8072].
+
+        The MPLS label stack list is ordered by the user, such that no
+        system re-ordering of leaves is permitted by the system.";
+    }
+
   }
 
   grouping aft-common-install-protocol {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -473,11 +473,22 @@ submodule openconfig-aft-common {
          packet.";
     }
 
-    leaf traffic-class {
-      type oc-mplst:mpls-tc;
+    leaf src-udp-port {
+      type oc-inet:port-number;
       description
-        "The value of the MPLS traffic class (TC) bits, formerly known as the
-         EXP bits.";
+        "Source UDP port number to use for the UDP header of the encapsulated
+         packet.";
+    }
+
+    leaf dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Source UDP port number to use for the UDP header of the encapsulated
+         packet.";
+      reference
+        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6636 must be
+        used only if the traffic is MPLS-in-UDP with DTLS.  Because of this
+        condition, no default is defined in OpenConfig.";
     }
 
     leaf ip-ttl {
@@ -487,6 +498,13 @@ submodule openconfig-aft-common {
          in the outer header during packet encapsulation. When this leaf is
          not set, the TTL value of the inner packet is copied over as the
          outer packet's IP TTL value during encapsulation.";
+    }
+
+    leaf traffic-class {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS traffic class (TC) bits, formerly known as the
+         EXP bits.";
     }
 
     leaf-list pushed-mpls-label-stack {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -482,7 +482,6 @@ submodule openconfig-aft-common {
       type oc-mplst:pushed-mpls-label-stack;
       ordered-by user;
       description
-      description
         "The MPLS label stack imposed when forwarding packets to the
          next-hop. See the description of the type
          oc-mplst:pushed-mpls-label-stack for encoding rules.

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -466,7 +466,8 @@ submodule openconfig-aft-common {
     leaf ip-dscp {
       type oc-inet:dscp;
       description
-        "Destination IP address to use for the encapsulated packet.";
+        "IP dscp value to use for the UDP header of the encapsulated
+         packet.";
     }
 
     leaf traffic-class {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -294,7 +294,7 @@ submodule openconfig-aft-common {
             }
 
             container gre {
-              when "../type = 'oc-aftt:GRE'";
+              when "../state/type = 'oc-aftt:GRE'";
               description
                 "Container of nodes for GRE encapsulation.";
               container state {
@@ -305,7 +305,7 @@ submodule openconfig-aft-common {
             }
 
             container ipv4 {
-              when "../type = 'oc-aftt:IPV4'";
+              when "../state/type = 'oc-aftt:IPV4'";
               description
                 "Container of nodes for IPv4 encapsulation.";
               container state {
@@ -316,7 +316,7 @@ submodule openconfig-aft-common {
             }
 
             container ipv6 {
-              when "../type = 'oc-aftt:IPV6'";
+              when "../state/type = 'oc-aftt:IPV6'";
               description
                 "Container of nodes for IPv6 encapsulation.";
               container state {
@@ -327,7 +327,7 @@ submodule openconfig-aft-common {
             }
 
             container mpls {
-              when "../type = 'oc-aftt:MPLS'";
+              when "../state/type = 'oc-aftt:MPLS'";
               description
                 "Container of nodes for MPLS encapsulation.";
               container state {
@@ -338,8 +338,8 @@ submodule openconfig-aft-common {
             }
 
             container udp {
-              when "../type = 'oc-aftt:UDPV4' or " +
-              "../type = 'oc-aftt:UDPV6'";
+              when "../state/type = 'oc-aftt:UDPV4' or " +
+              "../state/type = 'oc-aftt:UDPV6'";
               description
                 "Container of nodes for UDP encapsulation.";
               container state {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -372,7 +372,7 @@ submodule openconfig-aft-common {
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
-         next-hop. See the description of the type 
+         next-hop. See the description of the type
          oc-mplst:pushed-mpls-label-stack for encoding rules.
 
          Note: a swap operation is reflected by entries in the
@@ -479,20 +479,16 @@ submodule openconfig-aft-common {
     }
 
     leaf-list pushed-mpls-label-stack {
-      type oc-mplst:mpls-label;
+      type oc-mplst:pushed-mpls-label-stack;
       ordered-by user;
       description
+      description
         "The MPLS label stack imposed when forwarding packets to the
-         next-hop.  The stack is encoded as a leaf list where the first
-         entry in the list is the label at the bottom of the stack to be
-         pushed.
+         next-hop. See the description of the type
+         oc-mplst:pushed-mpls-label-stack for encoding rules.
 
-         For example, a packet with a label stack of two labels, the bottom
-         label being 42 and the top label being 8072 will be represented with
-         a leaf-list of [42, 8072].
-
-         The MPLS label stack list is ordered by the user, such that no
-         system re-ordering of leaves is permitted by the system.";
+         Note: a swap operation is reflected by entries in the
+         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
     }
 
   }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -268,6 +268,7 @@ submodule openconfig-aft-common {
             Each entry in the list must indicate an encapsulation type and
             populate a container with the parameters for that encapsulation
             header.";
+
           list encap-header {
             description
               "A list of headers added on top of a packet.  The first entry
@@ -277,6 +278,7 @@ submodule openconfig-aft-common {
               For example, in an encapsulation stack with MPLS in UDP, the
               first index in the list is the MPLS packet and the second
               index is UDP.";
+
             key "index";
 
             leaf index {
@@ -308,7 +310,9 @@ submodule openconfig-aft-common {
             container ipv4 {
               when "../state/type = 'oc-aftt:IPV4'";
               description
-                "Container of nodes for IPv4 encapsulation.";
+                "Container of nodes for UDP in IPv4 encapsulation.  When this
+                container is used, an IPv4 packet with no transport header
+                is added to the encapsulation list.";
               container state {
                 description
                   "State parameters relating to IP encapsulation headers.";
@@ -319,7 +323,9 @@ submodule openconfig-aft-common {
             container ipv6 {
               when "../state/type = 'oc-aftt:IPV6'";
               description
-                "Container of nodes for IPv6 encapsulation.";
+                "Container of nodes for UDP in IPv6 encapsulation.  When this
+                container is used, an IPv6 packet with no transport header
+                is added to the encapsulation list.";
               container state {
                 description
                   "State parameters relating to IP encapsulation headers.";
@@ -338,15 +344,31 @@ submodule openconfig-aft-common {
               }
             }
 
-            container udp {
-              when "../state/type = 'oc-aftt:UDPV4' or " +
-              "../state/type = 'oc-aftt:UDPV6'";
+            container udp-v4 {
+              when "../state/type = 'oc-aftt:UDPV4'";
               description
-                "Container of nodes for UDP encapsulation.";
+                "Container of nodes for UDP in IPv4 encapsulation.  When this
+                container is used, an IPv4 packet with a UDP header is added
+                to the encapsulation list.";
               container state {
                 description
-                  "State parameters relating to UDP encapsulation headers.";
-                uses aft-common-entry-nexthop-udp-state;
+                  "State parameters relating to UDP in IPv4 encapsulation
+                  headers.";
+                uses aft-common-entry-nexthop-encap-udp-state;
+              }
+            }
+
+            container udp-v6 {
+              when "../state/type = 'oc-aftt:UDPV6'";
+              description
+                "Container of nodes for UDP in IPv6 encapsulation.  When this
+                container is used, an IPv6 packet with a UDP header is added
+                to the encapsulation list.";
+              container state {
+                description
+                  "State parameters relating to UDP in IPv6 encapsulation
+                  headers.";
+                uses aft-common-entry-nexthop-encap-udp-state;
               }
             }
 
@@ -631,26 +653,26 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-udp-state {
+  grouping aft-common-entry-nexthop-encap-udp-state {
     description
       "UDP encapsulation applied on top of a packet.";
 
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "The source IP address for the MPLS in UDP encapsulation.";
+        "The source IP address for IP/UDP encapsulation.";
     }
 
     leaf dst-ip {
       type oc-inet:ip-address;
       description
-        "Destination IP address to use for the encapsulated packet.";
+        "Destination IP address for IP/UDP encapsulation.";
     }
 
     leaf ip-dscp {
       type oc-inet:dscp;
       description
-        "IP dscp value to use for the UDP header of the encapsulated
+        "IP DSCP value to use for the UDP header of the encapsulated
          packet.";
     }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -289,26 +289,41 @@ submodule openconfig-aft-common {
             container gre {
               description 
                 "Container of nodes for GRE encapsulation.";
-
-              uses aft-common-entry-nexthop-gre-state;
+              container state {
+                description 
+                  "State parameters relating to GRE encapsulation headers.";
+                uses aft-common-entry-nexthop-gre-state;
+              }
             }
 
             container ip {
               description 
                 "Container of nodes for IP encapsulation.";
-              uses aft-common-entry-nexthop-ip-state;
+              container state {
+                description 
+                  "State parameters relating to IP encapsulation headers.";
+                uses aft-common-entry-nexthop-ip-state;
+              }
             }
 
             container mpls {
               description 
                 "Container of nodes for IP encapsulation.";
-              uses aft-common-entry-nexthop-mpls-state;
+              container state {
+                description 
+                  "State parameters relating to MPLS encapsulation headers.";
+                uses aft-common-entry-nexthop-mpls-state;
+              }
             }
 
             container udp {
               description 
                 "Container of nodes for UDP encapsulation.";
-              uses aft-common-entry-nexthop-udp-state;
+              container state {
+                description 
+                  "State parameters relating to UDP encapsulation headers.";
+                uses aft-common-entry-nexthop-udp-state;
+              }
             }
           }
         }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -246,8 +246,11 @@ submodule openconfig-aft-common {
 
         container mpls-in-udp {
           description
-            "When specified, the packet has an MPLS in UDP header applied to it before
-            forwarding to the specified next-hop.";
+            "Container for mpls-in-udp encapsulation state attributes. The
+            attributes are used when encapsulate-header is set to 
+            openconfig-aft-types:MPLS_IN_UDPV(4|6), causing a the device to
+            add a MPLS in UDP header to a packet before forwarding to the
+            specified next-hop.";
 
           container state {
             config false;

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -464,7 +464,7 @@ submodule openconfig-aft-common {
     }
 
     leaf dscp {
-      type oc-inet:ip-address;
+      type oc-inet:dscp;
       description
         "Destination IP address to use for the encapsulated packet.";
     }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -506,7 +506,7 @@ submodule openconfig-aft-common {
         "When forwarding a packet to the specified next-hop the local
         system performs an encapsulation of the packet - adding the
         specified header type.
-        
+
         This node is deprecated and encap-headers/encap-header/state/type
         should be used instead.";
     }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -224,50 +224,107 @@ submodule openconfig-aft-common {
         container ip-in-ip {
           description
             "When specified, the packet has an IP-in-IP header applied to it before
-            forwarding to the specified next-hop.";
+            forwarding to the specified next-hop.  This node is deprecated and
+            the encap-headers/encap-header tree should be used instead.";
+          status deprecated;
 
           container state {
             config false;
+            status deprecated;
             description
               "State parameters relating to IP-in-IP encapsulation.";
-            uses aft-common-entry-nexthop-ipip-state;
+            uses aft-common-entry-nexthop-ip-state;
           }
         }
 
         container gre {
           description
             "When specified, the packet has an GRE
-            (Generic Routing Encapsulation)header applied to
+            (Generic Routing Encapsulation) header applied to
             it before forwarding to the specified next-hop.
             encapsulate-header leaf should be set to GRE for this
-            to apply";
+            to apply.
+            This node is deprecated and the encap-headers/encap-header tree
+            should be used instead.";
+          status deprecated;
 
           container state {
             config false;
             description
               "State parameters relating to GRE encapsulation.";
+            status deprecated;
             uses aft-common-entry-nexthop-gre-state;
           }
         }
 
-        container mpls-in-udp {
+        container encap-headers {
           description
-            "Container for mpls-in-udp encapsulation state attributes. The
-            attributes are used when encapsulate-header is set to
-            openconfig-aft-types:MPLS_IN_UDPV(4|6), causing a the device to
-            add a MPLS in UDP header to a packet before forwarding to the
-            specified next-hop.";
+            "Container for packet encapsulation headers.  When present, this
+            container indicates that encapsulation of the packet matching the
+            next-hop is performed using a stack of one or more packets defined
+            in the list encap-header.";
+          list encap-header {
+            key "index";
 
-          container state {
-            config false;
-            description
-              "State parameters relating to MPLS-in-UDP encapsulation.";
-            uses aft-common-entry-nexthop-mplsudp-state;
+            leaf index {
+              type leafref {
+                path "../state/index";
+              }
+              description
+                "A unique index identifying an encapsulation header in a stack
+                of encapsulation headers. The first entry in the list is the
+                inner-most packet at the bottom of the stack.
+
+                For example, in an encapsulation stack with MPLS in UDP, the
+                first, index in the list is the MPLS packet and the second
+                index is UDP.";
+            }
+
+            container state {
+              description 
+                "State parameters relating to encapsulation headers.";
+              uses aft-common-nexthop-encap-headers-state;
+            }
+
+            container gre {
+              description 
+                "Container of nodes for GRE encapsulation.";
+
+              uses aft-common-entry-nexthop-gre-state;
+            }
+
+            container ip {
+              description 
+                "Container of nodes for IP encapsulation.";
+              uses aft-common-entry-nexthop-ip-state;
+            }
+
+            container mpls {
+              description 
+                "Container of nodes for IP encapsulation.";
+              uses aft-common-entry-nexthop-mpls-state;
+            }
+
+            container udp {
+              description 
+                "Container of nodes for UDP encapsulation.";
+              uses aft-common-entry-nexthop-udp-state;
+            }
           }
         }
 
         uses oc-if:interface-ref-state;
       }
+    }
+  }
+
+  grouping aft-common-nexthop-encap-headers-state {
+    description
+      "Operational state parameters relating to encapsulation headers.";
+    leaf index {
+      type uint8;
+      description 
+        "A pointer to an entry in an ordered list of encapsulation headers.";
     }
   }
 
@@ -379,13 +436,17 @@ submodule openconfig-aft-common {
     leaf-list pushed-mpls-label-stack {
       type oc-mplst:mpls-label-stack;
       ordered-by user;
+      status deprecated;
       description
         "The MPLS label stack imposed when forwarding packets to the
          next-hop. See the description of the type
          oc-mplst:mpls-label-stack for encoding rules.
 
          Note: a swap operation is reflected by entries in the
-         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
+         
+         This node is deprecated and the encap-headers/encap-header tree
+         should be used instead.";
     }
 
     leaf encapsulate-header {
@@ -411,9 +472,9 @@ submodule openconfig-aft-common {
     uses aft-common-install-protocol;
   }
 
-  grouping aft-common-entry-nexthop-ipip-state {
+  grouping aft-common-entry-nexthop-ip-state {
     description
-      "IP-in-IP encapsulation applied on a next-hop";
+      "IP encapsulation applied on a next-hop";
 
     leaf src-ip {
       type oc-inet:ip-address;
@@ -456,11 +517,33 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-mplsudp-state {
+  grouping aft-common-entry-nexthop-mpls-state {
     description
-      "MPLS in UDP encapsulation applied on a IPv4 or IPv6 next-hop.  This
-      encapsulation is assumed to be using RFC 7510 - Encapsulating MPLS
-      in UDP.";
+      "MPLS encapsulation of a packet.";
+
+    leaf traffic-class {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS traffic class (TC) bits, formerly known as the
+         EXP bits.";
+    }
+
+    leaf-list pushed-mpls-label-stack {
+      type oc-mplst:mpls-label-stack;
+      ordered-by user;
+      description
+        "The MPLS label stack imposed when forwarding packets to the
+         next-hop. See the description of the type
+         oc-mplst:mpls-label-stack for encoding rules.
+
+         Note: a swap operation is reflected by entries in the
+         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-udp-state {
+    description
+      "UDP encapsulation applied on top of a packet.";
 
     leaf src-ip {
       type oc-inet:ip-address;
@@ -495,7 +578,10 @@ submodule openconfig-aft-common {
       type oc-inet:port-number;
       description
         "Source UDP port number to use for the UDP header of the encapsulated
-         packet.";
+        packet. 
+        
+        When the payload packet is MPLS, then RFC 7510 - Encapsulating MPLS
+        in UDP should be followed.";
       reference
         "RFC 7510 - Encapsulating MPLS in UDP specifies that 6635 must be
         used for MPLS-in-UDP and 6636 must be used for MPLS-in-UDP with DTLS.
@@ -511,26 +597,6 @@ submodule openconfig-aft-common {
          not set, the TTL value of the inner packet is copied over as the
          outer packet's IP TTL value during encapsulation.";
     }
-
-    leaf traffic-class {
-      type oc-mplst:mpls-tc;
-      description
-        "The value of the MPLS traffic class (TC) bits, formerly known as the
-         EXP bits.";
-    }
-
-    leaf-list pushed-mpls-label-stack {
-      type oc-mplst:mpls-label-stack;
-      ordered-by user;
-      description
-        "The MPLS label stack imposed when forwarding packets to the
-         next-hop. See the description of the type
-         oc-mplst:mpls-label-stack for encoding rules.
-
-         Note: a swap operation is reflected by entries in the
-         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
-    }
-
   }
 
   grouping aft-common-install-protocol {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -458,7 +458,9 @@ submodule openconfig-aft-common {
 
   grouping aft-common-entry-nexthop-mplsudp-state {
     description
-      "MPLS in UDP encapsulation applied on a IPv4 or IPv6 next-hop.";
+      "MPLS in UDP encapsulation applied on a IPv4 or IPv6 next-hop.  This
+      encapsulation is assumed to be using RFC 7510 - Encapsulating MPLS
+      in UDP.";
 
     leaf src-ip {
       type oc-inet:ip-address;
@@ -492,9 +494,10 @@ submodule openconfig-aft-common {
         "Source UDP port number to use for the UDP header of the encapsulated
          packet.";
       reference
-        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6636 must be
-        used only if the traffic is MPLS-in-UDP with DTLS.  Because of this
-        condition, no default is defined in OpenConfig.";
+        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6635 must be
+        used for MPLS-in-UDP and 6636 must be used for MPLS-in-UDP with DTLS.
+        Because of this condition, no default is defined in OpenConfig.  The
+        system is expected to utilize the appropriate port.";
     }
 
     leaf ip-ttl {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -491,9 +491,7 @@ submodule openconfig-aft-common {
     }
 
     leaf flow-label {
-      type uint32 {
-        range 0..1048575;
-      }
+      type oc-inet:ipv6-flow-label;
       description
         "If IPv6 UDP encapsulation is used, this leaf represents a static
         assignment for an IPv6 flow label.  If unspecified, the system may

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -247,7 +247,7 @@ submodule openconfig-aft-common {
         container mpls-in-udp {
           description
             "Container for mpls-in-udp encapsulation state attributes. The
-            attributes are used when encapsulate-header is set to 
+            attributes are used when encapsulate-header is set to
             openconfig-aft-types:MPLS_IN_UDPV(4|6), causing a the device to
             add a MPLS in UDP header to a packet before forwarding to the
             specified next-hop.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.6.0";
+  oc-ext:openconfig-version "2.7.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.7.0";
+  }
 
   revision "2024-04-25" {
     description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -230,10 +230,12 @@ submodule openconfig-aft-common {
             encap-headers/encap-header tree.  A future release of OpenConfig
             will deprecate this node in favor of the
             encap-headers/encap-header subtree.";
+
           container state {
             config false;
             description
               "State parameters relating to IP-in-IP encapsulation.";
+
             uses aft-common-entry-nexthop-ip-state;
           }
         }
@@ -250,20 +252,22 @@ submodule openconfig-aft-common {
             encap-headers/encap-header tree.  A future release of OpenConfig
             will deprecate this node in favor of the
             encap-headers/encap-header subtree.";
+
           container state {
             config false;
             description
               "State parameters relating to GRE encapsulation.";
+
             uses aft-common-entry-nexthop-gre-state;
           }
         }
 
         container encap-headers {
           description
-            "Container for packet encapsulation headers.  When present, this
-            container indicates that encapsulation of the packet matching the
-            next-hop is performed using a stack of one or more packets defined
-            in the list encap-header.
+            "Container for packet encapsulation headers.  When leaves in this
+            container are populated, it indicates encapsulation of the packet
+            matching the next-hop is performed using a stack of one or more
+            headers defined in the list encap-header.
 
             Each entry in the list must indicate an encapsulation type and
             populate a container with the parameters for that encapsulation
@@ -271,13 +275,14 @@ submodule openconfig-aft-common {
 
           list encap-header {
             description
-              "A list of headers added on top of a packet.  The first entry
-              in the list is the inner-most packet at the bottom of the
-              stack.
+              "A list of headers added on top of a packet ordered by the
+              index value.  The inner-most header is the 0th value and is
+              adjacent to the original packet.  Additional headers may be
+              added in index order.
 
-              For example, in an encapsulation stack with MPLS in UDP, the
-              first index in the list is the MPLS packet and the second
-              index is UDP.";
+              For example, in an encapsulation stack for MPLS in UDPv4, the
+              first index in the list is the MPLS header and the second
+              index is a UDPv4 header.";
 
             key "index";
 
@@ -293,6 +298,7 @@ submodule openconfig-aft-common {
             container state {
               description
                 "State parameters relating to encapsulation headers.";
+
               uses aft-common-nexthop-encap-headers-state;
             }
 
@@ -300,9 +306,11 @@ submodule openconfig-aft-common {
               when "../state/type = 'oc-aftt:GRE'";
               description
                 "Container of nodes for GRE encapsulation.";
+
               container state {
                 description
                   "State parameters relating to GRE encapsulation headers.";
+
                 uses aft-common-entry-nexthop-gre-state;
               }
             }
@@ -313,9 +321,11 @@ submodule openconfig-aft-common {
                 "Container of nodes for UDP in IPv4 encapsulation.  When this
                 container is used, an IPv4 packet with no transport header
                 is added to the encapsulation list.";
+
               container state {
                 description
                   "State parameters relating to IP encapsulation headers.";
+
                 uses aft-common-entry-nexthop-ip-state;
               }
             }
@@ -326,9 +336,11 @@ submodule openconfig-aft-common {
                 "Container of nodes for UDP in IPv6 encapsulation.  When this
                 container is used, an IPv6 packet with no transport header
                 is added to the encapsulation list.";
+
               container state {
                 description
                   "State parameters relating to IP encapsulation headers.";
+
                 uses aft-common-entry-nexthop-ip-state;
               }
             }
@@ -337,9 +349,11 @@ submodule openconfig-aft-common {
               when "../state/type = 'oc-aftt:MPLS'";
               description
                 "Container of nodes for MPLS encapsulation.";
+
               container state {
                 description
                   "State parameters relating to MPLS encapsulation headers.";
+
                 uses aft-common-entry-nexthop-mpls-state;
               }
             }
@@ -348,12 +362,14 @@ submodule openconfig-aft-common {
               when "../state/type = 'oc-aftt:UDPV4'";
               description
                 "Container of nodes for UDP in IPv4 encapsulation.  When this
-                container is used, an IPv4 packet with a UDP header is added
+                container is used, an IPv4 header with a UDP header is added
                 to the encapsulation list.";
+
               container state {
                 description
                   "State parameters relating to UDP in IPv4 encapsulation
                   headers.";
+
                 uses aft-common-entry-nexthop-encap-udp-state;
               }
             }
@@ -362,12 +378,14 @@ submodule openconfig-aft-common {
               when "../state/type = 'oc-aftt:UDPV6'";
               description
                 "Container of nodes for UDP in IPv6 encapsulation.  When this
-                container is used, an IPv6 packet with a UDP header is added
+                container is used, an IPv6 header with a UDP header is added
                 to the encapsulation list.";
+
               container state {
                 description
                   "State parameters relating to UDP in IPv6 encapsulation
                   headers.";
+
                 uses aft-common-entry-nexthop-encap-udp-state;
               }
             }
@@ -376,9 +394,11 @@ submodule openconfig-aft-common {
               when "../state/type = 'oc-aftt:VXLAN'";
               description
                 "Container of nodes for VXLAN encapsulation.";
+
               container state {
                 description
                   "State parameters relating to VXLAN encapsulation headers.";
+
                 uses aft-common-entry-nexthop-vxlan-state;
               }
             }
@@ -394,6 +414,7 @@ submodule openconfig-aft-common {
   grouping aft-common-nexthop-encap-headers-state {
     description
       "Operational state parameters relating to encapsulation headers.";
+
     leaf index {
       type uint8;
       description
@@ -465,7 +486,7 @@ submodule openconfig-aft-common {
       type oc-inet:ip-address;
       description
         "Where applicable this represents the vxlan tunnel source ip address.
-        For VXLAN this represents the source VTEP ip address.
+        For VXLAN this represents the source VTEP IP address.
 
         This node must be supported in addition to the
         encap-headers/encap-header tree.  A future release of OpenConfig
@@ -520,25 +541,29 @@ submodule openconfig-aft-common {
         should be popped from the packet when switched by the system.
 
         The top-most MPLS label associated with pop action is equal to
-        the label key used in 'mpls' AFT 'label-entry' list.
-
-        This node must be supported in addition to the
-        encap-headers/encap-header tree.  A future release of OpenConfig
-        will deprecate this node in favor of the
-        encap-headers/encap-header subtree.";
+        the label key used in 'mpls' AFT 'label-entry' list.";
     }
 
     leaf-list pushed-mpls-label-stack {
-      type oc-mplst:mpls-label-stack;
+      type oc-mplst:mpls-label;
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
-        next-hop. See the description of the type
-        oc-mplst:mpls-label-stack for encoding rules.
+        next-hop
+        - the stack is encoded as a leaf list whereby the order of the
+          entries is such that the first entry in the list is the
+          label at the bottom of the stack to be pushed.
 
-        Note: a swap operation is reflected by entries in the
+        To this end, a packet which is to forwarded to a device using
+        a service label of 42, and a transport label of 8072 will be
+        represented with a label stack list of [42, 8072].
+
+        The MPLS label stack list is ordered by the user, such that no
+        system re-ordering of leaves is permitted by the system.
+
+        A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
-
+        
         This node must be supported in addition to the
         encap-headers/encap-header tree.  A future release of OpenConfig
         will deprecate this node in favor of the
@@ -628,30 +653,36 @@ submodule openconfig-aft-common {
         "The value of the MPLS traffic class (TC) bits, formerly known as the
          EXP bits.";
     }
+    uses aft-common-entry-mpls-stack;
 
-    leaf pop-top-label {
-      type boolean;
-      default false;
+  }
+
+  grouping aft-common-entry-mpls-stack {
       description
-        "Flag that controls pop action, i.e., the top-most MPLS label
-         should be popped from the packet when switched by the system.
+        "A definition for an MPLS label stack represented by a leaf-list.
 
-        The top-most MPLS label associated with pop action is equal to
-        the label key used in 'mpls' AFT 'label-entry' list.";
-    }
+        MPLS label stack imposed when forwarding packets to the
+        next-hop. See the description of the type
+        oc-mplst:mpls-label-stack for encoding rules.
 
-    leaf-list pushed-mpls-label-stack {
-      type oc-mplst:mpls-label-stack;
+        Note: a swap operation is reflected by entries in the
+        popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+
+    leaf-list mpls-label-stack {
+      type oc-mplst:mpls-label;
       ordered-by user;
       description
-        "The MPLS label stack imposed when forwarding packets to the
-         next-hop. See the description of the type
-         oc-mplst:mpls-label-stack for encoding rules.
+        "A stack of MPLS label values.  The first entry in the list is the
+        label at the bottom of the stack.  The bottom of the stack is adjacent
+        to the MPLS payload.
 
-         Note: a swap operation is reflected by entries in the
-         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+        For example, a packet with a label stack of two labels, the bottom
+        label being 42 and the top label being 8072 will be represented with
+        a leaf-list of [42, 8072].  The resulting packet, starting with the
+        beginning of the packet will be '[8072][42][Payload]'.";
     }
   }
+
 
   grouping aft-common-entry-nexthop-encap-udp-state {
     description
@@ -669,10 +700,10 @@ submodule openconfig-aft-common {
         "Destination IP address for IP/UDP encapsulation.";
     }
 
-    leaf ip-dscp {
+    leaf dscp {
       type oc-inet:dscp;
       description
-        "IP DSCP value to use for the UDP header of the encapsulated
+        "DSCP value to use for the UDP header of the encapsulated
          packet.";
     }
 
@@ -681,7 +712,7 @@ submodule openconfig-aft-common {
       description
         "Source UDP port number to use for the UDP header of the encapsulated
          packet.  The source UDP port should be derived from the payload
-         packet entropy.  The extact methodology is implementation dependent,
+         packet entropy.  The exact methodology is implementation dependent,
          but for example, the port could be derived from an entropy hash of
          the payload or the source port (if present) of the payload.";
     }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -287,12 +287,6 @@ submodule openconfig-aft-common {
                 of encapsulation headers.";
             }
 
-            leaf type {
-              type oc-aftt:encapsulation-header-type;
-              description
-                "Defines which type of packet header should be used.";
-            }
-
             container state {
               description
                 "State parameters relating to encapsulation headers.";
@@ -371,6 +365,13 @@ submodule openconfig-aft-common {
       description
         "A pointer to an entry in an ordered list of encapsulation headers.";
     }
+
+    leaf type {
+      type oc-aftt:encapsulation-header-type;
+      description
+        "Defines which type of packet header should be used.";
+    }
+
   }
 
   grouping aft-common-entry-state {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -263,8 +263,8 @@ submodule openconfig-aft-common {
             container indicates that encapsulation of the packet matching the
             next-hop is performed using a stack of one or more packets defined
             in the list encap-header.
-            
-            Each entry in the list must indicate an encapsulation type and 
+
+            Each entry in the list must indicate an encapsulation type and
             populate a container with the parameters for that encapsulation
             header.";
           list encap-header {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -485,7 +485,10 @@ submodule openconfig-aft-common {
       type oc-inet:port-number;
       description
         "Source UDP port number to use for the UDP header of the encapsulated
-         packet.";
+         packet.  The source UDP port should be derived from the payload
+         packet entropy.  The extact methodology is implementation dependent,
+         but for example, the port could be derived from an entropy hash of
+         the payload or the source port (if present) of the payload.";
     }
 
     leaf dst-udp-port {

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -22,9 +22,9 @@ submodule openconfig-aft-ipv4 {
 
   oc-ext:openconfig-version "2.7.0";
 
-  revision "2024-07-18" {
+  revision "2024-09-05" {
     description
-        "Add container for mpls-in-udp under next-hops aft entry state.";
+        "Add encapsulate-stack under aft next-hops.";
       reference "2.7.0";
   }
 

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,19 +20,18 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.6.0";
+  oc-ext:openconfig-version "2.7.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.7.0";
+  }
 
   revision "2024-04-25" {
     description
       "Add backup-active to AFT NHG state.";
     reference "2.6.0";
-  }
-  oc-ext:openconfig-version "2.6.0";
-
-  revision "2024-07-18" {
-    description
-        "Add container for mpls-in-udp under next-hops aft entry state.";
-      reference "2.6.0";
   }
 
   revision "2024-01-26" {

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,13 +21,12 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.6.0";
-  oc-ext:openconfig-version "2.6.0";
+  oc-ext:openconfig-version "2.7.0";
 
   revision "2024-07-18" {
     description
         "Add container for mpls-in-udp under next-hops aft entry state.";
-      reference "2.6.0";
+      reference "2.7.0";
   }
 
   revision "2024-04-25" {

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -23,9 +23,9 @@ submodule openconfig-aft-mpls {
 
   oc-ext:openconfig-version "2.7.0";
 
-  revision "2024-07-18" {
+  revision "2024-09-05" {
     description
-        "Add container for mpls-in-udp under next-hops aft entry state.";
+        "Add encapsulate-stack under aft next-hops.";
       reference "2.7.0";
   }
 

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2024-07-18" {
+    description
+        "Add MPLS in UDP enums for encapsulate-header.";
+      reference "1.2.0";
+  }
 
   revision "2022-05-05" {
     description
@@ -88,6 +94,16 @@ module openconfig-aft-types {
       enum VXLAN {
         description
           "The encapsulation header is a VXLAN packet header";
+      }
+      enum MPLS-IN-UDPv4 {
+        description
+          "The encapsulation header is an MPLS packet inside an IPv4 UDP
+          packet header";
+      }
+      enum MPLS-IN-UDPv6 {
+        description
+          "The encapsulation header is an MPLS packet inside an IPv6 UDP
+          packet header";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -99,11 +99,15 @@ module openconfig-aft-types {
         description
           "The encapsulation header is an MPLS packet inside an IPv4 UDP
           packet header";
+        reference 
+          "RFC 7510 - Encapsulating MPLS in UDP.";
       }
       enum MPLS_IN_UDPV6 {
         description
           "The encapsulation header is an MPLS packet inside an IPv6 UDP
           packet header";
+        reference 
+          "RFC 7510 - Encapsulating MPLS in UDP.";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -95,12 +95,12 @@ module openconfig-aft-types {
         description
           "The encapsulation header is a VXLAN packet header";
       }
-      enum MPLS-IN-UDPV4 {
+      enum MPLS_IN_UDPV4 {
         description
           "The encapsulation header is an MPLS packet inside an IPv4 UDP
           packet header";
       }
-      enum MPLS-IN-UDPV6 {
+      enum MPLS_IN_UDPV6 {
         description
           "The encapsulation header is an MPLS packet inside an IPv6 UDP
           packet header";

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -99,14 +99,14 @@ module openconfig-aft-types {
         description
           "The encapsulation header is an MPLS packet inside an IPv4 UDP
           packet header";
-        reference 
+        reference
           "RFC 7510 - Encapsulating MPLS in UDP.";
       }
       enum MPLS_IN_UDPV6 {
         description
           "The encapsulation header is an MPLS packet inside an IPv6 UDP
           packet header";
-        reference 
+        reference
           "RFC 7510 - Encapsulating MPLS in UDP.";
       }
     }

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -95,19 +95,9 @@ module openconfig-aft-types {
         description
           "The encapsulation header is a VXLAN packet header";
       }
-      enum MPLS_IN_UDPV4 {
+      enum UDP {
         description
-          "The encapsulation header is an MPLS packet inside an IPv4 UDP
-          packet header";
-        reference
-          "RFC 7510 - Encapsulating MPLS in UDP.";
-      }
-      enum MPLS_IN_UDPV6 {
-        description
-          "The encapsulation header is an MPLS packet inside an IPv6 UDP
-          packet header";
-        reference
-          "RFC 7510 - Encapsulating MPLS in UDP.";
+          "The encapsulation header is UDP packet header.";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -95,12 +95,12 @@ module openconfig-aft-types {
         description
           "The encapsulation header is a VXLAN packet header";
       }
-      enum MPLS-IN-UDPv4 {
+      enum MPLS-IN-UDPV4 {
         description
           "The encapsulation header is an MPLS packet inside an IPv4 UDP
           packet header";
       }
-      enum MPLS-IN-UDPv6 {
+      enum MPLS-IN-UDPV6 {
         description
           "The encapsulation header is an MPLS packet inside an IPv6 UDP
           packet header";

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -44,9 +44,9 @@ module openconfig-aft {
 
   oc-ext:openconfig-version "2.7.0";
 
-  revision "2024-07-18" {
+  revision "2024-09-05" {
     description
-        "Add container for mpls-in-udp under next-hops aft entry state.";
+        "Add encapsulate-stack under aft next-hops.";
       reference "2.7.0";
   }
 

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.5.0";
+  oc-ext:openconfig-version "2.6.0";
+
+  revision "2024-07-18" {
+    description
+        "Add container for mpls-in-udp under next-hops aft entry state.";
+      reference "2.6.0";
+  }
 
   revision "2024-01-26" {
     description

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -23,7 +23,7 @@ module openconfig-mpls-types {
 
   revision "2024-07-24" {
     description
-      "Add pushed-mpls-label-stack typdef";
+      "Add mpls-label-stack typdef";
     reference "3.6.0";
   }
 
@@ -485,13 +485,13 @@ module openconfig-mpls-types {
     reference "RFC 3032 - MPLS Label Stack Encoding";
   }
 
-  typedef pushed-mpls-label-stack {
+  typedef mpls-label-stack {
     type mpls-label;
   description
-    "Type used to specify a stack of MPLS label values to be added to a
-     packet.  This type must be used in a leaf-list which is ordered by user.
-     The the stack of labels is encoded where the first entry in the list is
-     the label at the bottom of the stack.
+    "Type used to specify a stack of MPLS label values.  This type must be
+     used in a leaf-list which is ordered by user. The the stack of labels
+     is encoded where the first entry in the list is the label at the bottom
+     of the stack.
 
      For example, a packet with a label stack of two labels, the bottom
      label being 42 and the top label being 8072 will be represented with

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -479,6 +479,19 @@ module openconfig-mpls-types {
     reference "RFC 3032 - MPLS Label Stack Encoding";
   }
 
+  typedef pushed-mpls-label-stack {
+    type mpls-label;
+  description
+    "Type used to specify a stack of MPLS label values to be added to a
+     packet.  This type must be used in a leaf-list which is ordered by user.
+     The the stack of labels is encoded where the first entry in the list is
+     the label at the bottom of the stack.
+     
+     For example, a packet with a label stack of two labels, the bottom
+     label being 42 and the top label being 8072 will be represented with
+     a leaf-list of [42, 8072].";
+  }
+
   typedef tunnel-type {
     type enumeration {
       enum P2P {

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -19,13 +19,7 @@ module openconfig-mpls-types {
   description
     "General types for MPLS / TE data model";
 
-  oc-ext:openconfig-version "3.6.0";
-
-  revision "2024-07-24" {
-    description
-      "Add mpls-label-stack typdef";
-    reference "3.6.0";
-  }
+  oc-ext:openconfig-version "3.5.0";
 
   revision "2023-12-14" {
     description
@@ -483,19 +477,6 @@ module openconfig-mpls-types {
     description
       "type for MPLS label value encoding";
     reference "RFC 3032 - MPLS Label Stack Encoding";
-  }
-
-  typedef mpls-label-stack {
-    type mpls-label;
-    description
-      "Type used to specify a stack of MPLS label values.  This type must be
-      used in a leaf-list which is ordered by user. The the stack of labels
-      is encoded where the first entry in the list is the label at the bottom
-      of the stack.
-
-      For example, a packet with a label stack of two labels, the bottom
-      label being 42 and the top label being 8072 will be represented with
-      a leaf-list of [42, 8072].";
   }
 
   typedef tunnel-type {

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -487,15 +487,15 @@ module openconfig-mpls-types {
 
   typedef mpls-label-stack {
     type mpls-label;
-  description
-    "Type used to specify a stack of MPLS label values.  This type must be
-     used in a leaf-list which is ordered by user. The the stack of labels
-     is encoded where the first entry in the list is the label at the bottom
-     of the stack.
+    description
+      "Type used to specify a stack of MPLS label values.  This type must be
+      used in a leaf-list which is ordered by user. The the stack of labels
+      is encoded where the first entry in the list is the label at the bottom
+      of the stack.
 
-     For example, a packet with a label stack of two labels, the bottom
-     label being 42 and the top label being 8072 will be represented with
-     a leaf-list of [42, 8072].";
+      For example, a packet with a label stack of two labels, the bottom
+      label being 42 and the top label being 8072 will be represented with
+      a leaf-list of [42, 8072].";
   }
 
   typedef tunnel-type {

--- a/release/models/mpls/openconfig-mpls-types.yang
+++ b/release/models/mpls/openconfig-mpls-types.yang
@@ -19,7 +19,13 @@ module openconfig-mpls-types {
   description
     "General types for MPLS / TE data model";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2024-07-24" {
+    description
+      "Add pushed-mpls-label-stack typdef";
+    reference "3.6.0";
+  }
 
   revision "2023-12-14" {
     description
@@ -486,7 +492,7 @@ module openconfig-mpls-types {
      packet.  This type must be used in a leaf-list which is ordered by user.
      The the stack of labels is encoded where the first entry in the list is
      the label at the bottom of the stack.
-     
+
      For example, a packet with a label stack of two labels, the bottom
      label being 42 and the top label being 8072 will be represented with
      a leaf-list of [42, 8072].";


### PR DESCRIPTION
### Change Scope

* Add AFT container representing next-hop encapsulation headers.   A list of encap-headers is defined which is used to represent a stack of one or more packets added to any packet matching a next-hop.
* Add containers for GRE, IP, UDP and MPLS encapsulation

* Later we will deprecate the existing AFT encapsulation containers for [ip-in-ip](https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-network-instance.html#network-instances-network-instance-afts-next-hops-next-hop-ip-in-ip) and [gre](https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-network-instance.html#network-instances-network-instance-afts-next-hops-next-hop-gre) and MPLS.

* Changes to decapsulation are not in scope of this PR as the operational use cases inspiring this PR are met with with existing decapsulation leaves.  
 
### Use cases
* One operational use case for these nexthops is for an SDN controller to use gRIBI to program match and action rules that cause packets to be encapsulated in MPLS in UDP packets.  The SDN controller chooses the encapsulation stack. 
* In another, future operational use case, policy-forwarding might be used to define encapsulations which are representing in the afts model upon instantiation into the forwarding tables of the system.  (Note, at this moment,  changes to the policy-forwarding model to support multiple, arbitrary encapsulations is not in scope for this PR.)

### Platform Implementations

Regarding MPLS in UDP encapsulation (which is the operational use case inspiring this change) is defined by RFC and supported by the following implementations.

* [RFC 7510](https://datatracker.ietf.org/doc/html/rfc7510) defines the MPLS in UDP feature specification.
* [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k-r7-6/mpls/configuration/guide/b-mpls-cg-asr9000-76x/implementing-mpls-ldp.html) supports MPLS in UDP.
* [JunOS](https://www.juniper.net/documentation/us/en/software/junos/mpls/topics/topic-map/nexthop-based-dynamic-tunnels.html) nexthop-based-dynamic-tunnels supports MPLS in UDP.

### Tree view

we are at: /network-instances/network-instance/afts/

```diff
diff -U 10 ~/master-tree.txt ~/aft-encap-tree.txt
[... snip ...]
         |  |     +--ro ip-in-ip
         |  |     |  +--ro state
         |  |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     +--ro gre
         |  |     |  +--ro state
         |  |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro ttl?      uint8
+        |  |     +--ro encap-headers
+        |  |     |  +--ro encap-header* [index]
+        |  |     |     +--ro index     -> ../state/index
+        |  |     |     +--ro state
+        |  |     |     |  +--ro index?   uint8
+        |  |     |     |  +--ro type?    oc-aftt:encapsulation-header-type
+        |  |     |     +--ro gre
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro ttl?      uint8
+        |  |     |     +--ro ipv4
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     +--ro ipv6
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     +--ro mpls
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro traffic-class?      oc-mplst:mpls-tc
+        |  |     |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
+        |  |     |     +--ro udp-v4
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro dscp?           oc-inet:dscp
+        |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro ip-ttl?         uint8
+        |  |     |     +--ro udp-v6
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro dscp?           oc-inet:dscp
+        |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro ip-ttl?         uint8
+        |  |     |     +--ro vxlan
+        |  |     |        +--ro state
+        |  |     |           +--ro vni-label?               oc-evpn-types:evi-id
+        |  |     |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
         |  |     +--ro interface-ref
         |  |        +--ro state
         |  |           +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../
```
