### PR TITLE
Fix enclosing container p2p-primary-paths name

### DIFF
--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -32,6 +32,12 @@ submodule openconfig-mpls-te {
 
   oc-ext:openconfig-version "3.6.0";
 
+  revision "2024-12-19" {
+    description
+      "Fix enclosing container p2p-primary-paths name";
+    reference "3.6.1";
+  }
+
   revision "2024-06-19" {
     description
       "Added support with backward compatibility to configure ECMP
@@ -1334,7 +1340,7 @@ submodule openconfig-mpls-te {
     description
       "Top level grouping for p2p primary paths";
 
-    container p2p-primary-path {
+    container p2p-primary-paths {
       description
         "Primary paths associated with the LSP";
 


### PR DESCRIPTION
Fix enclosing container p2p-primary-paths name.

Enclosing container p2p-primary-path name is not in the format described in https://www.openconfig.net/docs/guides/style_guide/#yang-style-conventions.