### PR TITLE
Refactor IS-IS Graceful Restart nodes

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,15 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2025-02-10" {
+    description
+      "Remove graceful-restart restart-time defaults and update
+      description statements, reference and grouping naming.  Removal of
+      non-standard interface-time-expirations leaf.";
+    reference "2.0.0";
+  }
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,15 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2025-02-10" {
+    description
+      "Remove graceful-restart restart-time defaults and update
+      description statements, reference and grouping naming.  Removal of
+      non-standard interface-time-expirations leaf.";
+    reference "2.0.0";
+  }
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,15 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2025-02-10" {
+    description
+      "Remove graceful-restart restart-time defaults and update
+      description statements, reference and grouping naming.  Removal of
+      non-standard interface-time-expirations leaf.";
+    reference "2.0.0";
+  }
 
   revision "2024-02-28" {
     description
@@ -938,29 +946,24 @@ module openconfig-isis {
         "When this leaf is set to TRUE, planned restart procedures as
         described in RFC 8706 are not used.";
       reference
-      "RFC 5706: Restart Signaling for IS-IS";
+        "IETF RFC 8706, Section 3.2: Restart Signaling for IS-IS";
     }
-
-    reference
-      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
-      for IS-IS";
   }
 
-  grouping isis-graceful-restart-level-config {
+  grouping isis-graceful-restart-global-level-config {
     description
       "This grouping defines ISIS graceful restart configuration relevant
-      for ISIS level/LSDB";
+      for ISIS at global system and per-level/LSDB hierarchies.";
 
     leaf restart-time {
       type uint16;
-      default 30;
+      units "seconds";
       description
-        "Value of RFC5306/RFC8706 T2 timer";
+        "Value of T2 or T3 timers at either the LSDB/level or global
+        system context.";
+      reference
+        "IETF RFC 8706, Section 3.1: Restart Signaling for IS-IS";
     }
-
-    reference
-      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
-      for IS-IS";
   }
 
   grouping isis-graceful-restart-interface-config {
@@ -970,21 +973,20 @@ module openconfig-isis {
 
     leaf interface-timer {
       type uint16;
+      units "seconds";
       description
-        "Value of RFC5306/RFC8706 T1 timer";
+        "Value of T1 timer per interface.";
+      reference
+        "IETF RFC 8706, Section 3.1: Restart Signaling for IS-IS";
     }
 
     leaf interface-time-expirations {
-      type int64;
+      type uint32;
       description
         "Number of times T1 expires before IIH without Restart TLV's RR flag
         set is sent. That is GR helper is not supported by adjacents
-        Inermediate System";
+        Intermediate System";
     }
-
-    reference
-      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
-      for IS-IS";
   }
 
   // configuration context containers
@@ -1186,7 +1188,7 @@ module openconfig-isis {
 
         uses admin-config;
         uses isis-graceful-restart-config;
-        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-global-level-config;
         uses isis-graceful-restart-interface-config;
       }
 
@@ -1197,7 +1199,7 @@ module openconfig-isis {
 
         uses admin-config;
         uses isis-graceful-restart-config;
-        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-global-level-config;
         uses isis-graceful-restart-interface-config;
       }
     }
@@ -1585,7 +1587,7 @@ module openconfig-isis {
           "This container defines ISIS graceful-restart configuration.";
 
         uses admin-config;
-        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-global-level-config;
       }
 
       container state {
@@ -1594,7 +1596,7 @@ module openconfig-isis {
           "This container defines state information for ISIS graceful-restart.";
 
         uses admin-config;
-        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-global-level-config;
       }
     }
 


### PR DESCRIPTION
  * (M) release/models/isis/openconfig-isis-lsp.yang
  * (M) release/models/isis/openconfig-isis-routing.yang
  * (M) release/models/isis/openconfig-isis.yang
    - Refactor IS-IS GR leaves according to RFC, remove defaults
    - Removal of non-standard `interface-time-expirations` leaf

### Change Scope

This change involves:

* Removal of any graceful-restart timer defaults.  There are no such defaults
  agreed upon across implementations and usage can vary per use-case.
* Addition of `units` statements to represent correct time unit
* Refactor grouping names to align w/ the usage (level/system)
* Removal of `interface-time-expirations` leaf as there is only 1 referenced
  implementation.  Suggestion would be an augmentation or usage of native
  modeling in such cases vs. everyone else deviating.
* Correct description statements/RFC references

This change is backwards incompatible though likely reduced impact due to
implementation status.

### Platform Implementations

* RFC compliance
* Removal of `interface-time-expirations` leaf as there was only 1 prior
  implementation reference.
