### PR TITLE
Expand mount-point/state/type to union of string and enum

### DIFF
--- a/release/models/system/openconfig-fs-types.yang
+++ b/release/models/system/openconfig-fs-types.yang
@@ -1,0 +1,111 @@
+module openconfig-fs-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/fs/types";
+
+  prefix "oc-fs-types";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines identifies based on linux mount api fs_type";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2025-07-08" {
+    description
+      "Initial public release";
+    reference "0.1.0";
+  }
+
+  identity OPENCONFIG_FS_MOUNT {
+    description
+      "Base identity for system filesystem mounting point types. 
+      Derived identities are based on the linux mount api fs_type.";
+    reference
+      "https://docs.kernel.org/filesystems/mount_api.html";
+  }
+
+  identity UNKNOWN {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "Indicates that the mount type could not be determined.
+      Use of this identity SHOULD be avoided.";
+  }
+
+  identity CGROUP_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "cgroup filesystem type.";
+  }
+
+  identity DEBUGFS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "debugfs filesystem type.";
+  }
+
+  identity DEVPTS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "devpts filesystem type.";
+  }
+
+  identity DEVTMPFS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "devtmpfs filesystem type.";
+  }
+
+  identity EXT4_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "ext4 filesystem type.";
+  }
+
+  identity PROC_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "proc filesystem type.";
+  }
+
+  identity RAMFS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "ramfs filesystem type.";
+  }
+
+  identity SYSFS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "sysfs filesystem type.";
+  }
+
+  identity TMPFS_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "tmpfs filesystem type.";
+  }
+
+  identity VFAT_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "vfat filesystem type.";
+  }
+
+  identity OVERLAY_FS {
+    base OPENCONFIG_FS_MOUNT;
+    description
+      "overlay filesystem type.";
+  }
+}

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -21,6 +21,7 @@ module openconfig-system {
   import openconfig-messages { prefix oc-messages; }
   import openconfig-license { prefix oc-license; }
   import openconfig-network-instance { prefix oc-ni; }
+  import openconfig-fs-types { prefix oc-fs-types; }
 
   // meta
   organization "OpenConfig working group";
@@ -54,7 +55,7 @@ module openconfig-system {
       "Expand mount-point type leaf to a union of string and enum.";
     reference "2.4.0";
   }
-  
+
   revision "2024-09-24" {
     description
       "Added mount-point type leaf to describe the type of file system.";
@@ -434,59 +435,8 @@ module openconfig-system {
     }
 
     leaf type {
-      type union {
-        type string
-        type enumeration {
-          enum CGROUP_FS {
-            description
-              "cgroup filesystem type.";
-          }
-          enun DEBUGFS_FS {
-            description
-              "debugfs filesystem type.";
-          }
-          enum DEVPTS_FS {
-            description
-              "devpts filesystem type.";
-          }
-          enum DEVTMPFS_FS {
-            description
-              "devtmpfs filesystem type.";
-          }
-          enum EXT4_FS {
-            description
-              "ext4 filesystem type.";
-          }
-          enum PROC_FS {
-            description
-              "proc filesystem type.";
-          }
-          enum RAMFS_FS {
-            description
-              "ramfs filesystem type.";
-          }
-          enum SYSFS_FS {
-            description
-              "sysfs filesystem type.";
-          }
-          enum TMPFS_FS {
-            description
-              "tmpfs filesystem type.";
-          }
-          enum VFAT_FS {
-            description
-              "vfat filesystem type.";
-          }
-          enum OVERLAY_FS {
-            description
-              "overlay filesystem type.";
-          }
-        }
-      }        
-      description
-        "An enum or a human readable string indicating the filesystem type
-        used for storage. Examples might include flash, hard disk,
-        tmpfs/ramdisk or remote/network based storage.";
+      type identityref {
+        base oc-fs-types:OPENCONFIG_FS_MOUNT;
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -47,8 +47,14 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
 
+  revision "2024-11-15" {
+    description
+      "Expand mount-point type leaf to a union of string and enum.";
+    reference "2.4.0";
+  }
+  
   revision "2024-09-24" {
     description
       "Added mount-point type leaf to describe the type of file system.";
@@ -428,11 +434,59 @@ module openconfig-system {
     }
 
     leaf type {
-      type string;
+      type union {
+        type string
+        type enumeration {
+          enum CGROUP_FS {
+            description
+              "cgroup filesystem type.";
+          }
+          enun DEBUGFS_FS {
+            description
+              "debugfs filesystem type.";
+          }
+          enum DEVPTS_FS {
+            description
+              "devpts filesystem type.";
+          }
+          enum DEVTMPFS_FS {
+            description
+              "devtmpfs filesystem type.";
+          }
+          enum EXT4_FS {
+            description
+              "ext4 filesystem type.";
+          }
+          enum PROC_FS {
+            description
+              "proc filesystem type.";
+          }
+          enum RAMFS_FS {
+            description
+              "ramfs filesystem type.";
+          }
+          enum SYSFS_FS {
+            description
+              "sysfs filesystem type.";
+          }
+          enum TMPFS_FS {
+            description
+              "tmpfs filesystem type.";
+          }
+          enum VFAT_FS {
+            description
+              "vfat filesystem type.";
+          }
+          enum OVERLAY_FS {
+            description
+              "overlay filesystem type.";
+          }
+        }
+      }        
       description
-        "A human readable string indicating the filesystem type used
-        for storage.  Examples might include flash, hard disk, tmpfs/ramdisk
-        or remote/network based storage.";
+        "An enum or a human readable string indicating the filesystem type
+        used for storage. Examples might include flash, hard disk,
+        tmpfs/ramdisk or remote/network based storage.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* This change is being made to add more structure to the content of mount-point/state/type. This will enable more predictable content for programming against.
* The underlying type is being updated from a string to a union (indentyref/string), so it's not backwards compatible. In practice, a string will ultimately still be decoded, so it is backward compatible in that regard.
### Platform Implementations

 * Before mount-point/state/type was added to the standard, it was a Google specific augment.