### PR TITLE
Correct typo in protocol-name description

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-policy.yang
+++ b/release/models/network-instance/openconfig-network-instance-policy.yang
@@ -25,7 +25,14 @@ module openconfig-network-instance-policy {
     actions) for the network instance model.  These statements are
     generally added to the routing policy model.";
 
-  oc-ext:openconfig-version "0.1.2";
+  oc-ext:openconfig-version "0.1.3";
+
+  revision "2024-09-19" {
+    description
+      "Correct typo in description of
+       match-protocol-instance/protocol-name.";
+    reference "0.1.3";
+  }
 
   revision "2023-07-25" {
     description
@@ -74,7 +81,7 @@ revision "2018-11-21" {
           on in the local network instance. The string
           must match one of /network-instances/
           network-instance/protocols/
-          protocol/identifier in the local network
+          protocol/name in the local network
           instance.";
       }
   }


### PR DESCRIPTION
Description stated that this leaf should match identifier of a protocol, but it should actually match name of a protocol.

Fixes: #1184

### Change Scope

Comment-only change preventing misinterpretation of the leaf meaning.