### PR TITLE
Fix XPath syntax error caught by pyang in openconfig-wifi-mac.yang

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,11 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.3.2";
+  oc-ext:openconfig-version "1.3.3";
+
+  revision "2024-08-22" {
+    description "Fix XPath expression to avoid pyang error";
+  }
 
   revision "2024-08-07" {
     description
@@ -306,7 +310,7 @@ module openconfig-wifi-mac {
 
     leaf wpa3-psk {
       when "../opmode = 'WPA3_SAE' or
-      ../opemode = 'WPA3_2_SAE_TRANSITION";
+      ../opmode = 'WPA3_2_SAE_TRANSITION'";
       type string {
         length "8..63";
       }
@@ -318,7 +322,7 @@ module openconfig-wifi-mac {
       when "../opmode = 'WPA2_ENTERPRISE' or
       ../opmode = 'WPA2_PERSONAL' or
       ../opmode = 'WPA3_ENTERPRISE' or
-      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION
+      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION' or
       ../opmode = 'WPA3_ENTERPRISE_192_BIT' or
       ../opmode = 'WPA3_SAE' or
       ../opmode = 'WPA3_2_SAE_TRANSITION'";
@@ -392,12 +396,12 @@ module openconfig-wifi-mac {
 
     leaf mfp {
       when "../opmode = 'WPA3_ENTERPRISE' or
-      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION
+      ../opmode = 'WPA3_2_ENTERPRISE_TRANSITION' or
       ../opmode = 'WPA3_ENTERPRISE_192_BIT' or
       ../opmode = 'WPA3_SAE' or
-      ../opmode = 'WPA3_2_SAE_TRANSITION
-      ../opmode = 'ENHANCED_OPEN'
-      ../opmode = 'ENHANCED_OPEN_TRANSITION
+      ../opmode = 'WPA3_2_SAE_TRANSITION' or
+      ../opmode = 'ENHANCED_OPEN' or
+      ../opmode = 'ENHANCED_OPEN_TRANSITION'
       ";
       type boolean;
       mandatory true;

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -30,12 +30,14 @@ module openconfig-wifi-mac {
 
   revision "2024-08-22" {
     description "Fix XPath expression to avoid pyang error";
+    reference "1.3.3";
   }
 
   revision "2024-08-07" {
     description
       "Add transition modes ENHANCED_OPEN_TRANSITION, WPA3_2_SAE_TRANSITION and
       WPA3_2_ENTERPRISE_TRANSITION";
+    reference "1.3.2";
   }
 
   revision "2023-05-26" {


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/external-contributions-guide.md]

### Change Scope
Fix XPath syntax error caught by pyang:
./wifi/openconfig-wifi-mac.yang:309: error: XPath syntax error: syntax error
./wifi/openconfig-wifi-mac.yang:324: error: XPath syntax error: syntax error
./wifi/openconfig-wifi-mac.yang:401: error: XPath syntax error: syntax error
