### PR TITLE
Component upgrade state.

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,8 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.8.0";
+  oc-ext:openconfig-version "1.9.0";
 
+  revision "2025-01-03" {
+    description
+      "Add OPENCONFIG_UPGRADE_STATUS";
+    reference "1.9.0";
+  }
 
   revision "2024-04-30" {
     description
@@ -550,6 +555,35 @@ module openconfig-platform-types {
     base COMPONENT_REBOOT_REASON;
     description
       "The component reboots due to critical errors.";
+  }
+
+  identity OPENCONFIG_UPGRADE_STATUS {
+    description
+      "Base entity for component upgrade status.";
+  }
+
+  identity UPGRADE_FILE_LOADING {
+    base OPENCONFIG_UPGRADE_STATUS;
+    description
+      "The file is being loaded on the component.";
+  }
+
+  identity UPGRADE_IN_PROGRESS {
+    base OPENCONFIG_UPGRADE_STATUS;
+    description
+      "The upgrade is in-progress.";
+  }
+
+  identity UPGRADE_COMPLETE {
+    base OPENCONFIG_UPGRADE_STATUS;
+    description
+      "The upgrade was completed.";
+  }
+
+  identity UPGRADE_FAIL {
+    base OPENCONFIG_UPGRADE_STATUS;
+    description
+      "The upgrade failed.";
   }
 
   typedef component-redundant-role {

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.30.0";
+  oc-ext:openconfig-version "0.31.0";
+
+  revision "2025-01-03" {
+    description
+      "Add upgrade state information.";
+    reference "0.31.0";
+  }
 
   revision "2024-10-13" {
     description
@@ -705,6 +711,82 @@ module openconfig-platform {
 
   }
 
+  grouping platform-component-upgrade-state {
+    description
+      "Upgrade state data for platform components";
+
+    container upgrade {
+      description
+        "Top-level container for component upgrade state data";
+
+      leaf new-firmware-version {
+        type string;
+        description
+          "This is the version of associated firmware that is available on
+          the component, but the upgrade is not complete or has not
+          yet started.";
+      }
+
+      leaf new-firmware-version-service-impacting {
+        type boolean;
+        description
+          "A value of true indicates that upgrading the firmware would
+          be a service impacting event.";
+      }
+
+      leaf status {
+        type identityref {
+          base oc-platform-types:OPENCONFIG_UPGRADE_STATUS;
+        }
+        description
+          "The status of the upgrade.";
+      }
+
+      leaf step {
+        type string;
+        description
+          "Description of the current in-progress step of the upgrade.";
+      }
+
+      leaf step-percent-complete {
+        type oc-types:percentage;
+        description
+          "The percent complete for the in-progress step.";
+      }
+
+      leaf total-percent-complete {
+        type oc-types:percentage;
+        description
+          "The percent complete for the entire upgrade process.";
+      }
+
+      leaf start-timestamp {
+        type oc-types:timeticks64;
+        description
+          "The timestamp when the upgrade started.";
+      }
+
+      leaf duration {
+        type yang:counter64;
+        description
+          "The duration of the upgrade, in microseconds.";
+      }
+
+      leaf stop-timestamp {
+        type oc-types:timeticks64;
+        description
+          "The timestamp when the upgrade stopped.";
+      }
+
+      leaf last-known-failure {
+        type string;
+        description
+          "The reason of the last known failure, if the most recent
+          upgrade ended in failure.";
+      }
+    }
+  }
+
   grouping platform-component-temp-alarm-state {
     description
       "Temperature alarm data for platform components";
@@ -1309,6 +1391,7 @@ module openconfig-platform {
               "'oc-platform-types:INTEGRATED_CIRCUIT' or " +
               "'oc-platform-types:FRU'";
           }
+          uses platform-component-upgrade-state;
         }
 
         uses platform-component-properties-top;


### PR DESCRIPTION
Related to https://github.com/openconfig/public/issues/1241, this is a proposal to add upgrade state information for components.

Example output:

module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw name                  -> ../config/name
        +--ro state
        |  +--ro name?                     string
        <......>
        |  +--ro upgrade
        |     +--ro new-firmware-version?                     string
        |     +--ro new-firmware-version-service-impacting?   boolean
        |     +--ro status?                                   identityref
        |     +--ro step?                                     string
        |     +--ro step-percent-complete?                    oc-types:percentage
        |     +--ro total-percent-complete?                   oc-types:percentage
        |     +--ro start-timestamp?                          oc-types:timeticks64
        |     +--ro duration?                                 yang:counter64
        |     +--ro stop-timestamp?                           oc-types:timeticks64
        |     +--ro last-known-failure?                       string

@robshakir @ahsaanyousaf could you please take a look?