### PR TITLE
Update telemetry-atomic description

### DIFF
--- a/release/models/openconfig-extensions.yang
+++ b/release/models/openconfig-extensions.yang
@@ -18,7 +18,13 @@ module openconfig-extensions {
     "This module provides extensions to the YANG language to allow
     OpenConfig specific functionality and meta-data to be defined.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-01-02" {
+    description
+      "Update telemetry-atomic description.";
+    reference "0.7.0";
+  }
 
   revision "2024-09-19" {
     description
@@ -160,11 +166,17 @@ module openconfig-extensions {
   extension telemetry-atomic {
     description
       "The telemetry-atomic annotation is specified in the context of
-      a subtree (container, or list), and indicates that all nodes
+      a subtree (container, or leaf-list), and indicates that all nodes
       within the subtree are always updated together within the data
       model. For example, all elements under the subtree may be updated
       as a result of a new alarm being raised, or the arrival of a new
-       protocol message.
+      protocol message. When the annotation is specified in the context
+      of a list of containers, it applies to individual list elements
+      (subtree or container and all elements under that subtree) of the
+      list and not to the entire list. For example, say ipv4-entry list
+      has two elements, prefix1 and prefix2, all elements under the
+      prefix1 subtree may be updated as a result of a next-hop group
+      change while prefix2 subtree is not updated.
 
       Transport protocols may use the atomic specification to determine
       optimisations for sending or storing the corresponding data.";


### PR DESCRIPTION
* (M) aft/openconfig-aft-common.yang

Change Scope
* Update `telemetry-atomic` description to clarify the list container behavior.
* This change is backwards compatible.
