### PR TITLE
Use IP address-family specific types for udp-v4 and udp-V6 encapsulations in AFT

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "2.9.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UPD-V4 and UDP-V6 encapsulations in AFT.";
+    reference "2.9.0";
+  }
 
   revision "2024-09-19" {
     description
@@ -376,7 +382,7 @@ submodule openconfig-aft-common {
                   "State parameters relating to UDP in IPv4 encapsulation
                   headers.";
 
-                uses aft-common-entry-nexthop-encap-udp-state;
+                uses aft-common-entry-nexthop-encap-udp-v4-state;
               }
             }
 
@@ -392,7 +398,7 @@ submodule openconfig-aft-common {
                   "State parameters relating to UDP in IPv6 encapsulation
                   headers.";
 
-                uses aft-common-entry-nexthop-encap-udp-state;
+                uses aft-common-entry-nexthop-encap-udp-v6-state;
               }
             }
 
@@ -679,20 +685,78 @@ submodule openconfig-aft-common {
   }
 
 
-  grouping aft-common-entry-nexthop-encap-udp-state {
+  grouping aft-common-entry-nexthop-encap-udp-v4-state {
     description
-      "UDP encapsulation applied on top of a packet.";
+      "UDP in IPv4 encapsulation applied on top of a packet.";
 
     leaf src-ip {
-      type oc-inet:ip-address;
+      type oc-inet:ipv4-address;
       description
-        "The source IP address for IP/UDP encapsulation.";
+        "The source IPv4 address for IP/UDP encapsulation.";
     }
 
     leaf dst-ip {
-      type oc-inet:ip-address;
+      type oc-inet:ipv4-address;
       description
-        "Destination IP address for IP/UDP encapsulation.";
+        "Destination IPv4 address for IP/UDP encapsulation.";
+    }
+
+    leaf dscp {
+      type oc-inet:dscp;
+      description
+        "DSCP value to use for the UDP header of the encapsulated
+         packet.";
+    }
+
+    leaf src-udp-port {
+      type oc-inet:port-number;
+      description
+        "Source UDP port number to use for the UDP header of the encapsulated
+         packet.  The source UDP port should be derived from the payload
+         packet entropy.  The exact methodology is implementation dependent,
+         but for example, the port could be derived from an entropy hash of
+         the payload or the source port (if present) of the payload.";
+    }
+
+    leaf dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Source UDP port number to use for the UDP header of the encapsulated
+        packet.
+
+        When the payload packet is MPLS, then RFC 7510 - Encapsulating MPLS
+        in UDP should be followed.";
+      reference
+        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6635 must be
+        used for MPLS-in-UDP and 6636 must be used for MPLS-in-UDP with DTLS.
+        Because of this condition, no default is defined in OpenConfig.  The
+        system is expected to utilize the appropriate port.";
+    }
+
+    leaf ip-ttl {
+      type uint8;
+      description
+        "This leaf reflects the configured/default IP TTL value that is used
+         in the outer header during packet encapsulation. When this leaf is
+         not set, the TTL value of the inner packet is copied over as the
+         outer packet's IP TTL value during encapsulation.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-encap-udp-v6-state {
+    description
+      "UDP in IPv6 encapsulation applied on top of a packet.";
+
+    leaf src-ip {
+      type oc-inet:ipv6-address;
+      description
+        "The source IPv6 address for IP/UDP encapsulation.";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ipv6-address;
+      description
+        "Destination IPv6 address for IP/UDP encapsulation.";
     }
 
     leaf dscp {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,12 +23,12 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "2.9.0";
+  oc-ext:openconfig-version "3.0.0";
 
   revision "2025-03-12" {
     description
-      "Use IP address-family specific types for UPD-V4 and UDP-V6 encapsulations in AFT.";
-    reference "2.9.0";
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
   }
 
   revision "2024-09-19" {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -689,6 +689,24 @@ submodule openconfig-aft-common {
     description
       "UDP in IPv4 encapsulation applied on top of a packet.";
 
+    uses aft-common-entry-nexthop-encap-udp-v4;
+
+    uses aft-common-entry-nexthop-encap-udp;
+  }
+
+  grouping aft-common-entry-nexthop-encap-udp-v6-state {
+    description
+      "UDP in IPv6 encapsulation applied on top of a packet.";
+
+    uses aft-common-entry-nexthop-encap-udp-v6;
+
+    uses aft-common-entry-nexthop-encap-udp;
+  }
+
+  grouping aft-common-entry-nexthop-encap-udp-v4 {
+    description
+      "IPv4 addresses for an UDP in IPv4 encapsulation";
+
     leaf src-ip {
       type oc-inet:ipv4-address;
       description
@@ -700,52 +718,11 @@ submodule openconfig-aft-common {
       description
         "Destination IPv4 address for IP/UDP encapsulation.";
     }
-
-    leaf dscp {
-      type oc-inet:dscp;
-      description
-        "DSCP value to use for the UDP header of the encapsulated
-         packet.";
-    }
-
-    leaf src-udp-port {
-      type oc-inet:port-number;
-      description
-        "Source UDP port number to use for the UDP header of the encapsulated
-         packet.  The source UDP port should be derived from the payload
-         packet entropy.  The exact methodology is implementation dependent,
-         but for example, the port could be derived from an entropy hash of
-         the payload or the source port (if present) of the payload.";
-    }
-
-    leaf dst-udp-port {
-      type oc-inet:port-number;
-      description
-        "Source UDP port number to use for the UDP header of the encapsulated
-        packet.
-
-        When the payload packet is MPLS, then RFC 7510 - Encapsulating MPLS
-        in UDP should be followed.";
-      reference
-        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6635 must be
-        used for MPLS-in-UDP and 6636 must be used for MPLS-in-UDP with DTLS.
-        Because of this condition, no default is defined in OpenConfig.  The
-        system is expected to utilize the appropriate port.";
-    }
-
-    leaf ip-ttl {
-      type uint8;
-      description
-        "This leaf reflects the configured/default IP TTL value that is used
-         in the outer header during packet encapsulation. When this leaf is
-         not set, the TTL value of the inner packet is copied over as the
-         outer packet's IP TTL value during encapsulation.";
-    }
   }
 
-  grouping aft-common-entry-nexthop-encap-udp-v6-state {
+  grouping aft-common-entry-nexthop-encap-udp-v6 {
     description
-      "UDP in IPv6 encapsulation applied on top of a packet.";
+      "IPv6 addresses for an UDP in IPv6 encapsulation";
 
     leaf src-ip {
       type oc-inet:ipv6-address;
@@ -758,6 +735,11 @@ submodule openconfig-aft-common {
       description
         "Destination IPv6 address for IP/UDP encapsulation.";
     }
+  }
+
+  grouping aft-common-entry-nexthop-encap-udp {
+    description
+      "Common fields used for UDP in IPv4/IPv6 encapsulation applied on top of a packet.";
 
     leaf dscp {
       type oc-inet:dscp;

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-03-12" {
+    description
+      "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.8.0";
+  oc-ext:openconfig-version "2.9.0";
+
+  revision "2025-03-12" {
+    description
+       "Use IP address-family specific types for UPD-V4 and UDP-V6 encapsulations in AFT.";
+    reference "2.9.0";
+  }
 
   revision "2024-09-19" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,12 +42,12 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "2.9.0";
+  oc-ext:openconfig-version "3.0.0";
 
   revision "2025-03-12" {
     description
-       "Use IP address-family specific types for UPD-V4 and UDP-V6 encapsulations in AFT.";
-    reference "2.9.0";
+       "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
+    reference "3.0.0";
   }
 
   revision "2024-09-19" {


### PR DESCRIPTION
### Change Scope

* This change is based on review comment on [PR#1234](https://github.com/openconfig/public/pull/1234) about the re-use of `udp-v4` encapsulation header container.
* Use `ipv4-address` type for src-ip and dst-ip fields in `udp-v4` encapsulation header.
* Use `ipv6-address` for src-ip and dst-ip fields in `udp-v6` encapsulation header.
* The new types and old `ip-address` are both strings.

### Tree View

```diff
@@ -3594,50 +3594,50 @@
         |  |     |     |  +--ro type?    oc-aftt:encapsulation-header-type
         |  |     |     +--ro gre
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     |     +--ro ttl?      uint8
         |  |     |     +--ro ipv4
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro ipv6
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro mpls
         |  |     |     |  +--ro state
         |  |     |     |     +--ro traffic-class?      oc-mplst:mpls-tc
         |  |     |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
         |  |     |     +--ro udp-v4
         |  |     |     |  +--ro state
-        |  |     |     |     +--ro src-ip?         oc-inet:ip-address
-        |  |     |     |     +--ro dst-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro src-ip?         oc-inet:ipv4-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ipv4-address
         |  |     |     |     +--ro dscp?           oc-inet:dscp
         |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro ip-ttl?         uint8
         |  |     |     +--ro udp-v6
         |  |     |     |  +--ro state
-        |  |     |     |     +--ro src-ip?         oc-inet:ip-address
-        |  |     |     |     +--ro dst-ip?         oc-inet:ip-address
+        |  |     |     |     +--ro src-ip?         oc-inet:ipv6-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ipv6-address
         |  |     |     |     +--ro dscp?           oc-inet:dscp
         |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro ip-ttl?         uint8
         |  |     |     +--ro vxlan
         |  |     |        +--ro state
         |  |     |           +--ro vni-label?               oc-evpn-types:evi-id
         |  |     |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
         |  |     +--ro interface-ref
         |  |        +--ro state
         |  |           +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
         |  +--ro oc-aftsummary:aft-summaries
         |     +--ro oc-aftsummary:ipv4-unicast
         |     |  +--ro oc-aftsummary:protocols
         |     |     +--ro oc-aftsummary:protocol* [origin-protocol]
         |     |        +--ro oc-aftsummary:origin-protocol    -> ../state/origin-protocol
         |     |        +--ro oc-aftsummary:state
         |     |           +--ro oc-aftsummary:origin-protocol?   identityref
         |     |           +--ro oc-aftsummary:counters

```