### PR TITLE
Update PIM documentation to clarify that only ipv4 AF is supported.

### DIFF
--- a/release/models/multicast/openconfig-pim.yang
+++ b/release/models/multicast/openconfig-pim.yang
@@ -25,7 +25,7 @@ module openconfig-pim {
     www.openconfig.net";
 
   description
-    "An OpenConfig model for Protocol Independent Multicast (PIM).";
+    "An OpenConfig model for Protocol Independent Multicast (PIM) that supports IPv4 address family.";
 
   oc-ext:openconfig-version "0.4.3";
 

--- a/release/models/multicast/openconfig-pim.yang
+++ b/release/models/multicast/openconfig-pim.yang
@@ -27,7 +27,13 @@ module openconfig-pim {
   description
     "An OpenConfig model for Protocol Independent Multicast (PIM) that supports IPv4 address family.";
 
-  oc-ext:openconfig-version "0.4.3";
+  oc-ext:openconfig-version "0.4.4";
+
+  revision "2024-12-06" {
+    description
+      "Update PIM documentation to clarify that only ipv4 AF is supported.";
+    reference "0.4.4";
+  }
 
   revision "2023-03-06" {
     description


### PR DESCRIPTION
### Change Scope

Update PIM documentation to clarify that only ipv4 AF is supported.



