### PR TITLE
Updated UDP enums related to openconfig-aft-types.

### DIFF
--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -102,9 +102,8 @@ module openconfig-aft-types {
           "The encapsulation header is a VXLAN packet header";
       }
       enum UDP {
-        deprecated;
         description
-          "The encapsulation header is UDP packet header.  This node
+          "DEPRECATED. The encapsulation header is UDP packet header. This node
           is deprecated in favor of UDPV4 and UDPV6 nodes.";
       }
       enum UDPV4 {

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -108,11 +108,11 @@ module openconfig-aft-types {
       }
       enum UDPV4 {
         description
-          "The encapsulation header is UDPV4 packet header.";
+          "The encapsulation header is a UDP + IPv4 header.";
       }
       enum UDPV6 {
         description
-          "The encapsulation header is UDPV6 packet header.";
+          "The encapsulation header is UDP + IPv6 header.";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -95,9 +95,12 @@ module openconfig-aft-types {
         description
           "The encapsulation header is a VXLAN packet header";
       }
-      enum UDPV4 {
+      enum UDP {
         description
           "The encapsulation header is UDP packet header.";
+      }
+      enum UDPV4 {
+        description
           "The encapsulation header is UDPV4 packet header.";
       }
       enum UDPV6 {

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -112,7 +112,7 @@ module openconfig-aft-types {
       }
       enum UDPV6 {
         description
-          "The encapsulation header is UDP + IPv6 header.";
+          "The encapsulation header is a UDP + IPv6 header.";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
+
+  revision "2025-01-28" {
+    description
+        "Deprecated UDP enum and replaced it by more fine-grained enums UDPV4 and UDPV6.";
+    reference "1.3.0";
+  }
 
   revision "2024-07-18" {
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -95,9 +95,14 @@ module openconfig-aft-types {
         description
           "The encapsulation header is a VXLAN packet header";
       }
-      enum UDP {
+      enum UDPV4 {
         description
           "The encapsulation header is UDP packet header.";
+          "The encapsulation header is UDPV4 packet header.";
+      }
+      enum UDPV6 {
+        description
+          "The encapsulation header is UDPV6 packet header.";
       }
     }
     description

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -96,8 +96,10 @@ module openconfig-aft-types {
           "The encapsulation header is a VXLAN packet header";
       }
       enum UDP {
+        deprecated;
         description
-          "The encapsulation header is UDP packet header.";
+          "The encapsulation header is UDP packet header.  This node
+          is deprecated in favor of UDPV4 and UDPV6 nodes.";
       }
       enum UDPV4 {
         description


### PR DESCRIPTION
### Change Scope

* Added UDPV4 and UDPV6 while keeping enums of UDP for backward compatibility.
* Yes, I kept the UDP enum.

