### PR TITLE
Add decap mpls-in-gre

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-02-21" {
+    description
+      "Add MPLS-in-GRE decapsulation action.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description
@@ -385,6 +391,16 @@ submodule openconfig-pf-forwarding-policies {
       description
         "When this leaf is set to true, the local system should remove
         the UDP header from the packet matching the rule.
+        Following the decapsulation it should subsequently forward the
+        encapsulated packet according to the underlying MPLS label.";
+    }
+
+    leaf decapsulate-mpls-in-gre {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the GRE header from the packet matching the rule.
         Following the decapsulation it should subsequently forward the
         encapsulated packet according to the underlying MPLS label.";
     }

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,13 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-02-21" {
+    description
+      "Add MPLS-in-GRE decapsulation action.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,13 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-02-21" {
+    description
+      "Add MPLS-in-GRE decapsulation action.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -81,7 +81,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-02-21" {
+    description
+      "Add MPLS-in-GRE decapsulation action.";
+    reference "0.7.0";
+  }
 
   revision "2023-04-25" {
     description


### PR DESCRIPTION
### Change Scope

* Add a leaf to configure a policy-forwarding action to decapsulate MPLS in GRE packets.

`/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/decapsulate-mpls-in-gre`

### Platform Implementations

* Arista EOS - decap-group
* EOS native config creates a system wide configuration to decap packets with a specific destination IP address (decap-ip)
```
switch(config)#ip decap-group decap-gp-1
switch(config)#tunnel type gre
switch(config)#tunnel decap-ip 100.1.1.2
switch(config)#tunnel overlay mpls qos map mpls-traffic-class to traffic-class
```

 * [Cisco IOS XR - MPLS in GRE decap](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/mpls/24xx/configuration/guide/b-mpls-cg-cisco8000-24xx.pdf)
 Cisco IOS XR native config requires a tunnel interface in addition to a Cisco PBR rule.  
 ```
Router # configure
Router(config)# interface tunnel-ip1
Router(config-if)# ipv4 address 112.0.0.2 255.255.255.0
Router(config-if)# tunnel mode gre ipv4 decap
Router(config-if)# tunnel source Loopback 0
Router(config-if)# tunnel destination 10.0.0.1

! PBR Configuration for GRE Tunnel Decapsulation
Router(config)# class-map type traffic match-all test_gre1
Router(config-cmap)# match protocol gre
Router(config-cmap)# match destination-address ipv4 50.0.0.1 255.255.255.255
Router(config-cmap)# match source-address ipv4 10.0.0.1 255.255.255.255
Router(config-cmap)# end-class-map
Router(config)# policy-map type pbr P1-test
Router(config-pmap)# class type traffic test_gre1
Router(config-pmap-c)#decapsulate gre
Router(config-pmap-c)# end-policy-map
Router(config)# vrf-policy vrf default address-family ipv4 policy type pbr input P1-test
```

