### PR TITLE
Added set-ip-ttl under policy forwarding action.

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,14 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.6.1";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2025-03-04" {
+    description
+      "Added support for policy forwariding action to set packet TTL.";
+    reference "0.7.0";
+  }
+  
 
   revision "2023-04-25" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -398,6 +398,12 @@ submodule openconfig-pf-forwarding-policies {
         the rule. Following the decapsulation it should subsequently forward the
         encapsulated packet according to the underlying IPv4 or IPv6 header.";
     }
+
+    leaf set-ip-ttl {
+      type uint8;
+      description
+        "When this leaf is set, the local system will set packet TTL with the value.";
+    }
   }
 
   grouping pf-forwarding-policy-action-encapsulate-gre {

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,14 +21,14 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
 
   revision "2025-03-04" {
     description
       "Added support for policy forwariding action to set packet TTL.";
     reference "0.8.0";
   }
-  
+
   revision "2024-11-14" {
     description
       "Clarify that if no rules are present, all packets will be matched.";


### PR DESCRIPTION
Change Scope
(M) release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang

Packet flow:
An IP in MPLS packet enters the device from the backbone/provider network
The inner IP packet is a customer packet and may contain TTL=1 based on customer's use case.
Goal is to provide ability to retain inner packet TTL by setting it again as desired by customer.
Intent is to perform action while encapsulating customer packets and bypass "normal" TTL processing rules.

Platform Implementations
Arista:
Has committed to support the model changes.
Cisco:
Vendor engagement to support the model changes.