### PR TITLE
Update reference to current IETF DRAFT for link-bandwidth community.

### DIFF
--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -642,7 +642,7 @@ module openconfig-bgp-types {
         - color:<CO bits>:<4b value> per draft-ietf-idr-segment-routing-te-policy
           section 3
         - link-bandwidth:<2 byte asn>:<bandwidth_value> per
-          draft-ietf-idr-link-bandwidth-07";
+          draft-ietf-idr-link-bandwidth-08";
 
     reference
       "RFC 4360 - BGP Extended Communities Attribute


### PR DESCRIPTION
The new revision (-08) of draft-ietf-idr-link-bandwidth is published by IETF. This new revision do not make any changes but "refresh" draft to be active. The draft-ietf-idr-link-bandwidth-07 expierd on September 6, 2018. This is cosmetic change