### PR TITLE
Add Bfd diagnostic code for when neighbor signaled session down.

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -164,27 +164,21 @@ module openconfig-bfd {
           "The BFD echo function failed - echo packets have not been
           received for the required period of time.";
       }
-      enum NEIGHBOR_DOWN {
-        value 3;
-        description
-          "The Bfd neighbor signaled session down - Bfd packet was received with
-           neighbor state down.";
-      }
       enum FORWARDING_RESET {
-        value 4;
+        value 3;
         description
           "The forwarding plane in the local system was reset - such
           that the remote system cannot rely on the forwarding state of
           the device specifying this error code.";
       }
       enum PATH_DOWN {
-        value 5;
+        value 4;
         description
           "Signalling outside of BFD specified that the path underlying
           this session has failed.";
       }
       enum CONCATENATED_PATH_DOWN {
-        value 6;
+        value 5;
         description
           "When a BFD session runs over a series of path segments, this
           error code indicates that a subsequent path segment (i.e.,
@@ -192,18 +186,24 @@ module openconfig-bfd {
           of the session) has failed.";
       }
       enum ADMIN_DOWN {
-        value 7;
+        value 6;
         description
           "The BFD session has been administratively disabled by the
           peer.";
       }
       enum REVERSE_CONCATENATED_PATH_DOWN {
-        value 8;
+        value 7;
         description
           "In the case that a BFD session is running over a series of
           path segments, this error code indicates that a path segment
           on the reverse path (i.e., in the transmit direction from the
           destination to the source of the session) has failed.";
+      }
+      enum NEIGHBOR_DOWN {
+        value 8;
+        description
+          "The Bfd neighbor signaled session down - Bfd packet was received with
+          neighbor state down.";
       }
     }
     description

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -28,6 +28,13 @@ module openconfig-bfd {
 
   oc-ext:openconfig-version "0.3.0";
 
+  revision "2024-12-16" {
+    description
+      "Add Bfd diagnostic code for when
+       neighbor signaled session down. Specified in RFC5880.";
+    reference "0.3.1";
+ }
+
   revision "2024-03-05" {
     description
       "Add configuration of min interval, multiplier when
@@ -157,21 +164,27 @@ module openconfig-bfd {
           "The BFD echo function failed - echo packets have not been
           received for the required period of time.";
       }
-      enum FORWARDING_RESET {
+      enum NEIGHBOR_DOWN {
         value 3;
+        description
+          "The Bfd neighbor signaled session down - Bfd packet was received with
+           neighbor state down.";
+      }
+      enum FORWARDING_RESET {
+        value 4;
         description
           "The forwarding plane in the local system was reset - such
           that the remote system cannot rely on the forwarding state of
           the device specifying this error code.";
       }
       enum PATH_DOWN {
-        value 4;
+        value 5;
         description
           "Signalling outside of BFD specified that the path underlying
           this session has failed.";
       }
       enum CONCATENATED_PATH_DOWN {
-        value 5;
+        value 6;
         description
           "When a BFD session runs over a series of path segments, this
           error code indicates that a subsequent path segment (i.e.,
@@ -179,13 +192,13 @@ module openconfig-bfd {
           of the session) has failed.";
       }
       enum ADMIN_DOWN {
-        value 6;
+        value 7;
         description
           "The BFD session has been administratively disabled by the
           peer.";
       }
       enum REVERSE_CONCATENATED_PATH_DOWN {
-        value 7;
+        value 8;
         description
           "In the case that a BFD session is running over a series of
           path segments, this error code indicates that a path segment

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,7 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
 
   revision "2024-12-16" {
     description

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -208,7 +208,12 @@ module openconfig-bfd {
     }
     description
       "Diagnostic codes defined by BFD. These typically indicate the
-      reason for a change of session state.";
+      reason for a change of session state. The NEIGHBOR_DOWN diagnostic
+      was added to the enum at value 8 to avoid making a breaking change.
+      This deviates from RFC5880 where the enum is value 3. This also
+      shifts the following values by 1, in relation to RFC5880:
+      FORWARDING_RESET, PATH_DOWN, CONCATENATED_PATH_DOWN,
+      ADMIN_DOWN, REVERSE_CONCATENATED_PATH_DOWN.";
     reference
       "RFC5880 - Bidirectional Forwarding Detection, Section
       4.1";


### PR DESCRIPTION
### Change Scope

I have added a Bfd diagnostic code for when neighbor signals session down. This is specified in RFC5880 but is absent from the public model.

From RFC5880:

     A diagnostic code specifying the local system's reason for the
      last change in session state.  Values are:

         0 -- No Diagnostic
         1 -- Control Detection Time Expired
         2 -- Echo Function Failed
         3 -- Neighbor Signaled Session Down
         4 -- Forwarding Plane Reset
         5 -- Path Down
         6 -- Concatenated Path Down
         7 -- Administratively Down
         8 -- Reverse Concatenated Path Down

