### PR TITLE
#1159 wifi mac transition modes

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -253,11 +253,26 @@ module openconfig-wifi-mac {
           description
             "Open authentication with Opportunistic Wireless Encryption.";
         }
+        enum ENHANCED_OPEN_TRANSITION {
+          description
+            "Open authentication with Opportunistic Wireless Encryption and
+             support for transition mode.";
+        }
         enum WPA3_SAE {
           description
             "WPA3-SAE using Simultaneous Authentication of Equals (SAE).";
         }
+        enum WPA3_2_SAE_TRANSITION {
+          description
+            "WPA3-SAE using Simultaneous Authentication of Equals (SAE) and
+             WPA2-PSK AKMs.";
+        }
         enum WPA3_ENTERPRISE {
+          description
+            "WPA3-Enterprise with 802.1X SHA-256 authentication key
+             management.";
+        }
+        enum WPA3_2_ENTERPRISE_TRANSITION {
           description
             "WPA3-Enterprise with 802.1X SHA-256 authentication key
              management.";
@@ -284,7 +299,8 @@ module openconfig-wifi-mac {
     }
 
     leaf wpa3-psk {
-      when "../opmode = 'WPA3_SAE'";
+      when "../opmode = 'WPA3_SAE' or
+      ../opemode = 'WPA3_2_SAE_TRANSITION";
       type string {
         length "8..63";
       }
@@ -296,8 +312,10 @@ module openconfig-wifi-mac {
       when "../opmode = 'WPA2_ENTERPRISE' or
       ../opmode = 'WPA2_PERSONAL' or
       ../opmode = 'WPA3_ENTERPRISE' or
+      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION
       ../opmode = 'WPA3_ENTERPRISE_192_BIT' or
-      ../opmode = 'WPA3_SAE'";
+      ../opmode = 'WPA3_SAE' or
+      ../opmode = 'WPA3_2_SAE_TRANSITION'";
       type string;
         description
           "Specifies the RADIUS server-group to be used,
@@ -367,9 +385,14 @@ module openconfig-wifi-mac {
     }
 
     leaf mfp {
-      when "../opmode = 'WPA3_ENTERPRISE' or ../opmode =
-      'WPA3_ENTERPRISE_192_BIT' or ../opmode =
-      'WPA3_SAE' or ../opmode = 'ENHANCED_OPEN'";
+      when "../opmode = 'WPA3_ENTERPRISE' or
+      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION
+      ../opmode = 'WPA3_ENTERPRISE_192_BIT' or 
+      ../opmode = 'WPA3_SAE' or
+      ../opmode = 'WPA3_2_SAE_TRANSITION
+      ../opmode = 'ENHANCED_OPEN'
+      ../opmode = 'ENHANCED_OPEN_TRANSITION
+      ";
       type boolean;
       mandatory true;
       description

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -393,7 +393,7 @@ module openconfig-wifi-mac {
     leaf mfp {
       when "../opmode = 'WPA3_ENTERPRISE' or
       ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION
-      ../opmode = 'WPA3_ENTERPRISE_192_BIT' or 
+      ../opmode = 'WPA3_ENTERPRISE_192_BIT' or
       ../opmode = 'WPA3_SAE' or
       ../opmode = 'WPA3_2_SAE_TRANSITION
       ../opmode = 'ENHANCED_OPEN'

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.3.1";
+  oc-ext:openconfig-version "1.3.2";
+
+  revision "2024-08-07" {
+    description
+      "Add transition modes ENHANCED_OPEN_TRANSITION, WPA3_2_SAE_TRANSITION and
+      WPA3_2_ENTERPRISE_TRANSITION";
+  }
 
   revision "2023-05-26" {
     description


### PR DESCRIPTION
### Change Scope

* Adding transition modes to wifi opmode enums for configuration/state.
* This change is backwards compatible.
### Platform Implementations

 * Implementation A: https://www.arubanetworks.com/techdocs/ArubaOS_85_Web_Help/Content/arubaos-solutions/802-1x/enha-open-secu.htm
 * Implementation B: https://www.cisco.com/c/en/us/td/docs/wireless/controller/9800/technical-reference/wpa3-dg.html

Vendors like like Arista/Aruba are implementing TM inconsistently with respect to openconfig, some implement TM on WPA3/OWE and others do not.  This enables behavior to be specified explicitly.  