### PR TITLE
Add preserve-next-hop for ebgp-multihop container

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,12 +24,18 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,12 +21,18 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,19 +24,25 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
     description
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
-          reference "9.7.0";
+    reference "9.7.0";
   }
 
   revision "2023-11-02" {
@@ -432,6 +438,16 @@ submodule openconfig-bgp-common {
         "Time-to-live value to use when packets are sent to the
         referenced group or neighbors and ebgp-multihop is enabled";
     }
+
+    leaf preserve-next-hop {
+     type boolean;
+     default "false";
+     description
+      "Override the default eBGP behavior of rewriting the next-hop, and
+      instead keep the next-hop learned from a neighbor.  This leaf can
+      only be configured if multihop enabled is true.";
+    }
+
   }
 
   grouping bgp-common-neighbor-group-route-reflector-config {

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,12 +27,18 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,19 +30,25 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
     description
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
-          reference "9.7.0";
+    reference "9.7.0";
   }
 
   revision "2023-11-02" {

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,12 +25,18 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,19 +68,25 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-08-02" {
+    description
+      "Add preserve-next-hop to ebgp-multihop container.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
       "Clarification to last-prefix-limit-exceeded in description";
-          reference "9.7.1";
+    reference "9.7.1";
   }
 
   revision "2023-12-28" {
     description
       "Add support for controling use of link-bandwidth extended
       community for BGP multipath.";
-          reference "9.7.0";
+    reference "9.7.0";
   }
 
   revision "2023-11-02" {


### PR DESCRIPTION
### Change Scope
By default BGP changes the next hop of a BGP route to itself when advertising to neighbors.  `ebgp-nexthop/config/preserve-next-hop` is added to disable this behavior.    

This feature is commonly used in combination with BGP based VPN's (RFC4364).  

The full paths added are:

```
/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/ebgp-multihop/config/preserve-next-hop
/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/ebgp-multihop/state/preserve-next-hop

/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/ebgp-multihop/config/preserve-next-hop
/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/ebgp-multihop/state/preserve-next-hop
```

This change is backwards compatible.

### Platform Implementations

 * [Cisco IOS XR](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k-r7-6/routing/configuration/guide/b-routing-cg-asr9000-76x/implementing-bgp.html)
 * [JunOS no-nexthop-change](https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/topic-map/multihop-sessions.html)
