### PR TITLE
Correction to loopback-mode-type FACILITY and TERMINAL #1135

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,14 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "0.25.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2024-07-24" {
+    description
+      "Corrected description for FACILITY and TERMINAL loopback-mode-type
+       enums.";
+    refrence "1.0.0";
+  }
 
   revision "2024-06-28" {
     description
@@ -222,17 +229,17 @@ module openconfig-transport-types {
       }
       enum FACILITY {
         description
-          "A port internal loopback at ASIC level. The loopback directs
-          traffic normally transmitted on the port back to the device as
-          if received on the same port from an external source. Note this
-          mode is used when internal loopback does NOT specify MAC or PHY.";
-      }
-      enum TERMINAL {
-        description
           "A port external loopback at ASIC level. The loopback which
           directs traffic received from an external source on the port
           back out the transmit side of the same port. Note this mode is
           used when external loopback does NOT specify MAC or PHY";
+      }
+      enum TERMINAL {
+        description
+          "A port internal loopback at ASIC level. The loopback directs
+          traffic normally transmitted on the port back to the device as
+          if received on the same port from an external source. Note this
+          mode is used when internal loopback does NOT specify MAC or PHY.";
       }
       enum ASIC_PHY_LOCAL {
         description

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -28,7 +28,7 @@ module openconfig-transport-types {
     description
       "Corrected description for FACILITY and TERMINAL loopback-mode-type
        enums.";
-    refrence "1.0.0";
+    reference "1.0.0";
   }
 
   revision "2024-06-28" {


### PR DESCRIPTION
### Change Scope

* `release/models/optical-transport/openconfig-transport-types.yang` corrected description for FACILITY and TERMINAL
* NOT backwards compatible

### Platform Implementations

 * Cisco already implemented the corrected definition on both packet and optical devices: https://github.com/openconfig/public/issues/1135#issuecomment-2229397632
 * To my best knowledge, Arista, Juniper and Nokia packet devices implement the incorrect OC definition.
 * According to @ejbrever, Cisco, Ciena, Nokia, Infinera optical devices implement the correct definition.