### PR TITLE
Restore NONE as an enum value for typedef community-type

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description
@@ -326,9 +332,10 @@ submodule openconfig-bgp-common {
     leaf-list send-community-type {
       type oc-bgp-types:community-type;
       description
-        "Specify which types of community should be sent to the
-        neighbor or group. The default is to not send the
-        community attribute";
+        "Specify which types of community should be sent to the neighbor or
+        group. The default is to not send the community attribute.  Note, if
+        the NONE community-type is specified, no other types must be
+        specified.";
     }
 
     leaf description {

--- a/release/models/bgp/openconfig-bgp-errors.yang
+++ b/release/models/bgp/openconfig-bgp-errors.yang
@@ -18,7 +18,13 @@ submodule openconfig-bgp-errors {
     "This module defines BGP NOTIFICATION message error codes
     and subcodes";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "6.1.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "6.1.0";
+  }
 
   revision "2024-01-31" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -24,7 +24,13 @@ module openconfig-bgp-types {
     policy. It can be imported by modules that make use of BGP
     attributes";
 
-  oc-ext:openconfig-version "6.0.0";
+  oc-ext:openconfig-version "6.1.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "6.1.0";
+  }
 
   revision "2024-02-01" {
     description
@@ -795,10 +801,8 @@ module openconfig-bgp-types {
       }
       enum NONE {
         description
-            "Do not send any community attribute.
-            This value has been deprecated because the node is now
-            a leaf-list.";
-        status deprecated;
+            "Do not send any community attribute. If this value is present
+            then no communities will be sent.";
       }
     }
     description

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -802,7 +802,7 @@ module openconfig-bgp-types {
       enum NONE {
         description
             "Do not send any community attribute. If this value is present
-            then no communities will be sent.";
+            then the other community-types must not be present.";
       }
     }
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,13 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.7.1";
+  oc-ext:openconfig-version "9.8.0";
+
+  revision "2024-09-06" {
+    description
+      "Restore NONE enum value for community-type.";
+    reference "9.8.0";
+  }
 
   revision "2023-12-28" {
     description


### PR DESCRIPTION
Proposed fix for https://github.com/openconfig/public/issues/945

### Change Scope
In the current OC models, there is ambiguity regarding how to use send-community-type to disable sending any communities at the bgp global, peer-group and neighbor levels.  The OC model description says the lack of the `send-community-type` node means communities should not be sent.  This is in conflict with the expected inheritance from global, peer-group and neighbor levels in BGP configuration.   With inheritance, the lack of a node means to inherit the configuration from the next higher level.

It was proposed in #945 that an explicitly defined send-community-type as an empty list could be used to indicate no communities should be sent.  But this is problematic for some encodings and likely toolchains because [RFC7590](https://datatracker.ietf.org/doc/html/rfc7950) states that XML encoded yang simply omits empty lists ([ref](https://github.com/openconfig/public/issues/945#issuecomment-2311652367)).

This proposal removes the deprecated status from the `NONE` value of the `community-type` enum.