### PR TITLE
Update openconfig-gnsi-acctz.yang

### DIFF
--- a/release/models/gnsi/openconfig-gnsi-acctz.yang
+++ b/release/models/gnsi/openconfig-gnsi-acctz.yang
@@ -10,9 +10,6 @@ module openconfig-gnsi-acctz {
   import openconfig-system-grpc {
     prefix oc-sys-grpc;
   }
-  import openconfig-types {
-    prefix oc-types;
-  }
   import openconfig-yang-types {
     prefix oc-yang;
   }
@@ -30,7 +27,14 @@ module openconfig-gnsi-acctz {
     "This module provides counters of gNSI accountZ requests and responses and
     the quantity of data transferred.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision 2024-10-07 {
+    description
+      "Remove `idle-timeouts` and `counters-last-cleared` leaves.
+      Relocate source-counters and client-counters to separate paths";
+    reference "0.3.0";
+  }
 
   revision 2024-02-13 {
     description
@@ -116,54 +120,52 @@ module openconfig-gnsi-acctz {
     description
       "A collection of counters that were collected by the gNSI.acctz
       module while servicing acctz clients.";
+    container state {
+        description
+          "Operational state relating to acctz-counters.";
 
-    container client-counters {
-      description
-        "A collection of counters that were collected by the gNSI.acctz
-        module while servicing acctz clients.";
-      leaf history-istruncated {
-        type oc-yang:counter64;
+      container counters {
         description
-          "The total number of times that a RecordRequest resulted in
-          a RecordResponse being marked history-istruncated.  ie: a
-          request was made for a timestamp that did not exist in the
-          history.";
-      }
-      leaf idle-timeouts {
-        type oc-yang:counter64;
-        description
-          "The total number of times that a client was disconnected
-          due to missing keepalives (ie: RecordRequests).";
-      }
-      leaf record-requests {
-        type oc-yang:counter64;
-        description
-          "The total number of RecordRequest RPCs that have been received.";
-      }
-      leaf record-responses {
-        type oc-yang:counter64;
-        description
-          "The total number of RecordResponse RPCs that have been sent.";
+          "A collection of counters that were collected by the gNSI.acctz
+          module while servicing acctz clients.";
+
+        leaf history-istruncated {
+          type oc-yang:counter64;
+          description
+            "The total number of times that a RecordRequest resulted in
+            a RecordResponse being marked history-istruncated. ie: a
+            request was made for a timestamp that did not exist in the
+            history.";
+        }
+        leaf record-requests {
+          type oc-yang:counter64;
+          description
+            "The total number of RecordRequest messages that have been received.";
+        }
+        leaf record-responses {
+          type oc-yang:counter64;
+          description
+            "The total number of RecordResponse messages that have been sent.";
+        }
       }
     }
   }
 
   // gnsi.acctz producer statistics
-  grouping source-counters {
+  grouping source-records {
     description
       "A collection of counters for gNSI.acctz record production per
       service request type.";
 
-    container source-counters {
+    container source-records {
       description
         "A collection of counters for gNSI.acctz record production per
         service request type.";
-      list source-records {
+      list source-record {
         key "service type";
         // unique "service type";
         description
-          "The total number of times the gNSI.authz module denied access
-          to a RPC.";
+          "A collection of counters for each service request type.";
 
         leaf service {
           type leafref {
@@ -194,11 +196,16 @@ module openconfig-gnsi-acctz {
             description
               "service request application enum for the gNSI.acctz record.";
           }
-          leaf records {
-            type oc-yang:counter64;
+
+          container counters {
             description
-              "The total number of records produced for the service-request
-              type.";
+              "A collection of counters for gNSI.acctz record production per
+              service-type.";
+            leaf records {
+              type oc-yang:counter64;
+              description
+                "The total number of records produced for the service-type.";
+            }
           }
         }
       }
@@ -207,30 +214,26 @@ module openconfig-gnsi-acctz {
 
   grouping grpc-server-acctz-counters {
     description
-      "A collection of counters from the gNSI.acctz module.";
+      "A collection of counters from the gNSI.acctz module that exist per grpc server.";
 
-    container acctz-counters {
+    container acctz {
       config false;
       description
-        "A collection of counters from the gNSI.acctz module
-        for acctz clients and sources.";
+        "A collection of counters from the gNSI.acctz module that exist
+        per grpc server.";
+      uses client-counters;
+    }
+  }
 
-      container state {
-        description
-          "Operational state relating to acctz-counters.";
+  grouping system-acctz-counters {
+    description
+      "A collection of counters from the gNSI.acctz module.";
 
-        leaf counters-last-cleared {
-          type oc-types:timeticks64;
-          description
-            "The last time that the counters were cleared (reset to
-            zero). This value is reported as nanoseconds since epoch
-            (January 1st, 1970 00:00:00 GMT).";
-        }
-
-        uses client-counters;
-      }
-
-      uses source-counters;
+    container acctz {
+      config false;
+      description
+        "A collection of counters regarding the creation of gNSI.acctz records.";
+      uses source-records;
     }
   }
 
@@ -238,8 +241,15 @@ module openconfig-gnsi-acctz {
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
     when "config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
     description
-      "Counters collected by the gNSI.acctz module.";
+      "Counters collected by the gNSI.acctz module regarding grpc servers.";
 
     uses grpc-server-acctz-counters;
+  }
+
+  augment "/oc-sys:system/oc-sys:aaa/oc-sys:accounting" {
+    description
+      "Counters collected by the gNSI.acctz module regarding the system.";
+
+    uses system-acctz-counters;
   }
 }


### PR DESCRIPTION
* Delete idle-timeouts and counters-last-cleared leaves
* Split source-counters and client-counters to be under separate augments

### Change Scope

* https://github.com/openconfig/gnsi/blob/main/acctz/gnsi-acctz.yang has received updates that are not in openconfig/public. In particular, the `idle-timeouts` and `counters-last-cleared` leaves have been deleted. This PR will bring those changes into openconfig/public

* source-counters should not be under the `grpc-server` list since they cannot be associated to a specific grpc-server. Instead create another augment so source-counters are on a different path than client-counters

* Address typo in the `source-records` list description

* This change is not backwards compatible

**pyang output:**
```
module: openconfig-gnsi-acctz

  augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server:
    +--ro acctz
       +--ro state
          +--ro counters
             +--ro history-istruncated?   oc-yang:counter64
             +--ro record-requests?       oc-yang:counter64
             +--ro record-responses?      oc-yang:counter64
  augment /oc-sys:system/oc-sys:aaa/oc-sys:accounting:
    +--ro acctz
       +--ro source-records
          +--ro source-record* [service type]
             +--ro service    -> ../state/service
             +--ro type       -> ../state/type
             +--ro state
                +--ro service?    service-request
                +--ro type?       service-type
                +--ro counters
                   +--ro records?   oc-yang:counter64
```


### Platform Implementations

None
