### PR TITLE
 Add MACSEC SCI

### DIFF
--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -18,10 +18,17 @@ module openconfig-macsec {
     "This module defines configuration and state data for
      MACsec IEEE Std 802.1AE-2018.";
 
-  oc-ext:openconfig-version "1.1.1";
+  oc-ext:openconfig-version "1.2.0";
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2025-01-02" {
+    description
+      "Add include-sci to allow enable/disable of secure channel
+      identifiers.";
+    reference "1.2.0";
+  }
 
   revision "2023-08-03" {
     description
@@ -625,6 +632,12 @@ revision "2023-06-08" {
         "Generate and include an Integrity Check Value (ICV) field in the MKPDU.
          For compatibility with previous MACsec implementation that do not
          require an ICV";
+    }
+
+    leaf include-sci {
+      type boolean;
+      description
+        "Generate and include a Secure Channel Identifier (SCI).";
     }
 
     leaf sak-rekey-interval {


### PR DESCRIPTION
### Change Scope

* Add a leaf to enable/disable MACSEC Secure Channel Identifier (SCI) 
* `/macsec/mka/policies/policy/config/include-sci`
* `/macsec/mka/policies/policy/state/include-sci`
* This change is backwards compatible.



### Platform Implementations

 * Cisco IOS XR [Supports SCI by default](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/79x/b-system-security-cg-cisco8000-79x/configuring-macsec.html#concept_pw3_wft_s3b)

 * [Arista EOS](https://www.arista.com/en/um-eos/eos-data-plane-security#unique_1576191211)
 ```
switch(config)# mac security
switch(config-mac-security)# profile TEST
switch(config-mac-security-profile-TEST)# sci
```

 * [Juniper JunOS](https://www.juniper.net/documentation/us/en/software/junos/security-services/topics/task/macsec.html)
```
[edit security macsec connectivity-association connectivity-association-name]
user@host# set include-sci
```
