### PR TITLE
Relay Agent helper: add support for source, hostname, and network instance

### DIFF
--- a/release/models/relay-agent/openconfig-relay-agent.yang
+++ b/release/models/relay-agent/openconfig-relay-agent.yang
@@ -10,8 +10,10 @@ module openconfig-relay-agent {
   // import some basic types
   import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
+  import openconfig-network-instance { prefix oc-ni; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
 
 
   // meta
@@ -27,7 +29,14 @@ module openconfig-relay-agent {
     packets.  The supports both DHCP and DHCPv6 and device-wide and
     per-interface settings.";
 
-  oc-ext:openconfig-version "0.1.2";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2024-09-18" {
+    description
+      "Turn helper-address into a keyed list and add attributes for
+      source and hostname configuration";
+    reference "0.2.0";
+  }
 
   revision "2023-02-06" {
     description
@@ -624,6 +633,62 @@ module openconfig-relay-agent {
 
   }
 
+  grouping relay-agent-ipv4-helper-address-config {
+    description
+      "Configuration options for an IP helper-address";
+
+    leaf address {
+      type oc-inet:host;
+      description
+        "IP address to relay DHCP requests to";
+    }
+
+    leaf local-address {
+      type union {
+        type inet:ipv4-address;
+        type oc-if:interface-id;
+      }
+      description
+        "IP address or interface whose IP address is to be used as source in
+	relayed DHCP requests";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance that this DHCP Server
+        is associated with";
+    }
+  }
+
+  grouping relay-agent-ipv6-helper-address-config {
+    description
+      "Configuration options for an IPv6 helper-address";
+
+    leaf address {
+      type oc-inet:host;
+      description
+        "IPv6 address to relay DHCPv6 requests to";
+    }
+
+    leaf local-address {
+      type union {
+        type inet:ipv6-address;
+        type oc-if:interface-id;
+      }
+      description
+        "IPv6 address or interface whose IPv6 address is to be used as source in
+	relayed DHCPv6 requests";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance that this DHCP Server
+        is associated with";
+    }
+  }
+
   grouping relay-agent-ipv4-interfaces-config {
     description
       "Configuration data for interfaces enabled for relaying";
@@ -644,12 +709,52 @@ module openconfig-relay-agent {
 
     leaf-list helper-address {
       type inet:ip-address;
+      status deprecated;
       description
         "List of IPv4 or IPv6 addresses of DHCP servers to which the
         relay agent should forward DHCPv4 requests.  The relay agent is
         expected to forward DHCPv4/BOOTP requests to all listed
         server addresses when DHCPv4 relaying is enabled globally, or
         on the interface.";
+    }
+
+    container helper-addresses {
+      description
+        "Enclosing container for helper addresses";
+      list helper-address {
+	key "address";
+	description
+          "List of IPv4 addresses of DHCP servers to which the
+          relay agent should forward DHCPv4 requests.  The relay agent is
+          expected to forward DHCPv4/BOOTP requests to all listed
+          server addresses when DHCPv4 relaying is enabled globally, or
+          on the interface.";
+
+	leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to list key representing IP helper address";
+        }
+
+
+	container config {
+	  description
+	    "Configuration data for IP helper address";
+
+	  uses relay-agent-ipv4-helper-address-config;
+	}
+
+	container state {
+	  config false;
+
+	  description
+	    "Operational state for IP helper address";
+
+	  uses relay-agent-ipv4-helper-address-config;
+	}
+      }
     }
   }
 
@@ -736,12 +841,51 @@ module openconfig-relay-agent {
 
     leaf-list helper-address {
       type inet:ipv6-address;
+      status deprecated;
       description
         "List of IPv6 addresses of DHCP servers to which the
         relay agent should forward DHCPv6 requests.  The relay agent
         is expected to forward DHCPv4/BOOTP requests to all listed
         server addresses when DHCPv6 relaying is enabled globally, or
         on the interface.";
+    }
+
+    container helper-addresses {
+      description
+        "Enclosing container for IPv6 helper addresses";
+      list helper-address {
+        key "address";
+        description
+          "List of IPv6 addresses of DHCP servers to which the
+           relay agent should forward DHCPv6 requests.  The relay agent
+           is expected to forward DHCPv4/BOOTP requests to all listed
+           server addresses when DHCPv6 relaying is enabled globally, or
+           on the interface.";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to list key representing IP helper address";
+        }
+
+        container config {
+          description
+            "Configuration data for IP helper address";
+
+          uses relay-agent-ipv6-helper-address-config;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state for IP helper address";
+
+          uses relay-agent-ipv6-helper-address-config;
+        }
+      }
     }
   }
 

--- a/release/models/relay-agent/openconfig-relay-agent.yang
+++ b/release/models/relay-agent/openconfig-relay-agent.yang
@@ -643,7 +643,7 @@ module openconfig-relay-agent {
         "IP address to relay DHCP requests to";
     }
 
-    leaf local-address {
+    leaf source-address {
       type union {
         type inet:ipv4-address;
         type oc-if:interface-id;
@@ -671,7 +671,7 @@ module openconfig-relay-agent {
         "IPv6 address to relay DHCPv6 requests to";
     }
 
-    leaf local-address {
+    leaf source-address {
       type union {
         type inet:ipv6-address;
         type oc-if:interface-id;
@@ -686,6 +686,92 @@ module openconfig-relay-agent {
       description
         "The network instance that this DHCP Server
         is associated with";
+    }
+  }
+
+  grouping helper-addresses-ipv4-top {
+    description
+      "Top-level grouping for DHCPv4 helper-addresses on interfaces";
+
+    container helper-addresses {
+      description
+        "Enclosing container for helper addresses";
+      list helper-address {
+        key "address";
+        description
+          "List of IPv4 addresses of DHCP servers to which the
+          relay agent should forward DHCPv4 requests.  The relay agent is
+          expected to forward DHCPv4/BOOTP requests to all listed
+          server addresses when DHCPv4 relaying is enabled globally, or
+          on the interface.";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to list key representing IP helper address";
+        }
+
+        container config {
+          description
+            "Configuration data for IP helper address";
+
+          uses relay-agent-ipv4-helper-address-config;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state for IP helper address";
+
+          uses relay-agent-ipv4-helper-address-config;
+        }
+      }
+    }
+  }
+
+  grouping helper-addresses-ipv6-top{
+    description
+      "Top-level grouping for DHCPv4 helper-addresses on interfaces";
+
+    container helper-addresses {
+      description
+        "Enclosing container for IPv6 helper addresses";
+      list helper-address {
+        key "address";
+        description
+          "List of IPv6 addresses of DHCP servers to which the
+           relay agent should forward DHCPv6 requests.  The relay agent
+           is expected to forward DHCPv4/BOOTP requests to all listed
+           server addresses when DHCPv6 relaying is enabled globally, or
+           on the interface.";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "Reference to list key representing IP helper address";
+        }
+
+        container config {
+          description
+            "Configuration data for IP helper address";
+
+          uses relay-agent-ipv6-helper-address-config;
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state for IP helper address";
+
+          uses relay-agent-ipv6-helper-address-config;
+        }
+      }
     }
   }
 
@@ -716,45 +802,6 @@ module openconfig-relay-agent {
         expected to forward DHCPv4/BOOTP requests to all listed
         server addresses when DHCPv4 relaying is enabled globally, or
         on the interface.";
-    }
-
-    container helper-addresses {
-      description
-        "Enclosing container for helper addresses";
-      list helper-address {
-	key "address";
-	description
-          "List of IPv4 addresses of DHCP servers to which the
-          relay agent should forward DHCPv4 requests.  The relay agent is
-          expected to forward DHCPv4/BOOTP requests to all listed
-          server addresses when DHCPv4 relaying is enabled globally, or
-          on the interface.";
-
-	leaf address {
-          type leafref {
-            path "../config/address";
-          }
-          description
-            "Reference to list key representing IP helper address";
-        }
-
-
-	container config {
-	  description
-	    "Configuration data for IP helper address";
-
-	  uses relay-agent-ipv4-helper-address-config;
-	}
-
-	container state {
-	  config false;
-
-	  description
-	    "Operational state for IP helper address";
-
-	  uses relay-agent-ipv4-helper-address-config;
-	}
-      }
     }
   }
 
@@ -817,6 +864,7 @@ module openconfig-relay-agent {
 
         uses oc-if:interface-ref;
         uses agent-information-ipv4-interface-top;
+        uses helper-addresses-ipv4-top;
       }
     }
   }
@@ -848,44 +896,6 @@ module openconfig-relay-agent {
         is expected to forward DHCPv4/BOOTP requests to all listed
         server addresses when DHCPv6 relaying is enabled globally, or
         on the interface.";
-    }
-
-    container helper-addresses {
-      description
-        "Enclosing container for IPv6 helper addresses";
-      list helper-address {
-        key "address";
-        description
-          "List of IPv6 addresses of DHCP servers to which the
-           relay agent should forward DHCPv6 requests.  The relay agent
-           is expected to forward DHCPv4/BOOTP requests to all listed
-           server addresses when DHCPv6 relaying is enabled globally, or
-           on the interface.";
-
-        leaf address {
-          type leafref {
-            path "../config/address";
-          }
-          description
-            "Reference to list key representing IP helper address";
-        }
-
-        container config {
-          description
-            "Configuration data for IP helper address";
-
-          uses relay-agent-ipv6-helper-address-config;
-        }
-
-        container state {
-          config false;
-
-          description
-            "Operational state for IP helper address";
-
-          uses relay-agent-ipv6-helper-address-config;
-        }
-      }
     }
   }
 
@@ -948,6 +958,7 @@ module openconfig-relay-agent {
 
         uses oc-if:interface-ref;
         uses agent-options-ipv6-interface-top;
+        uses helper-addresses-ipv6-top;
       }
     }
   }

--- a/release/models/relay-agent/openconfig-relay-agent.yang
+++ b/release/models/relay-agent/openconfig-relay-agent.yang
@@ -8,7 +8,6 @@ module openconfig-relay-agent {
   prefix "oc-relay";
 
   // import some basic types
-  import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
   import openconfig-network-instance { prefix oc-ni; }
   import openconfig-interfaces { prefix oc-if; }
@@ -642,22 +641,21 @@ module openconfig-relay-agent {
       description
         "IP address to relay DHCP requests to";
     }
-
-    leaf source-address {
-      type union {
-        type inet:ipv4-address;
-        type oc-if:interface-id;
-      }
-      description
-        "IP address or interface whose IP address is to be used as source in
-	relayed DHCP requests";
-    }
-
     leaf network-instance {
       type oc-ni:network-instance-ref;
       description
         "The network instance that this DHCP Server
         is associated with";
+    }
+
+    leaf source-address {
+      type union {
+        type oc-inet:ipv4-address;
+        type oc-if:interface-id;
+      }
+      description
+        "IP address or interface whose IP address is to be used as source in
+	relayed DHCP requests";
     }
   }
 
@@ -671,21 +669,21 @@ module openconfig-relay-agent {
         "IPv6 address to relay DHCPv6 requests to";
     }
 
-    leaf source-address {
-      type union {
-        type inet:ipv6-address;
-        type oc-if:interface-id;
-      }
-      description
-        "IPv6 address or interface whose IPv6 address is to be used as source in
-	relayed DHCPv6 requests";
-    }
-
     leaf network-instance {
       type oc-ni:network-instance-ref;
       description
         "The network instance that this DHCP Server
         is associated with";
+    }
+
+    leaf source-address {
+      type union {
+        type oc-inet:ipv6-address;
+        type oc-if:interface-id;
+      }
+      description
+        "IPv6 address or interface whose IPv6 address is to be used as source in
+	relayed DHCPv6 requests";
     }
   }
 
@@ -697,7 +695,7 @@ module openconfig-relay-agent {
       description
         "Enclosing container for helper addresses";
       list helper-address {
-        key "address";
+        key "address network-instance";
         description
           "List of IPv4 addresses of DHCP servers to which the
           relay agent should forward DHCPv4 requests.  The relay agent is
@@ -712,6 +710,15 @@ module openconfig-relay-agent {
           description
             "Reference to list key representing IP helper address";
         }
+
+        leaf network-instance {
+          type leafref {
+            path "../config/network-instance";
+          }
+          description
+            "Reference to list key representing network instance";
+        }
+
 
         container config {
           description
@@ -740,7 +747,7 @@ module openconfig-relay-agent {
       description
         "Enclosing container for IPv6 helper addresses";
       list helper-address {
-        key "address";
+        key "address network-instance";
         description
           "List of IPv6 addresses of DHCP servers to which the
            relay agent should forward DHCPv6 requests.  The relay agent
@@ -754,6 +761,14 @@ module openconfig-relay-agent {
           }
           description
             "Reference to list key representing IP helper address";
+        }
+
+        leaf network-instance {
+          type leafref {
+            path "../config/network-instance";
+          }
+          description
+            "Reference to list key representing network instance";
         }
 
         container config {
@@ -794,7 +809,7 @@ module openconfig-relay-agent {
     }
 
     leaf-list helper-address {
-      type inet:ip-address;
+      type oc-inet:ip-address;
       status deprecated;
       description
         "List of IPv4 or IPv6 addresses of DHCP servers to which the
@@ -888,7 +903,7 @@ module openconfig-relay-agent {
     }
 
     leaf-list helper-address {
-      type inet:ipv6-address;
+      type oc-inet:ipv6-address;
       status deprecated;
       description
         "List of IPv6 addresses of DHCP servers to which the


### PR DESCRIPTION
This is a follow-up and update to #964  #951  . More context can be found there

### Change Scope

* Replace “helper-address” leaf-list with keyed list
* Update address type to be `oc:inet:host` to support ip and hostname configuration
* Add support for source-interface or source-address configuration 
* Add option to specify network-instance 
* This change is backwards compatible

### Platform Implementations

 * Arista: [ip helper-address](https://www.arista.com/en/um-eos/eos-ipv4#xx1144379) 



New tree (relevant changes):
```module: openconfig-relay-agent
  +--rw relay-agent
     +--rw dhcp
     |  +--rw interfaces
     |     +--rw interface* [id]
     |        +--rw id                          -> ../config/id
     |        +--rw config
     |        |  +--rw id?                 oc-if:interface-id
     |        |  +--rw enable?             boolean
     |        |  x--rw helper-address*     inet:ip-address
     |        |  +--rw helper-addresses
     |        |     +--rw helper-address* [address]
     |        |        +--rw address    -> ../config/address
     |        |        +--rw config
     |        |        |  +--rw address?            oc-inet:host
     |        |        |  +--rw local-address?      union
     |        |        |  +--rw network-instance?   oc-ni:network-instance-ref
     |        |        +--ro state
     |        |           +--ro address?            oc-inet:host
     |        |           +--ro local-address?      union
     |        |           +--ro network-instance?   oc-ni:network-instance-ref
     |        +--ro state
     |        |  +--ro id?                 oc-if:interface-id
     |        |  +--ro enable?             boolean
     |        |  x--ro helper-address*     inet:ip-address
     |        |  +--ro helper-addresses
     |        |  |  +--ro helper-address* [address]
     |        |  |     +--ro address    -> ../config/address
     |        |  |     +--ro config
     |        |  |     |  +--ro address?            oc-inet:host
     |        |  |     |  +--ro local-address?      union
     |        |  |     |  +--ro network-instance?   oc-ni:network-instance-ref
     |        |  |     +--ro state
     |        |  |        +--ro address?            oc-inet:host
     |        |  |        +--ro local-address?      union
     |        |  |        +--ro network-instance?   oc-ni:network-instance-ref
     +--rw dhcpv6
        +--rw interfaces
           +--rw interface* [id]
              +--rw id               -> ../config/id
              +--rw config
              |  +--rw id?                 oc-if:interface-id
              |  +--rw enable?             boolean
              |  x--rw helper-address*     inet:ipv6-address
              |  +--rw helper-addresses
              |     +--rw helper-address* [address]
              |        +--rw address    -> ../config/address
              |        +--rw config
              |        |  +--rw address?            oc-inet:host
              |        |  +--rw local-address?      union
              |        |  +--rw network-instance?   oc-ni:network-instance-ref
              |        +--ro state
              |           +--ro address?            oc-inet:host
              |           +--ro local-address?      union
              |           +--ro network-instance?   oc-ni:network-instance-ref
              +--ro state
              |  +--ro id?                 oc-if:interface-id
              |  +--ro enable?             boolean
              |  x--ro helper-address*     inet:ipv6-address
              |  +--ro helper-addresses
              |  |  +--ro helper-address* [address]
              |  |     +--ro address    -> ../config/address
              |  |     +--ro config
              |  |     |  +--ro address?            oc-inet:host
              |  |     |  +--ro local-address?      union
              |  |     |  +--ro network-instance?   oc-ni:network-instance-ref
              |  |     +--ro state
              |  |        +--ro address?            oc-inet:host
              |  |        +--ro local-address?      union
              |  |        +--ro network-instance?   oc-ni:network-instance-ref```


