### PR TITLE
Add syslog TLS

### DIFF
--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -23,7 +23,13 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+revision "2024-08-20" {
+    description
+      "Adding tls support for syslog.";
+    reference "0.7.0";
+  }
 
 revision "2023-07-20" {
     description
@@ -428,6 +434,22 @@ revision "2023-07-20" {
       description
         "Sets the destination port number for syslog UDP messages to
         the server.  The default for syslog is 514.";
+    }
+
+    leaf transport-security {
+      type boolean;
+      description
+      "Indicates if syslog transport layer security (TLS) is enabled.";
+    }
+
+    leaf tls-profile-id {
+      type string;
+      description
+        "The ID of this syslog server's TLS profile.  TLS profiles are managed
+        using the gNSI Certz service or other certificate management service
+        provided by the system.";
+      reference
+        "https://github.com/openconfig/gnsi/tree/main/certz";
     }
   }
 

--- a/release/models/system/openconfig-system-logging.yang
+++ b/release/models/system/openconfig-system-logging.yang
@@ -445,7 +445,7 @@ revision "2023-07-20" {
     leaf tls-profile-id {
       type string;
       description
-        "The ID of this syslog server's TLS profile.  TLS profiles are managed
+        "The ID of this syslog client's TLS profile.  TLS profiles are managed
         using the gNSI Certz service or other certificate management service
         provided by the system.";
       reference


### PR DESCRIPTION
### Change Scope

* Add support for syslog over TLS
* This change is backwards compatible

### Tree view
We are at   /system/logging

```diff
module: openconfig-system
[... snip ...]
         |  |  +--rw remote-servers
         |  |  |  +--rw remote-server* [host]
         |  |  |     +--rw host         -> ../config/host
         |  |  |     +--rw config
         |  |  |     |  +--rw host?               oc-inet:host
         |  |  |     |  +--rw source-address?     oc-inet:ip-address
         |  |  |     |  +--rw network-instance?   oc-ni:network-instance-ref
         |  |  |     |  +--rw remote-port?        oc-inet:port-number
         |  |  |     |  +--rw host?                 oc-inet:host
         |  |  |     |  +--rw source-address?       oc-inet:ip-address
         |  |  |     |  +--rw network-instance?     oc-ni:network-instance-ref
         |  |  |     |  +--rw remote-port?          oc-inet:port-number
+        |  |  |     |  +--rw transport-security?   boolean
+        |  |  |     |  +--rw tls-profile-id?       string
         |  |  |     +--ro state
         |  |  |     |  +--ro host?               oc-inet:host
         |  |  |     |  +--ro source-address?     oc-inet:ip-address
         |  |  |     |  +--ro network-instance?   oc-ni:network-instance-ref
         |  |  |     |  +--ro remote-port?        oc-inet:port-number
         |  |  |     |  +--ro host?                 oc-inet:host
         |  |  |     |  +--ro source-address?       oc-inet:ip-address
         |  |  |     |  +--ro network-instance?     oc-ni:network-instance-ref
         |  |  |     |  +--ro remote-port?          oc-inet:port-number
+        |  |  |     |  +--ro transport-security?   boolean
+        |  |  |     |  +--ro tls-profile-id?       string
```

### Platform Implementations

 * Arista EOS support [syslog over TLS](https://www.arista.com/en/um-eos/eos-control-plane-security#xx1117976)
```
configure
	management security
		ssl profile MYPROFILE
			trust certificate MYPROFILE-ca.crt
     logging host 10.1.1.1 6514 protocol tls ssl-profile MYPROFILE
```

 * Juniper JunOS supports [syslog over TLS ](https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-over-tls.html)
```
 set security pki ca-profile myprofile ca-identity test
 set security pki ca-profile myprofile revocation-check disable
 
 set system syslog host 10.1.1.1 port 6514
 set system syslog host 10.1.1.1 transport tls
 set system syslog host 10.1.1.1 any any
 set system syslog host 10.1.1.1 tlsdetails trusted-ca-group abc ca-profiles myprofile
 set system syslog host 10.1.1.1 source-address 192.168.10.10
```

* Cisco supports [syslog over TLS](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/75x/b-system-security-cg-cisco8000-75x/implementing-secure-logging.html#Cisco_Concept.dita_91d00c20-8a06-4071-a97c-f76d4d3f27f7)
```
Router(config)#logging tls-server TEST
Router(config-logging-tls-peer)#severity debugging
Router(config-logging-tls-peer)#trustpoint mytlsprofile
Router(config-logging-tls-peer)#address ipv4 10.1.1.1
Router(config-logging-tls-peer)#commit
```
