### PR TITLE
Add policy-forwarding network-instance attachment point

### DIFF
--- a/release/models/policy-forwarding/.spec.yml
+++ b/release/models/policy-forwarding/.spec.yml
@@ -1,10 +1,8 @@
-- name: openconfig-network-instance-srte-policy
+- name: openconfig-policy-forwarding
   docs:
-    - yang/network-instance/openconfig-network-instance-types.yang
-    - yang/network-instance/openconfig-network-instance.yang
-    - yang/policy-forwarding/openconfig-pf-network-instances.yang
-  build:
-    - yang/network-instance/openconfig-network-instance.yang
     - yang/policy-forwarding/openconfig-pf-srte.yang
-    - yang/policy-forwarding/openconfig-pf-network-instances.yang
+    - yang/policy-forwarding/openconfig-policy-forwarding.yang
+  build:
+    - yang/policy-forwarding/openconfig-pf-srte.yang
+    - yang/policy-forwarding/openconfig-policy-forwarding.yang
   run-ci: true

--- a/release/models/policy-forwarding/.spec.yml
+++ b/release/models/policy-forwarding/.spec.yml
@@ -2,7 +2,9 @@
   docs:
     - yang/network-instance/openconfig-network-instance-types.yang
     - yang/network-instance/openconfig-network-instance.yang
+    - yang/policy-forwarding/openconfig-pf-network-instances.yang
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/policy-forwarding/openconfig-pf-srte.yang
+    - yang/policy-forwarding/openconfig-pf-network-instances.yang
   run-ci: true

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2024-11-26" {
+    description
+      "Add network-instance as an attachment point.";
+    reference "0.8.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,13 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2024-11-26" {
+    description
+      "Add network-instance as an attachment point.";
+    reference "0.8.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-network-instances.yang
+++ b/release/models/policy-forwarding/openconfig-pf-network-instances.yang
@@ -18,7 +18,7 @@ submodule openconfig-pf-network-instances {
   description
     "This submodule contains groupings to attach
      a policy-forwarding policy to one or more network-instances.
-     
+
      When attached to a network-instance, the policy-forwarding rules
      should be evaluated against packets in the specified
      network-instances.";
@@ -121,10 +121,10 @@ submodule openconfig-pf-network-instances {
       }
       description
         "Apply the specific VRF selection policy on the network-instance.
-         
+
          The referenced policy MUST be of the type VRF_SELECTION_POLICY.
          The VRF selection policy may coexist with a policy-forwarding policy.
-         
+
          The policy specified in this leaf is used to specifically choose the
          L3VRF network instance that is used for specific input criteria of
          packets.";

--- a/release/models/policy-forwarding/openconfig-pf-network-instances.yang
+++ b/release/models/policy-forwarding/openconfig-pf-network-instances.yang
@@ -3,10 +3,9 @@ submodule openconfig-pf-network-instances {
     prefix "oc-pf";
   }
 
-  import openconfig-extensions { prefix "oc-ext"; }
-  import openconfig-interfaces { prefix "oc-if"; }
-  import openconfig-network-instance { prefix "oc-ni"; }
-
+  import openconfig-extensions {
+    prefix "oc-ext";
+  }
   include openconfig-pf-forwarding-policies;
 
   organization
@@ -14,104 +13,42 @@ submodule openconfig-pf-network-instances {
 
   contact
     "OpenConfig working group
-    www.openconfig.net";
+     www.openconfig.net";
 
   description
     "This submodule contains groupings to attach
-    a policy-forwarding policy to one or more network-instances.
-    
-    When attached to a network-instance, the policy-forwarding rules
-    should be evaluated against packets in the specified
-    network-instances.";
+     a policy-forwarding policy to one or more network-instances.
+     
+     When attached to a network-instance, the policy-forwarding rules
+     should be evaluated against packets in the specified
+     network-instances.";
 
   oc-ext:openconfig-version "0.8.0";
 
-  revision "2024-11-15" {
+  revision "2024-11-26" {
     description
       "Add network-instance as an attachment point.";
-    reference "0.8.0";
+    reference
+      "0.8.0";
   }
 
-  revision "2024-11-14" {
-    description
-      "Clarify that if no rules are present, no packets will be matched.";
-    reference "0.7.0";
-  }
-
-  revision "2023-04-25" {
-    description
-      "Clarify use of interface-ref.";
-    reference "0.6.1";
-  }
-
-  revision "2023-03-27" {
-    description
-      "Add support for decap in one NI and further actions in other NIs.";
-    reference "0.6.0";
-  }
-
-  revision "2022-01-25" {
-    description
-      "Add GUE and MPLS-in-UDP decapsulation actions.";
-    reference "0.5.0";
-  }
-
-  revision "2021-08-06" {
-    description
-      "Update path to the network instance action to allow references
-      to other NIs.";
-    reference "0.4.0";
-  }
-
-  revision "2021-05-19" {
-    description
-      "Add a VRF selection policy type, and means to apply the
-      policy.";
-    reference "0.3.0";
-  }
-
-  revision "2018-11-21" {
-    description
-      "Add OpenConfig module metadata extensions.";
-    reference "0.2.1";
-  }
-
-  revision "2017-06-21" {
-    description
-      "Amend policy forwarding model based on ACL changes.";
-    reference "0.2.0";
-  }
-
-  revision "2017-02-28" {
-    description
-      "Initial public release of policy forwarding.";
-    reference "0.1.0";
-  }
-
-  revision "2016-11-08" {
-    description
-      "Initial revision";
-    reference "0.0.1";
-  }
-
-
-  grouping pf-network-instance-structural {
+  grouping pf-network-instances-structural {
     description
       "Structural grouping for network-instances to forwarding policy
-      bindings within the policy-forwarding model.";
+       bindings within the policy-forwarding model.";
 
     container network-instances {
       description
         "Configuration and operational state relating policy
-        forwarding on interfaces.";
+         forwarding on interfaces.";
 
       list network-instance {
-        key "network-instance-id";
+        key "name";
 
         description
           "Configuration and operationals state relating to the
-          relationship between network-instances and policy-based
-          forwarding rules.";
+           relationship between network-instances and policy-based
+           forwarding rules.";
 
         leaf name {
           type leafref {
@@ -119,13 +56,13 @@ submodule openconfig-pf-network-instances {
           }
           description
             "A reference to the name of the network-instance
-            being referenced by the policy.";
+             being referenced by the policy.";
         }
 
         container config {
           description
-            "Configuration parameters relating to an network-instance to
-            policy forwarding rule binding.";
+            "Configuration parameters relating to a network-instance to
+             policy forwarding rule binding.";
 
           uses pf-network-instance-config;
         }
@@ -133,13 +70,11 @@ submodule openconfig-pf-network-instances {
         container state {
           config false;
           description
-            "Operational state parameters relating to an interface to
-            policy forwarding rule binding.";
+            "Operational state parameters relating to a network-instance to
+             policy forwarding rule binding.";
 
           uses pf-network-instance-config;
         }
-
-        uses oc-if:interface-ref;
       }
     }
   }
@@ -147,11 +82,15 @@ submodule openconfig-pf-network-instances {
   grouping pf-network-instance-config {
     description
       "Configuration parameters relating to an interface to policy
-      forwarding rule binding.";
-
+       forwarding rule binding.";
 
     leaf name {
-      type oc-ni:network-instance-ref;
+      type leafref {
+        path "/network-instances/network-instance/" +
+           "config/name";
+//        path "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+//           "oc-netinst:config/oc-netinst:name";
+      }
       description
         "A unique identifier for the network-instance.";
     }
@@ -159,18 +98,18 @@ submodule openconfig-pf-network-instances {
     leaf apply-forwarding-policy {
       type leafref {
         // We are at /network-instances/network-instance/
-        // policy-forwarding/interfaces/interface/config/
+        // policy-forwarding/network-instances/network-instance/config/
         // apply-forwarding-policy
         path "../../../../policies/policy/config/policy-id";
       }
       description
         "The policy to be applied on the network-instance. Packets ingress
-        on the referenced interface should be compared to the match
-        criteria within the specified policy, and in the case that
-        these criteria are met, the forwarding actions specified
-        applied. These policies should be applied following quality of
-        service classification, and ACL actions if such entities are
-        referenced by the corresponding interface.";
+         on the referenced interface should be compared to the match
+         criteria within the specified policy, and in the case that
+         these criteria are met, the forwarding actions specified
+         applied. These policies should be applied following quality of
+         service classification, and ACL actions if such entities are
+         referenced by the corresponding interface.";
     }
 
     leaf apply-vrf-selection-policy {
@@ -182,13 +121,13 @@ submodule openconfig-pf-network-instances {
       }
       description
         "Apply the specific VRF selection policy on the network-instance.
-
-        The referenced policy MUST be of the type VRF_SELECTION_POLICY.
-        The VRF selection policy may coexist with a policy-forwarding policy.
-
-        The policy specified in this leaf is used to specifically choose the
-        L3VRF network instance that is used for specific input criteria of
-        packets.";
+         
+         The referenced policy MUST be of the type VRF_SELECTION_POLICY.
+         The VRF selection policy may coexist with a policy-forwarding policy.
+         
+         The policy specified in this leaf is used to specifically choose the
+         L3VRF network instance that is used for specific input criteria of
+         packets.";
     }
   }
 }

--- a/release/models/policy-forwarding/openconfig-pf-network-instances.yang
+++ b/release/models/policy-forwarding/openconfig-pf-network-instances.yang
@@ -1,0 +1,194 @@
+submodule openconfig-pf-network-instances {
+  belongs-to openconfig-policy-forwarding {
+    prefix "oc-pf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  include openconfig-pf-forwarding-policies;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains groupings to attach
+    a policy-forwarding policy to one or more network-instances.
+    
+    When attached to a network-instance, the policy-forwarding rules
+    should be evaluated against packets in the specified
+    network-instances.";
+
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2024-11-15" {
+    description
+      "Add network-instance as an attachment point.";
+    reference "0.8.0";
+  }
+
+  revision "2024-11-14" {
+    description
+      "Clarify that if no rules are present, no packets will be matched.";
+    reference "0.7.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.6.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add support for decap in one NI and further actions in other NIs.";
+    reference "0.6.0";
+  }
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
+
+  revision "2021-05-19" {
+    description
+      "Add a VRF selection policy type, and means to apply the
+      policy.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Amend policy forwarding model based on ACL changes.";
+    reference "0.2.0";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Initial public release of policy forwarding.";
+    reference "0.1.0";
+  }
+
+  revision "2016-11-08" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+
+  grouping pf-network-instance-structural {
+    description
+      "Structural grouping for network-instances to forwarding policy
+      bindings within the policy-forwarding model.";
+
+    container network-instances {
+      description
+        "Configuration and operational state relating policy
+        forwarding on interfaces.";
+
+      list network-instance {
+        key "network-instance-id";
+
+        description
+          "Configuration and operationals state relating to the
+          relationship between network-instances and policy-based
+          forwarding rules.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "A reference to the name of the network-instance
+            being referenced by the policy.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to an network-instance to
+            policy forwarding rule binding.";
+
+          uses pf-network-instance-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to an interface to
+            policy forwarding rule binding.";
+
+          uses pf-network-instance-config;
+        }
+
+        uses oc-if:interface-ref;
+      }
+    }
+  }
+
+  grouping pf-network-instance-config {
+    description
+      "Configuration parameters relating to an interface to policy
+      forwarding rule binding.";
+
+
+    leaf name {
+      type oc-ni:network-instance-ref;
+      description
+        "A unique identifier for the network-instance.";
+    }
+
+    leaf apply-forwarding-policy {
+      type leafref {
+        // We are at /network-instances/network-instance/
+        // policy-forwarding/interfaces/interface/config/
+        // apply-forwarding-policy
+        path "../../../../policies/policy/config/policy-id";
+      }
+      description
+        "The policy to be applied on the network-instance. Packets ingress
+        on the referenced interface should be compared to the match
+        criteria within the specified policy, and in the case that
+        these criteria are met, the forwarding actions specified
+        applied. These policies should be applied following quality of
+        service classification, and ACL actions if such entities are
+        referenced by the corresponding interface.";
+    }
+
+    leaf apply-vrf-selection-policy {
+      type leafref {
+        // We are at /network-instances/network-instance/
+        // policy-forwarding/network-instances/network-instance/config/
+        // apply-vrf-selection-policy
+        path "../../../../policies/policy/config/policy-id";
+      }
+      description
+        "Apply the specific VRF selection policy on the network-instance.
+
+        The referenced policy MUST be of the type VRF_SELECTION_POLICY.
+        The VRF selection policy may coexist with a policy-forwarding policy.
+
+        The policy specified in this leaf is used to specifically choose the
+        L3VRF network instance that is used for specific input criteria of
+        packets.";
+    }
+  }
+}

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,13 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2024-11-26" {
+    description
+      "Add network-instance as an attachment point.";
+    reference "0.8.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -84,7 +84,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2024-11-15" {
+    description
+      "Add network-instance as an attachment point.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -11,6 +11,7 @@ module openconfig-policy-forwarding {
   include openconfig-pf-forwarding-policies;
   include openconfig-pf-path-groups;
   include openconfig-pf-interfaces;
+  include openconfig-pf-network-instances;
 
   organization
     "OpenConfig working group";
@@ -64,7 +65,7 @@ module openconfig-policy-forwarding {
     to use to determine the packets that it reroutes - this may
     consist of a number of criteria, such as DSCP. The match criteria
     is specified as rules.  If no rules are specified, then the policy
-    will not match any packets.
+    will match all packets.
 
     The action of the policy results in a forwarding action being applied
     to matching packets. For example, decapsulating the packet from a GRE
@@ -86,7 +87,7 @@ module openconfig-policy-forwarding {
 
   oc-ext:openconfig-version "0.8.0";
 
-  revision "2024-11-15" {
+  revision "2024-11-26" {
     description
       "Add network-instance as an attachment point.";
     reference "0.8.0";
@@ -170,6 +171,7 @@ module openconfig-policy-forwarding {
 
       uses pf-forwarding-policy-structural;
       uses pf-interfaces-structural;
+      uses pf-network-instances-structural;
       uses pf-path-groups-structural;
     }
   }

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -62,11 +62,14 @@ module openconfig-policy-forwarding {
 
     A forwarding-policy specifies the match criteria that it intends
     to use to determine the packets that it reroutes - this may
-    consist of a number of criteria, such as DSCP. The action of the
-    policy results in a forwarding action being applied to matching
-    packets. For example, decapsulating the packet from a GRE header.
-    In order to enact the policy based on particular interfaces - the
-    forwarding-policy is applied to an interface via referencing it
+    consist of a number of criteria, such as DSCP. The match criteria
+    is specified as rules.  If no rules are specified, then the policy
+    will not match any packets.
+
+    The action of the policy results in a forwarding action being applied
+    to matching packets. For example, decapsulating the packet from a GRE
+    header. In order to enact the policy based on particular interfaces -
+    the forwarding-policy is applied to an interface via referencing it
     within an 'apply-forwarding-policy' statement associated with an
     interface.
 
@@ -81,7 +84,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2024-11-14" {
+    description
+      "Clarify that if no rules are present, no packets will be matched.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description


### PR DESCRIPTION
### Change Scope

Today policy-forwarding policies can only be attached to interfaces.  This change adds network-instance as an attachment point for policy-forwarding rules.  This causes packets in the specified network-instance to be evaluated against the specified policy-forwarding rules and actions.

This change is backwards compatible.
## Tree diff view
We are at:
`/network-instances/network-instance/policy-forwarding/`

```diff
         |  +--rw interfaces
         |  |  +--rw interface* [interface-id]
         |  |     +--rw interface-id     -> ../config/interface-id
         |  |     +--rw config
         |  |     |  +--rw interface-id?                 oc-if:interface-id
         |  |     |  +--rw apply-forwarding-policy?      -> ../../../../policies/policy/config/policy-id
         |  |     |  +--rw apply-vrf-selection-policy?   -> ../../../../policies/policy/config/policy-id
         |  |     +--ro state
         |  |     |  +--ro interface-id?                 oc-if:interface-id
         |  |     |  +--ro apply-forwarding-policy?      -> ../../../../policies/policy/config/policy-id
         |  |     |  +--ro apply-vrf-selection-policy?   -> ../../../../policies/policy/config/policy-id
         |  |     +--rw interface-ref
         |  |        +--rw config
         |  |        |  +--rw interface?      -> /oc-if:interfaces/interface/name
         |  |        |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
         |  |        +--ro state
         |  |           +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
+        |  +--rw network-instances
+        |  |  +--rw network-instance* [name]
+        |  |     +--rw name      -> ../config/name
+        |  |     +--rw config
+        |  |     |  +--rw name?                         -> /network-instances/network-instance/config/name
+        |  |     |  +--rw apply-forwarding-policy?      -> ../../../../policies/policy/config/policy-id
+        |  |     |  +--rw apply-vrf-selection-policy?   -> ../../../../policies/policy/config/policy-id
+        |  |     +--ro state
+        |  |        +--ro name?                         -> /network-instances/network-instance/config/name
+        |  |        +--ro apply-forwarding-policy?      -> ../../../../policies/policy/config/policy-id
+        |  |        +--ro apply-vrf-selection-policy?   -> ../../../../policies/policy/config/policy-id
         |  +--rw path-selection-groups
         |     +--rw path-selection-group* [group-id]
         |        +--rw group-id    -> ../config/group-id
         |        +--rw config
         |        |  +--rw group-id?   string
         |        |  +--rw mpls-lsp*   -> ../../../../../mpls/lsps/constrained-path/tunnels/tunnel/config/name
         |        +--ro state
         |           +--ro group-id?   string
         |           +--ro mpls-lsp*   -> ../../../../../mpls/lsps/constrained-path/tunnels/tunnel/config/name


### Platform Implementations

Cisco IOS XR
```
 vrf-policy
 vrf default address-family ipv4 policy type pbr input GRE-DECAP-PBR
```
Arista EOS
```
ip decap-group SRTE-GRE-DECAP
 tunnel type gre
 tunnel decap-ip 10.5.32.0
```
