### PR TITLE
Remove unused config container under /system/alarms mislabeled as config=false

### DIFF
--- a/release/models/system/openconfig-alarms.yang
+++ b/release/models/system/openconfig-alarms.yang
@@ -44,7 +44,7 @@ module openconfig-alarms {
 
   oc-ext:openconfig-version "0.4.0";
 
-  revision "2024-11-01" {
+  revision "2025-11-11" {
     description
       "Remove empty config container under 'config false' hierarchy.";
     reference "0.4.0";


### PR DESCRIPTION
  * (M) release/models/system/openconfig-alarms.yang
    - Remove config container and retain entire hierarchy for alarms as
      read-only

### Change Scope

The current published `/system/alarms` hierarchy is tagged as read-only however
a config container grouping was introduced to follow common OC style.  This
config container inherited the r/o attributes of it's parent as a result.

We have a few options here:

1. Move config=false down to the `state` container and leave the entire list as
   r/w potentially accomodating future configuration (There could potentially
   be some attributes that you could tag an ID with in some implementations to
   suppress, change behavior, etc..)
2. Keep the entire hierarchy as config=false and thus remove any possibility
   for configuration.  This is similar to other hierarchies such as `/system/cpus`

### Platform Implementations

N/A: Bug
