### PR TITLE
Add template for static encap header fields

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -11,6 +11,7 @@ module openconfig-network-instance-static {
   import openconfig-aft { prefix "oc-aft"; }
   import openconfig-aft-types { prefix "oc-aftt"; }
   import openconfig-local-routing { prefix "oc-loc-rt"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
 
   // meta
   organization "OpenConfig working group";
@@ -22,7 +23,13 @@ module openconfig-network-instance-static {
   description
     "Static configurations associated with a network instance";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2025-03-20" {
+    description
+      "Add template for static encap header fields.";
+    reference "0.2.0";
+  }
 
   revision "2025-02-20" {
     description
@@ -42,6 +49,12 @@ module openconfig-network-instance-static {
         description
           "Configuration and state parameters relating to
           statically configured next hop group";
+      }
+
+      uses encap-header-templates-top {
+        description
+          "Configuration and state parameters relating to
+          statically configured encap-header templates";
       }
 
       uses static-next-hops-top {
@@ -250,6 +263,8 @@ module openconfig-network-instance-static {
             "Config parameters relating to encapsulation headers.";
 
           uses oc-aft:aft-common-nexthop-encap-headers-state;
+
+          uses encap-header-template-ref;
         }
 
         container state {
@@ -258,6 +273,8 @@ module openconfig-network-instance-static {
             "State parameters relating to encapsulation headers.";
 
           uses oc-aft:aft-common-nexthop-encap-headers-state;
+
+          uses encap-header-template-ref;
         }
 
         container udp-v4 {
@@ -286,5 +303,101 @@ module openconfig-network-instance-static {
       }
     }
   }
+
+  grouping encap-header-templates-top {
+    description
+      "Logical grouping for encap-header templates.";
+
+    container encap-header-templates {
+      description
+        "Surrounding container for groups of encap-header templates.";
+
+      list encap-header-template {
+        key "name";
+        description
+          "A list of user defined templates for encap-headers.next-hop-groups.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "A reference to a unique identifier for the encap-header-template.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to encap-header template.";
+          uses encap-header-template-group;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to encap-header template.";
+          uses encap-header-template-group;
+        }
+
+
+      }
+    }
+  }
+
+  grouping encap-header-template-group {
+    description
+      "Logical grouping for statically configured encap-header template.";
+
+    leaf name {
+      type string;
+      description
+        "A user defined name that uniquely identifies the encap-header template.";
+    }
+
+    leaf dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Destination UDP port number to use for the UDP header of the encapsulated
+        packet.
+
+        When the payload packet is MPLS, then RFC 7510 - Encapsulating MPLS
+        in UDP should be followed.";
+      reference
+        "RFC 7510 - Encapsulating MPLS in UDP specifies that 6635 must be
+        used for MPLS-in-UDP and 6636 must be used for MPLS-in-UDP with DTLS.
+        Because of this condition, no default is defined in OpenConfig.  The
+        system is expected to utilize the appropriate port.";
+    }
+
+    leaf ip-ttl {
+      type uint8;
+      description
+        "This leaf reflects the configured/default IP TTL value that is used
+         in the outer header during packet encapsulation. When this leaf is
+         not set, the TTL value of the inner packet is copied over as the
+         outer packet's IP TTL value during encapsulation.";
+    }
+
+    leaf dscp {
+      type oc-inet:dscp;
+      description
+        "DSCP value to use for the UDP header of the encapsulated
+         packet.";
+    }
+
+  }
+
+  grouping encap-header-template-ref {
+    description
+      "Logical grouping for reference to an encap-header template.";
+
+    leaf encap-header-template {
+      type string;
+      description
+        "A user defined name that uniquely identifies the encap-header template.
+        If the encap header already has its fields already configured
+        explicitly, that should take precendence over the template fields.";
+    }
+  }
+
 
 }


### PR DESCRIPTION
### Change Scope

* Add template for the fields used in static encap header. This will help make the static encapsulation configs more efficient by reducing the number of nexthop-groups (NHG) and nexthops (NH) configured.
* This is a follow up to https://github.com/openconfig/public/pull/1234 that will allow large number of NHG/NH (thousands) to be configured.

### Tree View

```diff
@@ -3446,64 +3446,79 @@
         |        |  +--rw group-id?   string
         |        |  +--rw mpls-lsp*   -> ../../../../../mpls/lsps/constrained-path/tunnels/tunnel/config/name
         |        +--ro state
         |           +--ro group-id?   string
         |           +--ro mpls-lsp*   -> ../../../../../mpls/lsps/constrained-path/tunnels/tunnel/config/name
         +--rw static
         |  +--rw next-hop-groups
         |  |  +--rw next-hop-group* [name]
         |  |     +--rw name         -> ../config/name
         |  |     +--rw config
         |  |     |  +--rw name?   string
         |  |     +--ro state
         |  |     |  +--ro name?   string
         |  |     +--rw next-hops
         |  |        +--rw next-hop* [index]
         |  |           +--rw index     -> ../config/index
         |  |           +--rw config
         |  |           |  +--rw index?   -> ../../../../../../next-hops/next-hop/index
         |  |           +--ro state
         |  |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
+        |  +--rw encap-header-templates
+        |  |  +--rw encap-header-template* [name]
+        |  |     +--rw name      -> ../config/name
+        |  |     +--rw config
+        |  |     |  +--rw name?           string
+        |  |     |  +--rw dst-udp-port?   oc-inet:port-number
+        |  |     |  +--rw ip-ttl?         uint8
+        |  |     |  +--rw dscp?           oc-inet:dscp
+        |  |     +--ro state
+        |  |        +--ro name?           string
+        |  |        +--ro dst-udp-port?   oc-inet:port-number
+        |  |        +--ro ip-ttl?         uint8
+        |  |        +--ro dscp?           oc-inet:dscp
         |  +--rw next-hops
         |     +--rw next-hop* [index]
         |        +--rw index            -> ../config/index
         |        +--rw config
         |        |  +--rw index?        string
         |        |  +--rw next-hop?     union
         |        |  +--rw recurse?      boolean
         |        |  +--rw metric?       uint32
         |        |  +--rw preference?   uint32
         |        +--ro state
         |        |  +--ro index?        string
         |        |  +--ro next-hop?     union
         |        |  +--ro recurse?      boolean
         |        |  +--ro metric?       uint32
         |        |  +--ro preference?   uint32
         |        +--rw encap-headers
         |           +--rw encap-header* [index]
         |              +--rw index     -> ../config/index
         |              +--rw config
-        |              |  +--rw index?   uint8
-        |              |  +--rw type?    oc-aftt:encapsulation-header-type
+        |              |  +--rw index?                   uint8
+        |              |  +--rw type?                    oc-aftt:encapsulation-header-type
+        |              |  +--rw encap-header-template?   string
         |              +--ro state
-        |              |  +--ro index?   uint8
-        |              |  +--ro type?    oc-aftt:encapsulation-header-type
+        |              |  +--ro index?                   uint8
+        |              |  +--ro type?                    oc-aftt:encapsulation-header-type
+        |              |  +--ro encap-header-template?   string
         |              +--rw udp-v4
         |                 +--rw config
         |                 |  +--rw src-ip?         oc-inet:ipv4-address
         |                 |  +--rw dst-ip?         oc-inet:ipv4-address
         |                 |  +--rw dscp?           oc-inet:dscp
         |                 |  +--rw src-udp-port?   oc-inet:port-number
         |                 |  +--rw dst-udp-port?   oc-inet:port-number
         |                 |  +--rw ip-ttl?         uint8
         |                 +--ro state
         |                    +--ro src-ip?         oc-inet:ipv4-address
         |                    +--ro dst-ip?         oc-inet:ipv4-address
         |                    +--ro dscp?           oc-inet:dscp
         |                    +--ro src-udp-port?   oc-inet:port-number
         |                    +--ro dst-udp-port?   oc-inet:port-number
         |                    +--ro ip-ttl?         uint8
         +--ro afts
         |  +--ro ipv4-unicast
         |  |  +--ro ipv4-entry* [prefix]
         |  |     +--ro prefix    -> ../state/prefix
         |  |     +--ro state
```

### Flatten View

```diff
@@ -9406,69 +9406,84 @@
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/color
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/in-labeled-octets
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/in-labeled-pkts
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/in-octets
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/in-pkts
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/out-labeled-octets
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/out-labeled-pkts
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/out-octets
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/counters/out-pkts
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/endpoint
 /openconfig-network-instance:network-instances/network-instance/segment-routing/te-policies/te-policy/state/name
 /openconfig-network-instance:network-instances/network-instance/state
 /openconfig-network-instance:network-instances/network-instance/state/description
 /openconfig-network-instance:network-instances/network-instance/state/fallback-network-instance
 /openconfig-network-instance:network-instances/network-instance/state/name
 /openconfig-network-instance:network-instances/network-instance/state/route-distinguisher
 /openconfig-network-instance:network-instances/network-instance/state/router-id
 /openconfig-network-instance:network-instances/network-instance/state/type
 /openconfig-network-instance:network-instances/network-instance/static
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/config
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/config/dscp
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/config/dst-udp-port
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/config/ip-ttl
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/config/name
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/name
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/state
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/state/dscp
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/state/dst-udp-port
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/state/ip-ttl
+/openconfig-network-instance:network-instances/network-instance/static/encap-header-templates/encap-header-template/state/name
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/config
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/config/name
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/name
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop/config
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop/config/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop/state
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/next-hops/next-hop/state/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/state
 /openconfig-network-instance:network-instances/network-instance/static/next-hop-groups/next-hop-group/state/name
 /openconfig-network-instance:network-instances/network-instance/static/next-hops
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config/metric
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config/next-hop
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config/preference
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/config/recurse
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/config
+/openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/config/encap-header-template
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/config/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/config/type
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/state
+/openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/state/encap-header-template
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/state/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/state/type
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/dscp
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/dst-ip
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/dst-udp-port
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/ip-ttl
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/src-ip
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/config/src-udp-port
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/dscp
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/dst-ip
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/dst-udp-port
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/ip-ttl
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/src-ip
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/encap-headers/encap-header/udp-v4/state/src-udp-port
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/index
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/state
 /openconfig-network-instance:network-instances/network-instance/static/next-hops/next-hop/state/index
```
