### PR TITLE
Update BFD documentation to clarify session failure.

### DIFF
--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -31,7 +31,9 @@ module openconfig-bfd {
   revision "2025-03-18" {
     description
       "Clarify BFD session failure as a transition
-      from the UP state to the DOWN state.";
+      from the UP state to the DOWN state. This does not include
+      UP to ADMIN_DOWN transitions, since when the BFD session is
+      administratively disabled it is not a session failure.";
     reference "0.4.1";
  }
 
@@ -352,14 +354,15 @@ module openconfig-bfd {
       description
         "The time of the last transition of the BFD session from the UP state
         to the DOWN state, expressed as the number of nanoseconds since
-        the Unix epoch.";
+        the Unix epoch. This does not include UP to ADMIN_DOWN transitions";
     }
 
     leaf failure-transitions {
       type uint64;
       description
         "The number of times that the BFD session has transitioned
-        from the UP state to the DOWN state.";
+        from the UP state to the DOWN state. This does not include
+        UP to ADMIN_DOWN transitions";
     }
 
     leaf up-transitions {

--- a/release/models/bfd/openconfig-bfd.yang
+++ b/release/models/bfd/openconfig-bfd.yang
@@ -26,7 +26,14 @@ module openconfig-bfd {
     "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
     configuration and operational state.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2025-03-18" {
+    description
+      "Clarify BFD session failure as a transition
+      from the UP state to the DOWN state.";
+    reference "0.4.1";
+ }
 
   revision "2025-02-05" {
     description
@@ -343,8 +350,8 @@ module openconfig-bfd {
     leaf last-failure-time {
       type oc-types:timeticks64;
       description
-        "The time of the last transition of the BFD session out of
-        the UP state, expressed as the number of nanoseconds since
+        "The time of the last transition of the BFD session from the UP state
+        to the DOWN state, expressed as the number of nanoseconds since
         the Unix epoch.";
     }
 
@@ -352,7 +359,7 @@ module openconfig-bfd {
       type uint64;
       description
         "The number of times that the BFD session has transitioned
-        out of the UP state.";
+        from the UP state to the DOWN state.";
     }
 
     leaf up-transitions {


### PR DESCRIPTION
### Change Scope

The current definition of a BFD session failure in OpenConfig is when the session transitions out of the UP state. This includes transitions from both UP -> DOWN and UP -> ADMIN_DOWN. When a BFD session is administratively disabled, this is not a session failure. Session failures should only track UP -> DOWN transitions. I have updated the descriptions of the ‘failure-transitions’ and ‘last-failure-time’ leaves to clarify this.

Discussed in #1254




