### PR TITLE
Clarify that if no rules are present, no packets will be matched.

### DIFF
--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -62,11 +62,14 @@ module openconfig-policy-forwarding {
 
     A forwarding-policy specifies the match criteria that it intends
     to use to determine the packets that it reroutes - this may
-    consist of a number of criteria, such as DSCP. The action of the
-    policy results in a forwarding action being applied to matching
-    packets. For example, decapsulating the packet from a GRE header.
-    In order to enact the policy based on particular interfaces - the
-    forwarding-policy is applied to an interface via referencing it
+    consist of a number of criteria, such as DSCP. The match criteria
+    is specified as rules.  If no rules are specified, then the policy
+    will not match any packets.
+
+    The action of the policy results in a forwarding action being applied
+    to matching packets. For example, decapsulating the packet from a GRE
+    header. In order to enact the policy based on particular interfaces -
+    the forwarding-policy is applied to an interface via referencing it
     within an 'apply-forwarding-policy' statement associated with an
     interface.
 
@@ -81,7 +84,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2024-11-14" {
+    description
+      "Clarify that if no rules are present, no packets will be matched.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description


### PR DESCRIPTION
### Change Scope
* Clarify policy-forwarding such that if no rules are present, no packets will be matched    
