### PR TITLE
Refactor physical ethernet vs. aggregate interface characteristics

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -24,7 +24,14 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.13.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2024-09-17" {
+    description
+      "Refactor config/state nodes to account for physical ethernet vs.
+      aggregate interface characteristics.";
+    reference "3.0.0";
+  }
 
   revision "2023-03-10" {
     description
@@ -294,7 +301,9 @@ module openconfig-if-ethernet {
   // grouping statements
 
   grouping ethernet-interface-config {
-    description "Configuration items for Ethernet interfaces";
+    description
+      "Common interface configuration for physical ethernet + logical
+      aggregate interfaces";
 
     leaf mac-address {
       type oc-yang:mac-address;
@@ -303,6 +312,27 @@ module openconfig-if-ethernet {
         specified, the corresponding operational state leaf is
         expected to show the system-assigned MAC address.";
     }
+
+    leaf enable-flow-control {
+      type boolean;
+      default false;
+      description
+        "Enable or disable flow control for this interface.
+        Ethernet flow control is a mechanism by which a receiver
+        may send PAUSE frames to a sender to stop transmission for
+        a specified time.
+
+        This setting should override auto-negotiated flow control
+        settings.  If left unspecified, and auto-negotiate is TRUE,
+        flow control mode is negotiated with the peer interface.";
+      reference
+        "IEEE 802.3x";
+    }
+  }
+
+  grouping physical-interface-config {
+    description
+      "Configuration specific to physical ethernet interfaces";
 
     leaf auto-negotiate {
       type boolean;
@@ -363,22 +393,6 @@ module openconfig-if-ethernet {
         negotiation.  When auto-negotiate is set to FALSE, sets the
         link speed to a fixed value -- supported values are defined
         by ETHERNET_SPEED identities";
-    }
-
-    leaf enable-flow-control {
-      type boolean;
-      default false;
-      description
-        "Enable or disable flow control for this interface.
-        Ethernet flow control is a mechanism by which a receiver
-        may send PAUSE frames to a sender to stop transmission for
-        a specified time.
-
-        This setting should override auto-negotiated flow control
-        settings.  If left unspecified, and auto-negotiate is TRUE,
-        flow control mode is negotiated with the peer interface.";
-      reference
-        "IEEE 802.3x";
     }
 
     leaf fec-mode {
@@ -596,7 +610,7 @@ module openconfig-if-ethernet {
 
   }
 
-  grouping ethernet-interface-state {
+  grouping physical-interface-state {
     description
       "Grouping for defining Ethernet-specific operational state";
 
@@ -631,6 +645,11 @@ module openconfig-if-ethernet {
         completed auto-negotiation with the remote peer, this value
         shows the interface speed that has been negotiated.";
     }
+  }
+
+  grouping ethernet-interface-state {
+    description
+      "Common state for physical ethernet and aggregate interfaces";
 
     container counters {
       description "Ethernet interface counters";
@@ -654,6 +673,13 @@ module openconfig-if-ethernet {
 
         uses ethernet-interface-config;
 
+        uses physical-interface-config {
+          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
+            description
+              "Configuration specific for physical ethernet interfaces";
+          }
+        }
+
       }
 
       container state {
@@ -662,6 +688,20 @@ module openconfig-if-ethernet {
         description "State variables for Ethernet interfaces";
 
         uses ethernet-interface-config;
+
+        uses physical-interface-config {
+          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
+            description
+              "Configuration specific for physical ethernet interfaces";
+          }
+        }
+
+        uses physical-interface-state {
+          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
+            description
+              "State specific for physical ethernet interfaces";
+          }
+        }
         uses ethernet-interface-state;
 
       }

--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -332,7 +332,11 @@ module openconfig-if-ethernet {
 
   grouping physical-interface-config {
     description
-      "Configuration specific to physical ethernet interfaces";
+      "Configuration specific to physical ethernet interfaces.  Note
+      that this grouping is to only apply when the interface `type` is
+      set to 'ianaift:ethernetCsmacd'.  This is not currently restricted
+      by YANG language statements (must/when) due to uses of this module
+      within other domains (e.g. wifi).";
 
     leaf auto-negotiate {
       type boolean;
@@ -612,7 +616,11 @@ module openconfig-if-ethernet {
 
   grouping physical-interface-state {
     description
-      "Grouping for defining Ethernet-specific operational state";
+      "Grouping for operational state specific to physical ethernet
+      interfaces.  Note that this grouping is to only apply when the
+      interface `type` is set to 'ianaift:ethernetCsmacd'.  This is not
+      currently restricted by YANG language statements (must/when) due
+      to uses of this module within other domains (e.g. wifi).";
 
     leaf hw-mac-address {
       type oc-yang:mac-address;
@@ -672,14 +680,7 @@ module openconfig-if-ethernet {
         description "Configuration data for ethernet interfaces";
 
         uses ethernet-interface-config;
-
-        uses physical-interface-config {
-          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
-            description
-              "Configuration specific for physical ethernet interfaces";
-          }
-        }
-
+        uses physical-interface-config;
       }
 
       container state {
@@ -688,20 +689,8 @@ module openconfig-if-ethernet {
         description "State variables for Ethernet interfaces";
 
         uses ethernet-interface-config;
-
-        uses physical-interface-config {
-          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
-            description
-              "Configuration specific for physical ethernet interfaces";
-          }
-        }
-
-        uses physical-interface-state {
-          when "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" {
-            description
-              "State specific for physical ethernet interfaces";
-          }
-        }
+        uses physical-interface-config;
+        uses physical-interface-state;
         uses ethernet-interface-state;
 
       }

--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -24,13 +24,14 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "2.14.0";
 
   revision "2024-09-17" {
     description
       "Refactor config/state nodes to account for physical ethernet vs.
-      aggregate interface characteristics.";
-    reference "3.0.0";
+      aggregate interface characteristics along with description updates
+      to indicate applicability.";
+    reference "2.14.0";
   }
 
   revision "2023-03-10" {


### PR DESCRIPTION
  * (M) release/models/interfaces/openconfig-if-ethernet.yang
    - Split/restrict physical vs. aggregate ethernet config/state

### Change Scope

Per https://github.com/openconfig/public/issues/1181 it was pointed out that
the reuse of all ethernet characteristics for both physical and aggregate
interfaces does not provide guidance or restrictions of what and how to
populate/certain leafs depending on the interface type.

This PR divides up groupings into physical and common data nodes gating what is
supported based on the interface `type`.

Validated instance-data below per the new restrictions:

```
{
  "openconfig-interfaces:interfaces": {
    "interface": [
      {
        "name": "ae0",
        "config": {
          "name": "ae0",
          "type": "iana-if-type:ieee8023adLag"
        },
        "state": {
          "name": "ae0",
          "type": "iana-if-type:ieee8023adLag",
          "loopback-mode": "NONE",
          "enabled": true,
          "admin-status": "UP",
          "oper-status": "UP"
        },
        "hold-time": {
          "state": {
            "up": 0,
            "down": 0
          }
        },
        "penalty-based-aied": {
          "state": {
            "max-suppress-time": 0,
            "decay-half-life": 0,
            "suppress-threshold": 0,
            "reuse-threshold": 0,
            "flap-penalty": 0
          }
        },
        "openconfig-if-aggregate:aggregation": {
          "config": {
            "lag-type": "LACP",
            "min-links": 1
          },
          "state": {
            "lag-type": "LACP",
            "min-links": 1,
            "lag-speed": 800000
          }
        },
        "openconfig-if-ethernet:ethernet": {
          "config": {
            "mac-address": "00:00:00:00:00:1a",
            "enable-flow-control": true
          },
          "state": {
            "mac-address": "00:00:00:00:00:1a",
            "enable-flow-control": true
          }
        }
      },
      {
        "name": "et-0/0/0",
        "config": {
          "name": "et-0/0/0",
          "type": "iana-if-type:ethernetCsmacd"
        },
        "state": {
          "name": "et-0/0/0",
          "type": "iana-if-type:ethernetCsmacd",
          "loopback-mode": "NONE",
          "enabled": true,
          "admin-status": "UP",
          "oper-status": "UP"
        },
        "hold-time": {
          "state": {
            "up": 0,
            "down": 0
          }
        },
        "penalty-based-aied": {
          "state": {
            "max-suppress-time": 0,
            "decay-half-life": 0,
            "suppress-threshold": 0,
            "reuse-threshold": 0,
            "flap-penalty": 0
          }
        },
        "openconfig-if-ethernet:ethernet": {
          "config": {
            "mac-address": "00:00:00:00:00:aa",
            "enable-flow-control": true,
            "auto-negotiate": true,
            "duplex-mode": "FULL",
            "port-speed": "SPEED_400GB",
            "openconfig-if-aggregate:aggregate-id": "ae0"
          },
          "state": {
            "mac-address": "00:00:00:00:00:aa",
            "enable-flow-control": true,
            "auto-negotiate": true,
            "standalone-link-training": false,
            "duplex-mode": "FULL",
            "port-speed": "SPEED_400GB",
            "hw-mac-address": "ff:00:00:00:00:01",
            "negotiated-duplex-mode": "FULL",
            "negotiated-port-speed": "SPEED_400GB",
            "openconfig-if-aggregate:aggregate-id": "ae0"
          }
        }
      },
      {
        "name": "et-0/0/1",
        "config": {
          "name": "et-0/0/1",
          "type": "iana-if-type:ethernetCsmacd"
        },
        "state": {
          "name": "et-0/0/1",
          "type": "iana-if-type:ethernetCsmacd",
          "loopback-mode": "NONE",
          "enabled": true,
          "admin-status": "UP",
          "oper-status": "UP"
        },
        "hold-time": {
          "state": {
            "up": 0,
            "down": 0
          }
        },
        "penalty-based-aied": {
          "state": {
            "max-suppress-time": 0,
            "decay-half-life": 0,
            "suppress-threshold": 0,
            "reuse-threshold": 0,
            "flap-penalty": 0
          }
        },
        "openconfig-if-ethernet:ethernet": {
          "config": {
            "mac-address": "00:00:00:00:00:ab",
            "enable-flow-control": true,
            "auto-negotiate": true,
            "duplex-mode": "FULL",
            "port-speed": "SPEED_400GB",
            "openconfig-if-aggregate:aggregate-id": "ae0"
          },
          "state": {
            "mac-address": "00:00:00:00:00:ab",
            "enable-flow-control": true,
            "auto-negotiate": true,
            "standalone-link-training": false,
            "duplex-mode": "FULL",
            "port-speed": "SPEED_400GB",
            "hw-mac-address": "ff:00:00:00:00:02",
            "negotiated-duplex-mode": "FULL",
            "negotiated-port-speed": "SPEED_400GB",
            "openconfig-if-aggregate:aggregate-id": "ae0"
          }
        }
      }
    ]
  }
}
```

#### Failure cases

If an aggregate interface contains `port-speed`

```
libyang err : When condition "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" not satisfied. (/openconfig-interfaces:interfaces/interface[name='ae0']/openconfig-if-ethernet:ethernet/state/port-speed)
```

The correct leaf node to report is rather `aggregation/state/lag-speed`

If an aggregate interface contains `negotiated-port-speed`

```
libyang err : When condition "../../oc-if:config/oc-if:type = 'ianaift:ethernetCsmacd'" not satisfied. (/openconfig-interfaces:interfaces/interface[name='ae0']/openconfig-if-ethernet:ethernet/state/negotiated-port-speed)
```

... and similar for physical interface characteristics under a logical interface of non `ethernetCsmacd` type

### Platform Implementations

Bug fix & enforced restrictions


_Edit: 2024-10-07_
----
_Due to reuse of this model within wifi related models, `when` restrictions are severely restricted at this time.  This PR has been refactored to segment out groupings and update description statements to describe the behavior until otherwise resolved._

_Edit: 2024-10-31_
---

Updated tree view (w/ groupings) per comment https://github.com/openconfig/public/pull/1183#issuecomment-2444743885

```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-eth:ethernet
           +--rw oc-eth:config
           |  +--rw oc-eth:mac-address?                oc-yang:mac-address
           |  +--rw oc-eth:enable-flow-control?        boolean
           |  +--rw oc-eth:auto-negotiate?             boolean
           |  +--rw oc-eth:standalone-link-training?   boolean
           |  +--rw oc-eth:duplex-mode?                enumeration
           |  +--rw oc-eth:port-speed?                 identityref
           |  +--rw oc-eth:fec-mode?                   identityref
           |  +--rw oc-lag:aggregate-id?               -> /oc-if:interfaces/interface/name
           +--ro oc-eth:state
              +--ro oc-eth:mac-address?                oc-yang:mac-address
              +--ro oc-eth:enable-flow-control?        boolean
              +--ro oc-eth:auto-negotiate?             boolean
              +--ro oc-eth:standalone-link-training?   boolean
              +--ro oc-eth:duplex-mode?                enumeration
              +--ro oc-eth:port-speed?                 identityref
              +--ro oc-eth:fec-mode?                   identityref
              +--ro oc-eth:hw-mac-address?             oc-yang:mac-address
              +--ro oc-eth:negotiated-duplex-mode?     enumeration
              +--ro oc-eth:negotiated-port-speed?      identityref
              +--ro oc-eth:counters
              |  +--ro oc-eth:in-mac-control-frames?    oc-yang:counter64
              |  +--ro oc-eth:in-mac-pause-frames?      oc-yang:counter64
              |  +--ro oc-eth:in-oversize-frames?       oc-yang:counter64
              |  +--ro oc-eth:in-undersize-frames?      oc-yang:counter64
              |  +--ro oc-eth:in-jabber-frames?         oc-yang:counter64
              |  +--ro oc-eth:in-fragment-frames?       oc-yang:counter64
              |  +--ro oc-eth:in-8021q-frames?          oc-yang:counter64
              |  +--ro oc-eth:in-crc-errors?            oc-yang:counter64
              |  +--ro oc-eth:in-block-errors?          oc-yang:counter64
              |  +--ro oc-eth:in-carrier-errors?        oc-yang:counter64
              |  +--ro oc-eth:in-interrupted-tx?        oc-yang:counter64
              |  +--ro oc-eth:in-late-collision?        oc-yang:counter64
              |  +--ro oc-eth:in-mac-errors-rx?         oc-yang:counter64
              |  +--ro oc-eth:in-single-collision?      oc-yang:counter64
              |  +--ro oc-eth:in-symbol-error?          oc-yang:counter64
              |  +--ro oc-eth:in-maxsize-exceeded?      oc-yang:counter64
              |  +--ro oc-eth:out-mac-control-frames?   oc-yang:counter64
              |  +--ro oc-eth:out-mac-pause-frames?     oc-yang:counter64
              |  +--ro oc-eth:out-8021q-frames?         oc-yang:counter64
              |  +--ro oc-eth:out-mac-errors-tx?        oc-yang:counter64
              +--ro oc-lag:aggregate-id?               -> /oc-if:interfaces/interface/name

  grouping interface-ref-common:
    +-- interface?      -> /interfaces/interface/name
    +-- subinterface?   -> /interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
  grouping interface-ref-state-container:
    +--ro state
  grouping interface-ref:
    +-- interface-ref
  grouping interface-ref-state:
    +-- interface-ref
  grouping base-interface-ref-state:
    +--ro state
  grouping interface-common-config:
    +-- description?   string
    +-- enabled?       boolean
  grouping interface-phys-config:
    +-- name?            string
    +-- type             identityref
    +-- mtu?             uint16
    +-- loopback-mode?   oc-opt-types:loopback-mode-type
    +-- description?     string
    +-- enabled?         boolean
  grouping interface-phys-holdtime-config:
    +-- up?     uint32
    +-- down?   uint32
  grouping interface-phys-holdtime-state:
  grouping interface-phys-holdtime-top:
    +-- hold-time
  grouping interface-link-damping-config:
    +-- max-suppress-time?    uint32
    +-- decay-half-life?      uint32
    +-- suppress-threshold?   uint32
    +-- reuse-threshold?      uint32
    +-- flap-penalty?         uint32
  grouping interface-link-damping-state:
  grouping link-damping-top:
    +-- penalty-based-aied
  grouping interface-common-state:
    +-- ifindex?        uint32
    +-- admin-status    enumeration
    +-- oper-status     enumeration
    +-- last-change?    oc-types:timeticks64
    +-- logical?        boolean
    +-- management?     boolean
    +-- cpu?            boolean
  grouping interface-common-counters-state:
    +-- in-octets?            oc-yang:counter64
    +-- in-pkts?              oc-yang:counter64
    +-- in-unicast-pkts?      oc-yang:counter64
    +-- in-broadcast-pkts?    oc-yang:counter64
    +-- in-multicast-pkts?    oc-yang:counter64
    +-- in-errors?            oc-yang:counter64
    +-- in-discards?          oc-yang:counter64
    +-- out-octets?           oc-yang:counter64
    +-- out-pkts?             oc-yang:counter64
    +-- out-unicast-pkts?     oc-yang:counter64
    +-- out-broadcast-pkts?   oc-yang:counter64
    +-- out-multicast-pkts?   oc-yang:counter64
    +-- out-discards?         oc-yang:counter64
    +-- out-errors?           oc-yang:counter64
    +-- last-clear?           oc-types:timeticks64
  grouping interface-counters-state:
    +-- in-unknown-protos?     oc-yang:counter64
    +-- in-fcs-errors?         oc-yang:counter64
    +-- carrier-transitions?   oc-yang:counter64
    +-- resets?                oc-yang:counter64
  grouping subinterfaces-counters-state:
    x-- in-unknown-protos?     oc-yang:counter64
    x-- in-fcs-errors?         oc-yang:counter64
    x-- carrier-transitions?   oc-yang:counter64
  grouping sub-unnumbered-config:
    +-- enabled?   boolean
  grouping sub-unnumbered-state:
  grouping sub-unnumbered-top:
    +-- unnumbered
  grouping subinterfaces-config:
    +-- index?         uint32
    +-- description?   string
    +-- enabled?       boolean
  grouping subinterfaces-state:
    +-- name?           string
    +-- ifindex?        uint32
    +-- admin-status    enumeration
    +-- oper-status     enumeration
    +-- last-change?    oc-types:timeticks64
    +-- logical?        boolean
    +-- management?     boolean
    +-- cpu?            boolean
    +-- counters
  grouping subinterfaces-top:
    +-- subinterfaces
  grouping interfaces-top:
    +-- interfaces

module: openconfig-if-aggregate

  grouping aggregation-logical-config:
    +-- lag-type?    aggregation-type
    +-- min-links?   uint16
  grouping aggregation-logical-state:
    +-- lag-speed?   uint32
    +-- member*      oc-if:base-interface-ref
  grouping aggregation-logical-top:
    +-- aggregation
  grouping ethernet-if-aggregation-config:
    +-- aggregate-id?   -> /oc-if:interfaces/interface/name

module: openconfig-if-ethernet

  grouping ethernet-interface-config:
    +-- mac-address?           oc-yang:mac-address
    +-- enable-flow-control?   boolean
  grouping physical-interface-config:
    +-- auto-negotiate?             boolean
    +-- standalone-link-training?   boolean
    +-- duplex-mode?                enumeration
    +-- port-speed?                 identityref
    +-- fec-mode?                   identityref
  grouping ethernet-interface-state-counters:
    +-- in-mac-control-frames?    oc-yang:counter64
    +-- in-mac-pause-frames?      oc-yang:counter64
    +-- in-oversize-frames?       oc-yang:counter64
    +-- in-undersize-frames?      oc-yang:counter64
    +-- in-jabber-frames?         oc-yang:counter64
    +-- in-fragment-frames?       oc-yang:counter64
    +-- in-8021q-frames?          oc-yang:counter64
    +-- in-crc-errors?            oc-yang:counter64
    +-- in-block-errors?          oc-yang:counter64
    +-- in-carrier-errors?        oc-yang:counter64
    +-- in-interrupted-tx?        oc-yang:counter64
    +-- in-late-collision?        oc-yang:counter64
    +-- in-mac-errors-rx?         oc-yang:counter64
    +-- in-single-collision?      oc-yang:counter64
    +-- in-symbol-error?          oc-yang:counter64
    +-- in-maxsize-exceeded?      oc-yang:counter64
    +-- out-mac-control-frames?   oc-yang:counter64
    +-- out-mac-pause-frames?     oc-yang:counter64
    +-- out-8021q-frames?         oc-yang:counter64
    +-- out-mac-errors-tx?        oc-yang:counter64
  grouping physical-interface-state:
    +-- hw-mac-address?           oc-yang:mac-address
    +-- negotiated-duplex-mode?   enumeration
    +-- negotiated-port-speed?    identityref
  grouping ethernet-interface-state:
    +-- counters
  grouping ethernet-top:
    +-- ethernet
```