### PR TITLE
Update openconfig-keychain-types.yang

### DIFF
--- a/release/models/keychain/openconfig-keychain-types.yang
+++ b/release/models/keychain/openconfig-keychain-types.yang
@@ -21,7 +21,13 @@ module openconfig-keychain-types {
     "This module contains general data definitions for use in
     keychain-based authentication.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2024-08-27" {
+    description
+      "Added AES_128_CMAC and AES_256_CMAC";
+    reference "0.3.0";
+  }
 
   revision "2022-03-01" {
     description
@@ -136,5 +142,23 @@ module openconfig-keychain-types {
         cipher.";
       reference
         "RFC 4494 - The AES-CMAC-96 Algorithm and Its Use with IPsec";
+  }
+
+  identity AES_128_CMAC {
+    base CRYPTO_TYPE;
+      description
+        "AES-128-CMAC keyed hash function based on a AES-128 block
+        cipher.";
+      reference
+        "RFC 4493 - The AES-CMAC Algorithm and Its Use with IPsec";
+  }
+
+  identity AES_256_CMAC {
+    base CRYPTO_TYPE;
+      description
+        "AES-256-CMAC keyed hash function based on a AES-256 block
+        cipher.";
+      reference
+        "RFC 4493 - The AES-CMAC Algorithm and Its Use with IPsec";
   }
 }


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. lines

tagged with "Note" can be removed from the template.]



[Note: Before this PR can be reviewed please agree to the CLA covering this

repo. Please also review the contribution guide -

https://github.com/openconfig/public/blob/master/doc/external-contributions-guide.md]



### Change Scope



* This change adds new identity definitions for AES-CMAC algorithms to the OpenConfig crypto-types model. Specifically, it adds AES_128_CMAC, AES_256_CMAC identities.

* This change is backwards compatible as it only adds new identities and does not modify existing structures or semantics.



### Platform Implementations



* Implementation: Cisco. [Documentation link](https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/102x/command-reference/config/b_n9k_config_commands_1021/m_k_cmds.pdf)