### PR TITLE
Add FAN_TRAY_CONTROLLER type.

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,8 +22,14 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.8.0";
+  oc-ext:openconfig-version "1.9.0";
 
+
+  revision "2024-11-04" {
+    description
+      "Add FAN_TRAY_CONTROLLER";
+    reference "1.9.0";
+  }
 
   revision "2024-04-30" {
     description
@@ -337,6 +343,12 @@ module openconfig-platform-types {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
       "Contains multiple fans that work in unison to cool the router components.";
+  }
+
+  identity FAN_TRAY_CONTROLLER {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "Controls the fan trays.";
   }
 
   identity SENSOR {


### PR DESCRIPTION
### Change Scope

* Adding a component type for fan tray controller components.
* This change is backwards compatible.

### Platform Implementations

 * Implementation A: 
   * https://www.juniper.net/documentation/us/en/hardware/ptx10008/topics/topic-map/ptx10008-cooling-system.html
   * On Juniper ptx10008 devices, these components have a type of FRU, have a state/parent of the chassis, and have no child components. This means we cannot infer their type from OpenConfig telemetry unless we parse the component name, which is not stable.
   * Juniper ptx10008 have two fan tray controller components, for example `openconfig/components/component/FTC0/state/type, FRU` and `openconfig/components/component/FTC1/state/type, FRU`
 * Implementation B: 
    * Cisco CRS https://www.cisco.com/c/en/us/td/docs/iosxr/crs/hardware-install/crs-1/4-slot/system-description/b-crs-crs1-4-slot-line-card-chassis-system-description/b-crs-crs1-4-slot-line-card-chassis-system-description_chapter_011.pdf