### PR TITLE
Add status flags for transceiver host lanes and media channels

### DIFF
--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,21 +66,27 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.15.0";
+  oc-ext:openconfig-version "0.16.0";
 
-revision "2024-09-21" {
+  revision "2024-10-09" {
+    description
+      "Add status flags for transceiver host lanes and media channels.";
+    reference "0.16.0";
+  }
+
+  revision "2024-09-21" {
     description
       "Clearly define how physical channel power leaves are used.";
     reference "0.15.0";
   }
 
-revision "2023-08-30" {
+  revision "2023-08-30" {
     description
       "Clarify transceiver module threshold for input-power.";
     reference "0.14.0";
   }
 
-revision "2023-08-30" {
+  revision "2023-08-30" {
     description
       "Add transceiver module temperature thresholds";
     reference "0.13.0";
@@ -407,6 +413,29 @@ revision "2023-08-30" {
       uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
     }
 
+    leaf tx-failure {
+      type boolean;
+      description
+        "Transmitter failure flag.
+        In earlier standards, including SFF-8436, SFF-8472, and QSFP-DD CMIS 4.0,
+        this flag was named Tx Fault.";
+      reference "QSFP-DD CMIS 5.0 Table 8-77, SFF-8472 Table 9-11, SFF-8436 Table 19";
+    }
+
+    leaf rx-los {
+      type boolean;
+      description
+        "Receiver loss-of-signal flag.";
+      reference "QSFP-DD CMIS 5.0 Table 8-78, SFF-8472 Table 9-11, SFF-8436 Table 19";
+    }
+
+    leaf rx-cdr-lol {
+      type boolean;
+      description
+        "Receiver clock-and-data-recovery loss-of-lock flag.";
+      reference "QSFP-DD CMIS 5.0 Table 8-78";
+    }
+
     uses output-optical-frequency;
     uses optical-power-state;
   }
@@ -450,6 +479,83 @@ revision "2023-08-30" {
 
           uses physical-channel-config;
           uses physical-channel-state;
+        }
+      }
+    }
+  }
+
+  grouping host-lane-config {
+    description
+      "Configuration data for electrical host lanes.";
+
+    leaf lane-number {
+      type uint8 {
+        range 1..max;
+      }
+      description
+        "Number identifying an electrical host lane carrying one serial
+        signal.  Lanes are numbered starting with 1.";
+      reference "CMIS 5.0 section 2.3.4";
+    }
+  }
+
+  grouping host-lane-state {
+    description
+      "Operational state data for electrical host lanes.";
+
+    leaf tx-los {
+      type boolean;
+      description
+        "Transmitter loss-of-signal flag.";
+      reference "CMIS 5.0 Table 8-77, SFF-8436 Table 19";
+    }
+
+    leaf tx-cdr-lol {
+      type boolean;
+      description
+        "Transmitter clock-and-data-recovery loss-of-lock flag.";
+      reference "CMIS 5.0 Table 8-77";
+    }
+  }
+
+  grouping host-lane-top {
+    description
+      "Top-level grouping for electrical host lanes.";
+
+    container host-lanes {
+      description
+        "Enclosing container for host lanes.";
+
+      list lane {
+        key "lane-number";
+        description
+          "List of electrical host lanes, keyed by lane number.
+          The host lanes of a transceiver constitute its electrical interface
+          with the host system.";
+        reference "CMIS 5.0 section 4.1";
+
+        leaf lane-number {
+          type leafref {
+            path "../config/lane-number";
+          }
+          description
+            "Reference to the host lane number.";
+        }
+
+        container config {
+          description
+            "Configuration data for host lanes.";
+
+          uses host-lane-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for host lanes.";
+
+          uses host-lane-config;
+          uses host-lane-state;
         }
       }
     }
@@ -926,6 +1032,7 @@ revision "2023-08-30" {
       // physical channels are associated with a transceiver
       // component
       uses physical-channel-top;
+      uses host-lane-top;
       uses transceiver-threshold-top;
     }
   }


### PR DESCRIPTION
### Change Scope

* This change adds leaf nodes for several status flags defined in the CMIS spec.  Some of them are also defined in the earlier specs for management interfaces of SFP+ and QSFP+ modules.
* Some of the flags are specific to media channels.  They are defined in 
  the existing list `/components/component/transceiver/physical-channels/channel`.
* Other flags are specific to electrical host lanes.  This change adds a new list `/components/component/transceiver/host-lanes/lane` to hold them, analogous to `physical-channels/channel`.
* This change is backwards compatible.

### Tree View

(including the unchanged beginning of the channel list, for context)

```diff
--- oldtree.txt 2024-10-08 23:58:55.826051270 +0000
+++ newtree.txt 2024-10-08 23:54:19.131792033 +0000
@@ -79,7 +79,7 @@
        |     +--ro interval?   oc-types:stat-interval
        |     +--ro min-time?   oc-types:timeticks64
        |     +--ro max-time?   oc-types:timeticks64
        +--rw physical-channels
        |  +--rw channel* [index]
        |     +--rw index     -> ../config/index
        |     +--rw config
@@ -119,6 +119,9 @@
        |        |  +--ro interval?   oc-types:stat-interval
        |        |  +--ro min-time?   oc-types:timeticks64
        |        |  +--ro max-time?   oc-types:timeticks64
+       |        +--ro tx-failure?                   boolean
+       |        +--ro rx-los?                       boolean
+       |        +--ro rx-cdr-lol?                   boolean
        |        +--ro output-frequency?             oc-opt-types:frequency-type
        |        +--ro output-power
        |        |  +--ro instant?    decimal64
@@ -144,6 +147,15 @@
        |           +--ro interval?   oc-types:stat-interval
        |           +--ro min-time?   oc-types:timeticks64
        |           +--ro max-time?   oc-types:timeticks64
+       +--rw host-lanes
+       |  +--rw lane* [lane-number]
+       |     +--rw lane-number    -> ../config/lane-number
+       |     +--rw config
+       |     |  +--rw lane-number?   uint8
+       |     +--ro state
+       |        +--ro lane-number?   uint8
+       |        +--ro tx-los?        boolean
+       |        +--ro tx-cdr-lol?    boolean
        +--rw thresholds
           +--ro threshold* [severity]
              +--ro severity    -> ../state/severity
```

### Platform Implementations

 * Reference [Arista EOS](https://www.arista.com/en/um-eos/eos-ethernet-ports#unique_865768927)

```
switch#show transceiver status interface Ethernet34/1
Current System Time: Wed Oct  9 17:59:11 2024
                                Current State        Changes       Last Change
                                -------------        -------       -----------
Port 34
  Transceiver                   400GBASE-FR4               1       0:54:09 ago
[...]
Ethernet34/1
  Operational speed             400Gbps
  RX LOS
    Channel 1                   ok                         4       0:52:21 ago
    Channel 2                   ok                         4       0:52:21 ago
    Channel 3                   ok                         4       0:52:21 ago
    Channel 4                   ok                         4       0:52:21 ago
  TX fault
    Channel 1                   ok                         0       never
    Channel 2                   ok                         0       never
    Channel 3                   ok                         0       never
    Channel 4                   ok                         0       never
  RX CDR LOL
    Channel 1                   ok                         4       0:52:21 ago
    Channel 2                   ok                         4       0:52:21 ago
    Channel 3                   ok                         4       0:52:21 ago
    Channel 4                   ok                         4       0:52:21 ago
[...]
  TX LOS
    Host lane 1                 ok                         0       never
    Host lane 2                 ok                         0       never
    Host lane 3                 ok                         0       never
    Host lane 4                 ok                         0       never
    Host lane 5                 ok                         0       never
    Host lane 6                 ok                         0       never
    Host lane 7                 ok                         0       never
    Host lane 8                 ok                         0       never
  TX CDR LOL
    Host lane 1                 ok                         0       never
    Host lane 2                 ok                         0       never
    Host lane 3                 ok                         0       never
    Host lane 4                 ok                         0       never
    Host lane 5                 ok                         0       never
    Host lane 6                 ok                         0       never
    Host lane 7                 ok                         0       never
    Host lane 8                 ok                         0       never
```