### PR TITLE
Add ISIS single-topology metric leaf under interface level config

### DIFF
--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -718,6 +718,12 @@ module openconfig-isis {
       description
         "ISIS neighbor priority(LAN hello PDU only).";
     }
+
+    leaf metric {
+      type uint32;
+      default 10;
+      description "ISIS single-topology metric value(default=10).";
+    }
   }
 
   grouping isis-hello-timers-config {


### PR DESCRIPTION
### Change Scope

Add ISIS single-topology metric leaf under interface/level:
- /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/config/metric
- /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/state/metric

### Rationale

Currently, the ISIS metric can only be defined per Address Family under isis interface/level. This is not a problem for ISIS multi-topology but becomes an issue when an ISIS single-topology is used and an interface has only IPv6 AF configured. In most implementations today the IPv6 ISIS metric is ignored in ISIS single-topology mode. Instead, one has to configure  IPv4 AF metric even for interfaces without IPV4 AF configured/enabled.

```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw interfaces
                    +--rw interface* [interface-id]
                       +--rw levels
                          +--rw level* [level-number]
                             +--rw config
                                +--rw level-number?   oc-isis-types:level-number
                                +--rw passive?        boolean
                                +--rw priority?       uint8
                                +--rw metric?         uint32    <<< new
                                +--rw enabled?        boolean
```
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw interfaces
                    +--rw interface* [interface-id]
                       +--rw levels
                          +--rw level* [level-number]
                             +--ro state
                                +--ro level-number?   oc-isis-types:level-number
                                +--ro passive?        boolean
                                +--ro priority?       uint8
                                +--ro metric?         uint32    <<< new
                                +--ro enabled?        boolean
```

This change is backwards compatible

### Platform Implementations

[From Juniper ISIS metric reference](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/metric-edit-protocols-isis.html) and [Juniper ISIS multi-topology reference](https://www.juniper.net/documentation/us/en/software/junos/is-is/topics/example/isis-ipv6-unicast-multitopology.html)
```
isis {
    level 2 wide-metrics-only;
    interface ae2.0 {
        level 2 metric 100;
    }
}
```
[From Arista ISIS config guide](https://www.arista.com/en/um-eos/eos-is-is)
```
switch(config)# interface ethernet 5
switch(config-if-Et5)# isis metric 30
switch(config-if-Et5)#

switch(config)# interface Ethernet 5
switch(config-if-Et5)# isis ipv6 metric 30
switch(config-if-Et5)#
```
[IOS XR Configuring Single Topology for IS-IS](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/configuration/guide/rc40xr12k_chapter3.html#task_1189544)