### PR TITLE
Adding glome key version and console state.

### DIFF
--- a/release/models/gnsi/openconfig-gnsi-credentialz.yang
+++ b/release/models/gnsi/openconfig-gnsi-credentialz.yang
@@ -142,6 +142,26 @@ module openconfig-gnsi-credentialz {
     }
   }
 
+  // GLOME related definitions.
+
+  grouping glome-key-version {
+    description
+      "Version identifier for the configured GLOME key.";
+
+    leaf active-glome-key-version {
+      type version;
+      description
+        "The version of the GLOME key.";
+    }
+
+    leaf active-glome-key-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment when the GLOME key
+        was created.";
+    }
+  }
+
   // Success/failure counters.
   grouping counters {
     description
@@ -232,9 +252,16 @@ module openconfig-gnsi-credentialz {
           "Console-related state.";
 
         uses counters;
+
+        leaf glome {
+          type boolean;
+          description
+            "Whether GLOME is configured or not.";
+        }
       }
     }
   }
+
   // System role console related definitions.
 
   grouping user-console-credentials-version {

--- a/release/models/gnsi/openconfig-gnsi-credentialz.yang
+++ b/release/models/gnsi/openconfig-gnsi-credentialz.yang
@@ -39,7 +39,7 @@ module openconfig-gnsi-credentialz {
       /system/aaa/authentication/users/user/config/password-hashed
       /system/aaa/authentication/users/user/state/password-hashed";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
 
   revision 2024-09-10 {
     description

--- a/release/models/gnsi/openconfig-gnsi-credentialz.yang
+++ b/release/models/gnsi/openconfig-gnsi-credentialz.yang
@@ -41,6 +41,12 @@ module openconfig-gnsi-credentialz {
 
   oc-ext:openconfig-version "0.6.0";
 
+  revision 2024-09-10 {
+    description
+      "Adding GLOME capabilities.";
+    reference "0.7.0";
+  }
+
   revision 2024-02-13 {
     description
       "Major style updates and move to openconfig/public from openconfig/gnsi.

--- a/release/models/gnsi/openconfig-gnsi-credentialz.yang
+++ b/release/models/gnsi/openconfig-gnsi-credentialz.yang
@@ -259,10 +259,10 @@ module openconfig-gnsi-credentialz {
 
         uses counters;
 
-        leaf glome {
+        leaf enabled {
           type boolean;
           description
-            "Whether GLOME is configured or not.";
+            "Whether GLOME is enabled or not.";
         }
       }
     }


### PR DESCRIPTION
### Change Scope

* Adding key and glome-console state to telemetry, for use in an upcoming gnsi.credentialz change
* This is backwards compatible

There are no implementations yet.
