### PR TITLE
Clarify last-reboot-time is updated during a power-on event

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,14 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.27.0";
+  oc-ext:openconfig-version "0.28.0";
+
+  revision "2024-09-09" {
+    description
+      "Clarify last-reboot-time is updated during a power-on
+      event.";
+    reference "0.28.0";
+  }
 
   revision "2024-05-29" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -644,8 +644,8 @@ revision "2024-05-29" {
          - SYSTEM_INITIATED
          - POWER_FAILURE
          This field is only updated when power is shut off.  It is not
-         updated during reboots; those are tracked in the
-         'last-reboot-time' leaf.";
+         updated during reboots; those are tracked in the 'boot-time'
+         leaf.";
     }
 
     container last-switchover-reason {
@@ -681,13 +681,25 @@ revision "2024-05-29" {
     leaf last-reboot-time {
       type oc-types:timeticks64;
       units "nanoseconds";
+      status deprecated;
       description
         "This reports the time of the last reboot of the component. The
         value is the timestamp in nanoseconds relative to the Unix Epoch
         (Jan 1, 1970 00:00:00 UTC). This timer is updated when the component
         starts up, either due to a power-on event or a reboot.  This timer
         is not updated during power shutdowns; those are tracked in
-        the 'last-poweroff-time' leaf.";
+        the 'last-poweroff-time' leaf.
+        This leaf is deprecated and the boot-time leaf should be used
+        instead.";
+    }
+
+    leaf boot-time {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "This timestamp indicates the time that the component was started.
+        The value is the timestamp in nanoseconds relative to the Unix
+        Epoch (Jan 1, 1970 00:00:00 UTC).";
     }
 
     leaf switchover-ready {

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,14 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.29.0";
+  oc-ext:openconfig-version "0.30.0";
+
+  revision "2024-10-13" {
+    description
+      "Clarify last-reboot-time is updated during a power-on
+      event.";
+    reference "0.30.0";
+  }
 
   revision "2024-10-13" {
     description

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -625,8 +625,8 @@ revision "2024-05-29" {
          - USER_INITIATED
          - SYSTEM_INITIATED
          - POWER_FAILURE
-         This field is only updated when power is shut off.  It is not 
-         updated during reboots; those are tracked in the 
+         This field is only updated when power is shut off.  It is not
+         updated during reboots; those are tracked in the
          'last-reboot-time' leaf.";
     }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,9 +65,16 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.27.0";
+  oc-ext:openconfig-version "0.28.0";
 
-  revision "2024-05-29" {
+  revision "2024-09-09" {
+    description
+      "Clarify last-reboot-time is updated during a power-on
+      event.";
+    reference "0.28.0";
+  }
+
+revision "2024-05-29" {
     description
       "Change install-position from leaf-ref to string.";
     reference "0.27.0";
@@ -618,8 +625,9 @@ module openconfig-platform {
          - USER_INITIATED
          - SYSTEM_INITIATED
          - POWER_FAILURE
-         This field is not updated during reboots; those are tracked
-         in the 'last-reboot-time' leaf.";
+         This field is only updated when power is shut off.  It is not 
+         updated during reboots; those are tracked in the 
+         'last-reboot-time' leaf.";
     }
 
     container last-switchover-reason {
@@ -658,8 +666,10 @@ module openconfig-platform {
       description
         "This reports the time of the last reboot of the component. The
         value is the timestamp in nanoseconds relative to the Unix Epoch
-        (Jan 1, 1970 00:00:00 UTC). This timer is not updated during
-        power shutdowns; those are tracked in 'last-poweroff-time' leaf.";
+        (Jan 1, 1970 00:00:00 UTC). This timer is updated when the component
+        starts up, either due to a power-on event or a reboot.  This timer
+        is not updated during power shutdowns; those are tracked in
+        the 'last-poweroff-time' leaf.";
     }
 
     leaf switchover-ready {


### PR DESCRIPTION
Fixes #1171 


### Tree view
We are at `/components/component/state`
```diff
         |  +--ro last-poweroff-reason
         |  |  +--ro trigger?   component-last-poweroff-reason-trigger
         |  |  +--ro details?   string
         |  +--ro last-poweroff-time?             oc-types:timeticks64
         |  +--ro last-switchover-reason
         |  |  +--ro trigger?   component-redundant-role-switchover-reason-trigger
         |  |  +--ro details?   string
         |  +--ro last-switchover-time?           oc-types:timeticks64
         |  +--ro last-reboot-reason?             identityref
-        |  +--ro last-reboot-time?               oc-types:timeticks64
+        |  x--ro last-reboot-time?               oc-types:timeticks64
+        |  +--ro boot-time?                      oc-types:timeticks64
         |  +--ro switchover-ready?               boolean
```