### PR TITLE
Define `telemetry-atomic-exempt` annotation. Add `telemetry-atomic-exempt` annotation to AFT counters containers

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.6.0";
+  oc-ext:openconfig-version "2.7.0";
+
+  revision "2024-09-19" {
+    description
+      "Add atomic-exempt attribute to AFT counters containers.";
+    reference "2.7.0";
+  }
 
   revision "2024-04-25" {
     description
@@ -785,6 +791,7 @@ submodule openconfig-aft-common {
   }
 
   grouping aft-common-entry-counter-state {
+    oc-ext:telemetry-atomic-exempt;
     description
       "Counters relating to a forwarding entry";
 
@@ -804,6 +811,7 @@ submodule openconfig-aft-common {
   }
 
   grouping aft-common-backup-entry-counter-state {
+    oc-ext:telemetry-atomic-exempt;
     description
       "Counters relating to a backup forwarding entry";
 

--- a/release/models/openconfig-extensions.yang
+++ b/release/models/openconfig-extensions.yang
@@ -18,7 +18,13 @@ module openconfig-extensions {
     "This module provides extensions to the YANG language to allow
     OpenConfig specific functionality and meta-data to be defined.";
 
-  oc-ext:openconfig-version "0.5.1";
+  oc-ext:openconfig-version "0.5.2";
+
+  revision "2024-09-19" {
+    description
+      "Add telemetry-atomic-exempt annotation.";
+    reference "0.5.2";
+  }
 
   revision "2022-10-05" {
     description
@@ -154,7 +160,7 @@ module openconfig-extensions {
   extension telemetry-atomic {
     description
       "The telemetry-atomic annotation is specified in the context of
-      a subtree (containre, or list), and indicates that all nodes
+      a subtree (container, or list), and indicates that all nodes
       within the subtree are always updated together within the data
       model. For example, all elements under the subtree may be updated
       as a result of a new alarm being raised, or the arrival of a new
@@ -162,6 +168,20 @@ module openconfig-extensions {
 
       Transport protocols may use the atomic specification to determine
       optimisations for sending or storing the corresponding data.";
+  }
+
+  extension telemetry-atomic-exempt {
+    description
+      "The telemetry-atomic-exempt annotation is specified in the context
+      of a subtree (container, or list), and indicates that all nodes
+      within the subtree are not always updated together within the data
+      model of the parent tree. All elements under the
+      subtree may not be updated as a result of a new alarm being raised,
+      or the arrival of a new protocol message that updates the parent
+      tree.
+      This annotation allows parent tree containers with telemetry-atomic
+      annotation  to not be updated when a more frequently updated subtree
+      (like a counters container) is present.";
   }
 
   extension operational {


### PR DESCRIPTION
* (M) aft/openconfig-aft-common.yang
* (M) openconfig-extensions.yang

Change Scope
* Define `telemetry-atomic-exempt` annotation.
* Add `telemetry-atomic-exempt` annotation to AFT counters containers/grouping
* This change is backwards compatible

[AFT atomic and counters issue](https://github.com/openconfig/public/issues/1064)