### PR TITLE
Move the up-transitions leaf from the async and echo sub-containers into the state container.

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,14 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2025-02-05" {
+    description
+      "Move the up-transitions leaf from the asynch and echo
+       sub-containers into the state container.";
+    reference "0.3.1";
+ }
 
   revision "2024-03-05" {
     description
@@ -283,14 +290,6 @@ module openconfig-bfd {
         "The number of packets that have been received by the
         local system from the remote neighbour.";
     }
-
-    leaf up-transitions {
-      // TODO: looks to only be supported in SROS
-      type uint64;
-      description
-        "The number of times that the adjacency with the neighbor
-        has transitioned into the up state.";
-    }
   }
 
   grouping bfd-session-state-sessiondetails-common {
@@ -325,6 +324,14 @@ module openconfig-bfd {
       description
         "The number of times that the BFD session has transitioned
         out of the UP state.";
+    }
+
+    leaf up-transitions {
+      // TODO: looks to only be supported in SROS
+      type uint64;
+      description
+        "The number of times that the adjacency with the neighbor
+        has transitioned into the up state.";
     }
 
     leaf local-discriminator {

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -294,7 +294,6 @@ module openconfig-bfd {
     }
 
     leaf transmitted-packets {
-      // TODO: looks to be unsupported on JUNOS
       type uint64;
       description
         "The number of packets that have been transmitted

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -30,7 +30,7 @@ module openconfig-bfd {
 
   revision "2025-02-05" {
     description
-      "Move the up-transitions leaf from the asynch and echo
+      "Move the up-transitions leaf from the async and echo
        sub-containers into the state container.";
     reference "0.3.1";
  }

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -309,7 +309,6 @@ module openconfig-bfd {
     }
 
     leaf up-transitions {
-      // TODO: looks to only be supported in SROS
       status deprecated;
       type uint64;
       description

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -290,6 +290,19 @@ module openconfig-bfd {
         "The number of packets that have been received by the
         local system from the remote neighbour.";
     }
+
+    leaf up-transitions {
+      // TODO: looks to only be supported in SROS
+      status deprecated;
+      type uint64;
+      description
+        "The number of times that the adjacency with the neighbor
+        has transitioned into the up state.
+
+        This leaf is deprecated and will be replaced by a single
+        up-transitions leaf in state container. New path:
+        /bfd/interfaces/interface/peers/peer/state/up-transitions.";
+    }
   }
 
   grouping bfd-session-state-sessiondetails-common {


### PR DESCRIPTION
### Change Scope

Currently there is an up-transitions leaf in both the async and echo subcontainers:

```/bfd/interfaces/interface/peers/peer/state/echo/up-transitions```
```/bfd/interfaces/interface/peers/peer/state/async/up-transitions```

I have moved this leaf into the state container, so that it is grouped with the failure-transitions leaf:

```/bfd/interfaces/interface/peers/peer/state/failure-transitions```
```/bfd/interfaces/interface/peers/peer/state/up-transitions```


 * Discussed here: [Clarification on Bfd up-transitions and failure-transitions.](https://github.com/openconfig/public/issues/1251)