### PR TITLE
Refactor non-compliant/overlapping YANG definition for BGP MED

### DIFF
--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -30,10 +30,10 @@ module openconfig-bgp-policy {
 
   oc-ext:openconfig-version "8.0.0";
 
-  revision "2024-08-15" {
+  revision "2024-08-23" {
     description
-      "Separate the ability to set the BGP MED into a distinct value
-      with optional action.";
+      "Separate the ability to set the BGP MED along with an appropriate
+      action.";
     reference "8.0.0";
   }
 
@@ -228,14 +228,17 @@ module openconfig-bgp-policy {
     description
       "Type definition for specifying how the BGP MED can be set in BGP
       policy actions.  The MED can be specified as a direct integer
-      value or setting it to the IGP cost.  When set to the integer
-      value without a MED 'action', the value will be explicitly set.
-      If a MED 'action' is defined, the previous value will be modified
-      according to the action (e.g. ADD or SUBTRACT).";
+      value or setting it to the IGP cost.  To be used in conjunction
+      with `bgp-set-med-action` in order to specify the appropriate
+      action to take on this value.";
   }
 
   typedef bgp-set-med-action {
     type enumeration {
+      enum SET {
+        description
+          "Action to set the MED to a specific value.";
+      }
       enum ADD {
         description
           "Action to increment the previous MED value.";
@@ -246,8 +249,8 @@ module openconfig-bgp-policy {
       }
     }
     description
-      "If specified, this action will alter a previous MED value by the
-      value defined by the bgp-set-med-type.";
+      "Specifies which action to take on the value specified by the
+      bgp-set-med-type.";
   }
 
   // grouping statements
@@ -1366,17 +1369,24 @@ module openconfig-bgp-policy {
 
     leaf set-med {
       type bgp-set-med-type;
+      must "../set-med-action" {
+        error-message
+          "set-med cannot be specified without a valid set-med-action";
+      }
       description
-        "Set the MED metric attribute in the route update.  Can be used
-        in conjunction with 'set-med-action' in order to alter a
-        previous value by the value specified here.";
+        "Set the MED metric attribute in the route update.  When set, a
+        valid `set-med-action` must be specified.";
     }
 
     leaf set-med-action {
       type bgp-set-med-action;
+      must "../set-med" {
+        error-message
+          "set-med-action cannot be specified without a set-med value";
+      }
       description
-        "Optionally used in conjunction with 'set-med' to alter a
-        previous value.";
+        "When set-med is specified, this leaf is mandatory to set the
+        appropriate action on the MED metric value.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -32,7 +32,8 @@ module openconfig-bgp-policy {
 
   revision "2024-08-15" {
     description
-      "";
+      "Separate the ability to set the BGP MED into a distinct value
+      with optional action.";
     reference "8.0.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -28,7 +28,13 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "7.1.0";
+  oc-ext:openconfig-version "8.0.0";
+
+  revision "2024-08-15" {
+    description
+      "";
+    reference "8.0.0";
+  }
 
   revision "2024-07-02" {
     description
@@ -210,23 +216,37 @@ module openconfig-bgp-policy {
   typedef bgp-set-med-type {
     type union {
       type uint32;
-      type string {
-        pattern '[+-][0-9]+';
-        oc-ext:posix-pattern '^[+-][0-9]+$';
-      }
       type enumeration {
         enum IGP {
-          description "set the MED value to the IGP cost toward the
-          next hop for the route";
+          description
+            "Set the MED value to the IGP cost toward the next hop for
+            the route";
         }
       }
     }
     description
-      "Type definition for specifying how the BGP MED can
-      be set in BGP policy actions. The three choices are to set
-      the MED directly using the uint32 type or increment/decrement
-      using +/- notation in the string type or setting it to
-      the IGP cost using the enum (predefined value).";
+      "Type definition for specifying how the BGP MED can be set in BGP
+      policy actions.  The MED can be specified as a direct integer
+      value or setting it to the IGP cost.  When set to the integer
+      value without a MED 'action', the value will be explicitly set.
+      If a MED 'action' is defined, the previous value will be modified
+      according to the action (e.g. ADD or SUBTRACT).";
+  }
+
+  typedef bgp-set-med-action {
+    type enumeration {
+      enum ADD {
+        description
+          "Action to increment the previous MED value.";
+      }
+      enum SUBTRACT {
+        description
+          "Action to decrement the previous MED value.";
+      }
+    }
+    description
+      "If specified, this action will alter a previous MED value by the
+      value defined by the bgp-set-med-type.";
   }
 
   // grouping statements
@@ -1345,8 +1365,17 @@ module openconfig-bgp-policy {
 
     leaf set-med {
       type bgp-set-med-type;
-      description "set the med metric attribute in the route
-      update";
+      description
+        "Set the MED metric attribute in the route update.  Can be used
+        in conjunction with 'set-med-action' in order to alter a
+        previous value by the value specified here.";
+    }
+
+    leaf set-med-action {
+      type bgp-set-med-action;
+      description
+        "Optionally used in conjunction with 'set-med' to alter a
+        previous value.";
     }
   }
 


### PR DESCRIPTION
  * (M) release/models/bgp/openconfig-bgp-policy.yang
    - Remove string type from bgp-set-med-type union
    - Add new bgp-set-med-action typedef to separate out action on MED
      values
    - Add new set-med-action leaf to be optionally utilized with set-med

### Change Scope

YANG 1.0 (RFC 6020) as well as YANG 1.1 (RFC 7950) specify that the legal
lexical representation for built-in integer types can be represented with an
optional sign.

https://www.rfc-editor.org/rfc/rfc6020.html#section-9.2.1

```
   An integer value is lexically represented as an optional sign ("+" or
   "-"), followed by a sequence of decimal digits.  If no sign is
   specified, "+" is assumed.
```

Example:

```
$ cat main.yang
module main {
  yang-version "1";
  namespace urn:m;
  prefix m;

  leaf value {
    type uint64;
  }
}

$ cat main.xml
<value xmlns="urn:m">+100</value>

$ yanglint -f xml main.xml main.yang
<value xmlns="urn:m">100</value>
```

The current union as specified interleaves a built-in integer type with a
string pattern regex that just so happens to overlap with allowable characters
for the uint32 type.

```
  type union {
    type uint32;
    type string {
      pattern '[+-][0-9]+';
      oc-ext:posix-pattern '^[+-][0-9]+$';
    }
    type enumeration {
      enum IGP {
        description "set the MED value to the IGP cost toward the
        next hop for the route";
      }
    }
  }
```

Therefore a "+100" would be matched by the `uint32` and the "+" character
dropped.  Since the integer is unsigned in this case, a "-100" would
fallthrough to the 2nd match.

Rather than encode the "action" and value into a string, this proposal suggests
separating out the action to a distinct optional node.  It appears that this is
the only such usage where there is a string with a pattern statement that
overlaps that of another permissible type encoding when also used in a union
with that type.

### Platform Implementations

This is a NBC however necessary to fix to remove ambiguity and improper handling
