### PR TITLE
Add encapsulation header types referenced from AFT module.

### DIFF
--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -99,6 +99,14 @@ module openconfig-aft-types {
         description
           "The encapsulation header is UDP packet header.";
       }
+      enum UDPV4 {
+        description
+          "The encapsulation header is UDP packet header followed by IPv4 packet header.";
+      }
+      enum UDPV6 {
+        description
+          "The encapsulation header is UDP packet header followed by IPv6 packet header.";
+      }
     }
     description
       "Types of tunnel encapsulation that are supported by systems as either

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.2.1";
+
+  revision "2024-10-21" {
+    description
+        "Add UDPV4 and UDPV6 enums to encapsualtion header types.";
+      reference "1.2.1";
+  }
 
   revision "2024-07-18" {
     description


### PR DESCRIPTION
### Change Scope

* These encapsulation header types were referenced in openconfig-aft-common.yang but were not defined.