### PR TITLE
Add fallback leaf for LACP in OC model

### DIFF
--- a/release/models/lacp/openconfig-lacp.yang
+++ b/release/models/lacp/openconfig-lacp.yang
@@ -418,7 +418,8 @@ grouping aggregation-lacp-members-statistics {
       description
         "If the fallback is set to true, current LACP interface is
         able to establish a Link Aggregation (LAG) before it receives
-        LACP PDUs from its peer";
+        LACP PDUs from its peer, and fallback to a single port active
+        after the expiry of the timeout period.";
     }
 
     uses aggregation-lacp-global-config;

--- a/release/models/lacp/openconfig-lacp.yang
+++ b/release/models/lacp/openconfig-lacp.yang
@@ -26,7 +26,13 @@ module openconfig-lacp {
     managing aggregate interfaces.   It works in conjunction with
     the OpenConfig interfaces and aggregate interfaces models.";
 
-  oc-ext:openconfig-version "2.0.0";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2024-09-24" {
+    description
+      "Add LACP fallback leaf under both config and state.";
+    reference "2.1.0";
+  }
 
   revision "2023-12-11" {
     description
@@ -405,6 +411,14 @@ grouping aggregation-lacp-members-statistics {
         "The MAC address portion of the node's System ID. This is
         combined with the system priority to construct the 8-octet
         system-id";
+    }
+
+    leaf fallback {
+      type boolean;
+      description
+        "If the fallback is set to true, current LACP interface is
+        able to establish a Link Aggregation (LAG) before it receives
+        LACP PDUs from its peer";
     }
 
     uses aggregation-lacp-global-config;


### PR DESCRIPTION
### Change Scope

* Add a new leaf `fallback` under both config and state subtree if lacp interface
* The is a new leaf, and has no reference on any current leaves.
```
module: openconfig-lacp
  +--rw lacp
     +--rw interfaces
        +--rw interface* [name]
           +--rw config
           |  +--rw fallback?                    boolean
           +--ro state
           |  +--ro fallback?                    boolean
```
### Platform Implementations

 * SONIC HLD: https://github.com/sonic-net/SONiC/blob/18de1c1f71d1be495852fe57263bc5aaf56e1d42/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md?plain=1#L4
 * SONIC Implementation: https://github.com/sonic-net/sonic-swss/blob/42ea859ce982b21ff40c78c92a5ab21aafb52fad/cfgmgr/teammgr.cpp#L270
 * Cisco: https://www.cisco.com/c/en/us/td/docs/iosxr/ncs560/interfaces/72x/b-interfaces-hardware-component-cg-72x-ncs560/configuring_link_bundling.html#task_844BB227554D4C42A96F1AF8D5AC477C
 * Arista: https://arista.my.site.com/AristaCommunity/s/article/configuring-port-channel-lacp-fallback-on-arista-switches-2
