### PR TITLE
Add mount-point type

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,7 +47,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.1.0";
+  oc-ext:openconfig-version "2.2.0";
+
+  revision "2024-08-21" {
+    description
+      "Added mount-point type leaf to describe the type of file system.";
+    reference "2.2.0";
+  }
 
   revision "2024-07-15" {
     description
@@ -377,6 +383,26 @@ module openconfig-system {
       units megabytes;
       description
         "The amount of space currently in use on the filesystem.";
+    }
+
+    leaf type {
+      type enumeration {
+        enum FLASH {
+          description
+            "The storage type for the mount point is flash memory
+            based.";
+        }
+        enum HDD {
+          description
+            "The storage type for the mount point is hard disk
+            based.";
+        }
+        enum NETWORK {
+          description
+            "The storage type for the mount point is a remotely
+            connected network storage.";
+        }
+      }
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -386,23 +386,11 @@ module openconfig-system {
     }
 
     leaf type {
-      type enumeration {
-        enum FLASH {
-          description
-            "The storage type for the mount point is flash memory
-            based.";
-        }
-        enum HDD {
-          description
-            "The storage type for the mount point is hard disk
-            based.";
-        }
-        enum NETWORK {
-          description
-            "The storage type for the mount point is a remotely
-            connected network storage.";
-        }
-      }
+      type string;
+      description
+        "A human readable string indicating the filesystem type used
+        for storage.  Examples might include flash, hard disk, tmpfs/ramdisk
+        or remote/network based storage.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* Add filesystem type as /system/mount-points/mount-point/type
* This change is backwards compatible
* The operational use case is to give a human a hint as to the type of storage device in use for troubleshooting and diagnostics purposes.  Example storage types might include flash, HDD, temporary/ramdisk or network based.

### Platform Implementations

 * Cisco [show filesystem](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-management/b-system-management/m-file-system-commands.html#wp4346186860) contains a type field
 * [JunOS show-system-storage](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/command/show-system-storage.html) has a filesystem field that is suitable for communicating type.

