### PR TITLE
Add interface-transitions and link-transitions counters

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -766,8 +766,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCInOctets.
         RFC 4293: Management Information Base for the
@@ -795,8 +794,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts.
         RFC 4293: Management Information Base for the
@@ -812,8 +810,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCInBroadcastPkts.
         RFC 4293: Management Information Base for the
@@ -830,8 +827,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCInMulticastPkts.
         RFC 4293: Management Information Base for the
@@ -851,8 +847,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifInErrors.
         RFC 4293: Management Information Base for the
@@ -870,9 +865,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
-
+        other times as indicated by the value of 'last-clear'.";
 
       reference
         "RFC 2863: The Interfaces Group MIB - ifInDiscards.
@@ -888,8 +881,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCOutOctets.
         RFC 4293: Management Information Base for the
@@ -918,8 +910,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts.
         RFC 4293: Management Information Base for the
@@ -936,8 +927,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCOutBroadcastPkts.
         RFC 4293: Management Information Base for the
@@ -956,8 +946,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifHCOutMulticastPkts.
         RFC 4293: Management Information Base for the
@@ -975,8 +964,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifOutDiscards.
         RFC 4293: Management Information Base for the
@@ -994,8 +982,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifOutErrors.
         RFC 4293: Management Information Base for the
@@ -1036,8 +1023,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
     }
@@ -1049,8 +1035,8 @@ module openconfig-interfaces {
         frame check sequence (FCS), i.e., framing errors.
 
         Discontinuities in the value of this counter can occur
-        when the device is re-initialization as indicated by the
-        value of 'last-clear'.";
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
 
     leaf carrier-transitions {
@@ -1078,8 +1064,8 @@ module openconfig-interfaces {
         or from 'UP' state are not included in the counter.
 
         Discontinuities in the value of this counter can occur
-        when the device is re-initialization as indicated by the
-        value of 'last-clear'.";
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
       oc-ext:telemetry-on-change;
     }
 
@@ -1103,8 +1089,9 @@ module openconfig-interfaces {
         the system, and hence may not tally with the equivalent counter
         on the remote end of the link.
 
-        Reported relative to the time the device restarted or
-        the last-clear time, whichever is most recent.";
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
       oc-ext:telemetry-on-change;
     }
 
@@ -1139,8 +1126,7 @@ module openconfig-interfaces {
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'last-clear'.";
+        other times as indicated by the value of 'last-clear'.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
     }
@@ -1153,8 +1139,8 @@ module openconfig-interfaces {
         frame check sequence (FCS), i.e., framing errors.
 
         Discontinuities in the value of this counter can occur
-        when the device is re-initialization as indicated by the
-        value of 'last-clear'.";
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
 
     leaf carrier-transitions {

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -1061,17 +1061,25 @@ module openconfig-interfaces {
         between up and down since the time the device restarted
         or the last-clear time, whichever is most recent.
 
-        Please use interface-transitions instead, which has the
-        same semantics, but a clearer name.";
+        Please use interface-transitions instead, which has
+        similar, but more precisely specified, semantics and a
+        clearer name.";
       oc-ext:telemetry-on-change;
     }
 
     leaf interface-transitions {
       type oc-yang:counter64;
       description
-        "Number of times the interface state has transitioned
-        between up and down since the time the device restarted
-        or the last-clear time, whichever is most recent.";
+        "The total number of times the interface state (oper-status)
+        has either transitioned to 'UP' state from any other state, or
+        from state 'UP' to any other state.  I.e., an interface flap
+        from UP to DOWN back to UP increments the counter by 2.
+        Transitions between any other interface states other than to
+        or from 'UP' state are not included in the counter.
+
+        Discontinuities in the value of this counter can occur
+        when the device is re-initialization as indicated by the
+        value of 'last-clear'.";
       oc-ext:telemetry-on-change;
     }
 
@@ -1079,11 +1087,21 @@ module openconfig-interfaces {
       type oc-yang:counter64;
       description
         "This is the number of times that the underlying link state
-        (e.g., at the optical receiver) has transitioned to/from
-        up state before any holdtime, dampening, or other
-        processing has been applied that could suppress an
-        update to the interface state and corresponding
-        interface-transitions counter.
+        (e.g., at the optical receiver) has transitioned to or from
+        'UP' state before any holdtime, dampening, or other processing
+        has been applied that could suppress an update to the interface
+        'oper-status' and corresponding interface-transitions counter.
+
+        The counter is incremented both when the link transitions
+        to 'UP' state from any other link state and also when the link
+        transitions from 'UP' state to any other link state, i.e., an
+        interface flap from UP to DOWN back to UP increments the
+        counter by 2.
+
+        Implementations are not required to count all transitions,
+        e.g., if they are below the level of granularity monitored by
+        the system, and hence may not tally with the equivalent counter
+        on the remote end of the link.
 
         Reported relative to the time the device restarted or
         the last-clear time, whichever is most recent.";

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -1048,10 +1048,38 @@ module openconfig-interfaces {
 
     leaf carrier-transitions {
       type oc-yang:counter64;
+      status deprecated;
+      description
+        "Number of times the interface state has transitioned
+        between up and down since the time the device restarted
+        or the last-clear time, whichever is most recent.
+
+        Please use interface-transitions instead, which has the
+        same semantics, but a clearer name.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf interface-transitions {
+      type oc-yang:counter64;
       description
         "Number of times the interface state has transitioned
         between up and down since the time the device restarted
         or the last-clear time, whichever is most recent.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf link-transitions {
+      type oc-yang:counter64;
+      description
+        "This is the number of times that the underlying link state
+        (e.g., at the optical receiver) has transitioned to/from
+        up state before any holdtime, dampening, or other
+        processing has been applied that could suppress an
+        update to the interface state and corresponding
+        interface-transitions counter.
+
+        Reported relative to the time the device restarted or
+        the last-clear time, whichever is most recent.";
       oc-ext:telemetry-on-change;
     }
 

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.7.2";
+  oc-ext:openconfig-version "3.8.0";
+
+  revision "2024-12-05" {
+      description
+        "Add interface-transitions and link-transitions counters";
+      reference
+        "3.8.0";
+  }
 
   revision "2024-12-05" {
       description


### PR DESCRIPTION
### Change Scope

* Deprecates carrier-transitions counter (because it has the wrong name), replacing with interface-transitions counter with the same definition.
* Add a new link-transitions counter that reports the number of underlying link transitions (i.e., matching the historical vendor definition of carrier-transitions).

### Platform Implementations

 * Cisco, IOS XR:
 * https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/Interfaces/b-interfaces-hardware-component-cr-8000/m-global-interface-commands.html, "interface transitions" & "carrier transitions" 
 * From the discussion last month it sounded like JunOS also has similar counters available.  At least one of them is published as "carrier transitions"

Tree change:
```
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        +--rw name                  -> ../config/name
        +--rw config
        +--ro state
        |  +--ro counters
        |     x--ro carrier-transitions?     oc-yang:counter64
        |     +--ro interface-transitions?   oc-yang:counter64
        |     +--ro link-transitions?        oc-yang:counter64
```

