### PR TITLE
Add accept action to policy-forwarding supported actions

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -272,11 +272,10 @@ submodule openconfig-pf-forwarding-policies {
 
     leaf accept {
       type boolean;
-      default true;
+      default false;
       description
         "When this leaf is set to true, the local system should accept
-        packets that match the rule. When both accept and discard are
-        set to true, discard takes precedence";
+        packets that match the rule.";
     }
 
     leaf decapsulate-gre {

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -270,6 +270,15 @@ submodule openconfig-pf-forwarding-policies {
         packets that match the rule.";
     }
 
+    leaf accept {
+      type boolean;
+      default true;
+      description
+        "When this leaf is set to true, the local system should accept
+        packets that match the rule. When both accept and discard are 
+        set to true, discard takes precedence";
+    }
+
     leaf decapsulate-gre {
       type boolean;
       default false;

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -275,7 +275,7 @@ submodule openconfig-pf-forwarding-policies {
       default true;
       description
         "When this leaf is set to true, the local system should accept
-        packets that match the rule. When both accept and discard are 
+        packets that match the rule. When both accept and discard are
         set to true, discard takes precedence";
     }
 

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -86,7 +86,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-03-19" {
+    description
+      "Added accept action to policy-forwarding rules.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description


### PR DESCRIPTION


### Change Scope

The 'accept' action is to be included in the set of actions supported by policy-forwarding.

