### PR TITLE
Add prefixing to ACL when conditionals that are part of reusable groupings

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,7 +34,14 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.4.0";
+
+  revision "2025-01-15" {
+    description
+      "Adjust prefixing for when conditionals that are part of reusable
+      groupings.";
+    reference "1.4.0";
+  }
 
   revision "2023-02-06" {
     description
@@ -451,8 +458,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ethernet-header-top {
-          when "../../config/type='ACL_L2' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_L2' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "MAC-layer fields are valid when the ACL type is L2 or
               MIXED";
@@ -460,8 +467,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ipv4-protocol-fields-top {
-          when "../../config/type='ACL_IPV4' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV4' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "IPv4-layer fields are valid when the ACL type is
               IPv4 or MIXED";
@@ -469,8 +476,8 @@ module openconfig-acl {
         }
 
         uses oc-match:mpls-header-top {
-          when "../../config/type='ACL_MPLS' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_MPLS' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "MPLS-layer fields are valid when the ACL type is
               MPLS or MIXED";
@@ -478,8 +485,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ipv6-protocol-fields-top {
-          when "../../config/type='ACL_IPV6' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV6' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "IPv6-layer fields are valid when the ACL type is
               IPv6 or MIXED";
@@ -487,9 +494,9 @@ module openconfig-acl {
         }
 
         uses oc-match:transport-fields-top {
-          when "../../config/type='ACL_IPV6' or " +
-            "../../config/type='ACL_IPV4' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV6' or " +
+            "../../config/type='oc-acl:ACL_IPV4' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "Transport-layer fields are valid when specifying
               L3 or MIXED ACL types";


### PR DESCRIPTION
  * (M) release/models/acl/openconfig-acl.yang
    - Add prefixing to when conditionals

### Change Scope

Add prefixing to when conditionals that are part of reusable groupings

Current yanglint warnings generated:

```
libyang warn: Identityref "type" comparison with identity "ACL_IPV6" without prefix, consider adding a prefix or best using "derived-from(-or-self)()" functions.
libyang warn: Previous warning generated by XPath subexpression[13] "type='ACL_IPV6'" with context node "/openconfig-acl:acl/acl-sets/acl-set/acl-entries/acl-entry".
libyang warn: Identityref "type" comparison with identity "ACL_IPV4" without prefix, consider adding a prefix or best using "derived-from(-or-self)()" functions.
libyang warn: Previous warning generated by XPath subexpression[45] "type='ACL_IPV4'" with context node "/openconfig-acl:acl/acl-sets/acl-set/acl-entries/acl-entry".
libyang warn: Identityref "type" comparison with identity "ACL_MIXED" without prefix, consider adding a prefix or best using "derived-from(-or-self)()" functions.
```

This change is backwards compatible

### Platform Implementations

No known change to current implemented functionality
