### PR TITLE
Add set-as-path-prepend/use-last-as

### DIFF
--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -28,7 +28,13 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "8.0.0";
+  oc-ext:openconfig-version "8.1.0";
+
+  revision "2024-11-13" {
+    description
+      "Add use-last-as leaf to set-as-path-prepend to prepend last AS.";
+    reference "8.1.0";
+  }
 
   revision "2024-08-23" {
     description
@@ -920,9 +926,19 @@ module openconfig-bgp-policy {
     leaf asn {
       type oc-inet:as-number;
       description
-        "The AS number to prepend to the AS path. If this leaf is
-        not specified and repeat-n is set, then the local AS
-        number will be used for prepending.";
+        "The AS number to prepend to the AS path. If neither this
+        leaf nor use-last-as leaf is specified but repeat-n is set, then
+        the local AS number will be used for prepending.";
+    }
+
+    leaf use-last-as {
+      type boolean;
+      description
+        "Indicates whether to use the last AS number, which is also the
+        most recent AS number, to prepend to the AS path.
+        If neither this leaf nor asn leaf is specified
+        but repeat-n is set, then the local AS number will be
+        used for prepending.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* Add set-as-path-prepend/use-last-as to allow prepending last AS to the path.
* This change is backwards compatible.

### Platform Implementations

 * Implementation A: CiscoXR [prepend as-path most-recent](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-0/routing/command/reference/rr40crs1book_chapter8.html#wp1928320454).
 * Implementation B: Arista routemap [set as-path prepend last-as](https://www.arista.com/en/um-eos/eos-acls-and-route-maps#xx1325439).

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].

New paths added:

```
+ /openconfig-routing-policy:routing-policy/policy-definitions/policy-definition/statements/statement/actions/openconfig-bgp-policy:bgp-actions/set-as-path-prepend/config/use-last-as
+ /openconfig-routing-policy:routing-policy/policy-definitions/policy-definition/statements/statement/actions/openconfig-bgp-policy:bgp-actions/set-as-path-prepend/state/use-last-as
```
