### PR TITLE
Auto generated link bandwidth

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -346,7 +346,7 @@ submodule openconfig-bgp-common-structure {
         uses auto-gen-link-bandwidth-config;
       }
       container state {
-        description: "";
+        description "";
         uses auto-gen-link-bandwidth-config;
       }
     }

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -351,18 +351,18 @@ submodule openconfig-bgp-common-structure {
         configuration.";
       container config {
         description
-          "Container used to provides configuration
+          "Container used to provide configuration
           parameters related to auto-generation of link-bandwidth
-          extended-community attribute for lerned routes.
-          Apply only for routes that do not have link-bandwidth
+          extended-community attribute for learned routes.
+          Applies only for routes that do not have link-bandwidth
           extended-community.";
         uses auto-gen-link-bandwidth-config;
       }
       container state {
         description
-          "Container used to provides state
+          "Container used to provide state
           parameters related to auto-generation of link-bandwidth
-          extended-community attribute for lerned routes.
+          extended-community attribute for learned routes.
           Apply only for routes that do not have link-bandwidth
           extended-community.";
         uses auto-gen-link-bandwidth-config;

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -338,7 +338,7 @@ submodule openconfig-bgp-common-structure {
       provides configuration and state parameters relating to
       auto-generation of link-bandwidth extended-community
       attribute.";
-      
+
     container import {
       description
         "Container used to provide configuration and state

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -325,4 +325,31 @@ submodule openconfig-bgp-common-structure {
     }
   }
 
+   grouping bgp-common-structure-neighbor-group-auto-gen-link-bandwidth {
+    description:
+      "Common grouping used for both groups and neighbors which
+      provides configuration and state parameters relating to
+      auto-generation of link-bandwidth extended-community
+      attribute.";
+    container import {
+      description: 
+        "Container used to provides configuration and state
+        parameters relating tovauto-generation of link-bandwidth 
+        extended-community attribute for lerned routes.
+        Apply only for routes that do not have link-bandwidth 
+        extended-community.
+        Any policy action related to link-bandwidth 
+        extended-community takes precedence over this
+        configuration";
+      container config {
+        description: "";
+        uses auto-gen-link-bandwidth-config;
+      }
+      container state {
+        description: "";
+        uses auto-gen-link-bandwidth-config;
+      }
+    }
+  }
+  
 }

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -359,6 +359,7 @@ submodule openconfig-bgp-common-structure {
           extended-community.";
         uses auto-gen-link-bandwidth-config;
       }
+
       container state {
         description
           "Container used to provide state

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -344,7 +344,7 @@ submodule openconfig-bgp-common-structure {
         "Container used to provide configuration and state
         parameters related to auto-generation of link-bandwidth
         extended-community attribute for learned routes.
-        Apply only for routes that do not have link-bandwidth
+        Applies only for routes that do not have link-bandwidth
         extended-community.
         Any policy action related to link-bandwidth
         extended-community takes precedence over this

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -349,6 +349,7 @@ submodule openconfig-bgp-common-structure {
         Any policy action related to link-bandwidth
         extended-community takes precedence over this
         configuration.";
+
       container config {
         description
           "Container used to provide configuration

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -326,13 +326,13 @@ submodule openconfig-bgp-common-structure {
   }
 
    grouping bgp-common-structure-neighbor-group-auto-gen-link-bandwidth {
-    description:
+    description
       "Common grouping used for both groups and neighbors which
       provides configuration and state parameters relating to
       auto-generation of link-bandwidth extended-community
       attribute.";
     container import {
-      description: 
+      description 
         "Container used to provides configuration and state
         parameters relating tovauto-generation of link-bandwidth 
         extended-community attribute for lerned routes.
@@ -342,7 +342,7 @@ submodule openconfig-bgp-common-structure {
         extended-community takes precedence over this
         configuration";
       container config {
-        description: "";
+        description "";
         uses auto-gen-link-bandwidth-config;
       }
       container state {
@@ -351,5 +351,5 @@ submodule openconfig-bgp-common-structure {
       }
     }
   }
-  
+
 }

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -325,7 +325,7 @@ submodule openconfig-bgp-common-structure {
     }
   }
 
-   grouping bgp-common-structure-neighbor-group-auto-gen-link-bandwidth {
+  grouping bgp-common-structure-neighbor-group-auto-gen-link-bandwidth {
     description
       "Common grouping used for both groups and neighbors which
       provides configuration and state parameters relating to
@@ -359,6 +359,15 @@ submodule openconfig-bgp-common-structure {
           extended-community.";
         uses auto-gen-link-bandwidth-config;
       }
+    }
+  }
+
+  grouping bgp-common-structure-neighbor-group-auto-link-bandwidth {
+      container auto-generated-link-bandwidth {
+      description
+        "Parameters related to automatic generation link-bandwidth
+        extended community base on underlaying interface speed.";
+      uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,14 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -332,21 +332,31 @@ submodule openconfig-bgp-common-structure {
       auto-generation of link-bandwidth extended-community
       attribute.";
     container import {
-      description 
+      description
         "Container used to provides configuration and state
-        parameters relating tovauto-generation of link-bandwidth 
+        parameters related to auto-generation of link-bandwidth
         extended-community attribute for lerned routes.
-        Apply only for routes that do not have link-bandwidth 
+        Apply only for routes that do not have link-bandwidth
         extended-community.
-        Any policy action related to link-bandwidth 
+        Any policy action related to link-bandwidth
         extended-community takes precedence over this
         configuration";
       container config {
-        description "";
+        description
+          "Container used to provides configuration
+          parameters related to auto-generation of link-bandwidth
+          extended-community attribute for lerned routes.
+          Apply only for routes that do not have link-bandwidth
+          extended-community.";
         uses auto-gen-link-bandwidth-config;
       }
       container state {
-        description "";
+        description
+          "Container used to provides state
+          parameters related to auto-generation of link-bandwidth
+          extended-community attribute for lerned routes.
+          Apply only for routes that do not have link-bandwidth
+          extended-community.";
         uses auto-gen-link-bandwidth-config;
       }
     }

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -363,7 +363,7 @@ submodule openconfig-bgp-common-structure {
   }
 
   grouping bgp-common-structure-neighbor-group-auto-link-bandwidth {
-      container auto-generated-link-bandwidth {
+      container auto-link-bandwidth {
       description
         "Parameters related to automatic generation link-bandwidth
         extended community base on underlaying interface speed.";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -368,6 +368,7 @@ submodule openconfig-bgp-common-structure {
       }
 
       container state {
+        config false;
         description
           "Container used to provide state
           parameters related to auto-generation of link-bandwidth
@@ -380,7 +381,10 @@ submodule openconfig-bgp-common-structure {
   }
 
   grouping bgp-common-structure-neighbor-group-auto-link-bandwidth {
-      container auto-link-bandwidth {
+    description
+      "Parameters related to automatic generation link-bandwidth
+      extended community base on underlaying interface speed.";
+    container auto-link-bandwidth {
       description
         "Parameters related to automatic generation link-bandwidth
         extended community base on underlaying interface speed.";

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -348,7 +348,7 @@ submodule openconfig-bgp-common-structure {
         extended-community.
         Any policy action related to link-bandwidth
         extended-community takes precedence over this
-        configuration";
+        configuration.";
       container config {
         description
           "Container used to provides configuration

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -341,7 +341,7 @@ submodule openconfig-bgp-common-structure {
       
     container import {
       description
-        "Container used to provides configuration and state
+        "Container used to provide configuration and state
         parameters related to auto-generation of link-bandwidth
         extended-community attribute for lerned routes.
         Apply only for routes that do not have link-bandwidth

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -338,6 +338,7 @@ submodule openconfig-bgp-common-structure {
       provides configuration and state parameters relating to
       auto-generation of link-bandwidth extended-community
       attribute.";
+      
     container import {
       description
         "Container used to provides configuration and state

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -348,6 +348,13 @@ submodule openconfig-bgp-common-structure {
         extended-community.
         Any policy action related to link-bandwidth
         extended-community takes precedence over this
+        configuration.
+        This configuration when present, MUST be supported in
+        context of single-hop EBGP neighbor (with and without
+        TTL security enabled). Implementation may support it
+        in other reasonable contexts. Implementation shall not
+        silently ignore this configuration. If present in not
+        supported context, implementation shall reject
         configuration.";
 
       container config {

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -343,7 +343,7 @@ submodule openconfig-bgp-common-structure {
       description
         "Container used to provide configuration and state
         parameters related to auto-generation of link-bandwidth
-        extended-community attribute for lerned routes.
+        extended-community attribute for learned routes.
         Apply only for routes that do not have link-bandwidth
         extended-community.
         Any policy action related to link-bandwidth

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -864,22 +864,25 @@ submodule openconfig-bgp-common {
     description
       "Grouping of parameters related to automatic generation of
       link-bandwidth extended community.";
+      
     leaf enabled {
       description
         "Generate link-bandwidth extnded community for BGP routes that do not
-        have link-bandwidth extnded community attached.";
+        have link-bandwidth extended community attached.";
       type boolean;
       default false;
     }
+    
     leaf hold-down-time {
       description
         "Suppress frequent changes in the link-bandwidth value when bandwidth
         increases.";
       type uint16;
     }
+    
     leaf transitive {
       description
-        "Generated link-bandwidth attribute of transitive type. The non-transitive
+        "Generate link-bandwidth extended community as a transitive value. The non-transitive
         is default and matches original draft.";
       type boolean;
       default false;

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -867,7 +867,7 @@ submodule openconfig-bgp-common {
 
     leaf enabled {
       description
-        "Generate link-bandwidth extnded community for BGP routes that do not
+        "Append a link-bandwidth extended community for BGP routes that do not
         have link-bandwidth extended community attached.";
       type boolean;
       default false;
@@ -875,10 +875,10 @@ submodule openconfig-bgp-common {
 
     leaf hold-down-time {
       description
-        "Suppress for a nuber of seconds changes in the link-bandwidth value
+        "Suppress for a number of seconds changes in the link-bandwidth value
         when bandwidth increases. Every time bandwidth of link increases,
         it must remain constant for hold-down-time before it is reflected
-        into link-bandwidth extended community of routes lerned on this
+        into link-bandwidth extended community of routes learned on this
         link.";
       type uint16;
       units seconds;

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -857,14 +857,14 @@ submodule openconfig-bgp-common {
     description
       "";
     leaf enabled {
-      description:
+      description
         "Generate link-bandwidth extnded community for BGP routes that do not
         have link-bandwidth extnded community attached.";
       type boolean;
-      default: false;
+      default false;
     }
     leaf hold-down-time {
-      description:
+      description
         "Suppress frequent changes in the link-bandwidth value when bandwidth
         increases.";
       type unit16;

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -853,7 +853,7 @@ submodule openconfig-bgp-common {
   }
 
 
-  grupping auto-gen-link-bandwidth-config {
+  grouping auto-gen-link-bandwidth-config {
     description
       "";
     leaf enabled {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -875,15 +875,21 @@ submodule openconfig-bgp-common {
     
     leaf hold-down-time {
       description
-        "Suppress frequent changes in the link-bandwidth value when bandwidth
-        increases.";
+        "Suppress for a nuber of seconds changes in the link-bandwidth value
+        when bandwidth increases. Every time bandwidth of link increases,
+        it must remain constant for hold-down-time before it is reflected
+        into link-bandwidth extended community of routes lerned on this
+        link.";
       type uint16;
+      unit seconds;
     }
     
     leaf transitive {
       description
-        "Generate link-bandwidth extended community as a transitive value. The non-transitive
-        is default and matches original draft.";
+        "When leaf is set to TRUE, generate link-bandwidth extended community
+        as a transitive type. When set to FALSE - generate as
+        non-transitive. The non-transitive is default and matches
+        original/earlier versions of IETF draft.";
       type boolean;
       default false;
     }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -870,6 +870,13 @@ submodule openconfig-bgp-common {
         increases.";
       type uint16;
     }
+    leaf transitive {
+      description
+        "Generated link-bandwidth attribute of transitive type. The non-transitive
+        is default and matches original draft.";
+      type boolean;
+      default false;
+    }
   }
 
 }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -855,7 +855,8 @@ submodule openconfig-bgp-common {
 
   grouping auto-gen-link-bandwidth-config {
     description
-      "";
+      "Grouping of parameters related to automatic generation of
+      link-bandwidth extended community.";
     leaf enabled {
       description
         "Generate link-bandwidth extnded community for BGP routes that do not

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -867,7 +867,7 @@ submodule openconfig-bgp-common {
       description
         "Suppress frequent changes in the link-bandwidth value when bandwidth
         increases.";
-      type unit32;
+      type uint16;
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -868,7 +868,14 @@ submodule openconfig-bgp-common {
     leaf enabled {
       description
         "Append a link-bandwidth extended community for BGP routes that do not
-        have link-bandwidth extended community attached.";
+        have link-bandwidth extended community attached.
+        This configuration when present, MUST be supported in
+        context of single-hop EBGP neighbor (with and without
+        TTL security enabled). Implementation may support it
+        in other reasonable contexts. Implementation shall not
+        silently ignore this configuration. If present in not
+        supported context, implementation shall reject
+        configuration.";
       type boolean;
       default false;
     }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -881,7 +881,7 @@ submodule openconfig-bgp-common {
         into link-bandwidth extended community of routes lerned on this
         link.";
       type uint16;
-      unit seconds;
+      units seconds;
     }
 
     leaf transitive {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -867,7 +867,7 @@ submodule openconfig-bgp-common {
       description
         "Suppress frequent changes in the link-bandwidth value when bandwidth
         increases.";
-      type unit16;
+      type unit32;
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -853,4 +853,22 @@ submodule openconfig-bgp-common {
   }
 
 
+  grupping auto-gen-link-bandwidth-config {
+    description
+      "";
+    leaf enabled {
+      description:
+        "Generate link-bandwidth extnded community for BGP routes that do not
+        have link-bandwidth extnded community attached.";
+      type boolean;
+      default: false;
+    }
+    leaf hold-down-time {
+      description:
+        "Suppress frequent changes in the link-bandwidth value when bandwidth
+        increases.";
+      type unit16;
+    }
+  }
+
 }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -864,7 +864,7 @@ submodule openconfig-bgp-common {
     description
       "Grouping of parameters related to automatic generation of
       link-bandwidth extended community.";
-      
+
     leaf enabled {
       description
         "Generate link-bandwidth extnded community for BGP routes that do not
@@ -872,7 +872,7 @@ submodule openconfig-bgp-common {
       type boolean;
       default false;
     }
-    
+
     leaf hold-down-time {
       description
         "Suppress for a nuber of seconds changes in the link-bandwidth value
@@ -883,7 +883,7 @@ submodule openconfig-bgp-common {
       type uint16;
       unit seconds;
     }
-    
+
     leaf transitive {
       description
         "When leaf is set to TRUE, generate link-bandwidth extended community

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,14 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,14 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -853,6 +853,13 @@ submodule openconfig-bgp-neighbor {
     uses bgp-common-structure-neighbor-group-ebgp-multihop;
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
+
+    container auto-generated-link-bandwidth {
+      description: 
+        "Parameters related to automatic generation link-bandwidth
+        extended community base on underlaying interface speed.";
+      uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
+    }
     uses bgp-neighbor-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -855,7 +855,7 @@ submodule openconfig-bgp-neighbor {
     uses bgp-common-structure-neighbor-group-as-path-options;
 
     container auto-generated-link-bandwidth {
-      description: 
+      description
         "Parameters related to automatic generation link-bandwidth
         extended community base on underlaying interface speed.";
       uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -853,13 +853,7 @@ submodule openconfig-bgp-neighbor {
     uses bgp-common-structure-neighbor-group-ebgp-multihop;
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
-
-    container auto-generated-link-bandwidth {
-      description
-        "Parameters related to automatic generation link-bandwidth
-        extended community base on underlaying interface speed.";
-      uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
-    }
+    uses bgp-common-structure-neighbor-group-auto-link-bandwidth;
     uses bgp-neighbor-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -361,12 +361,7 @@ submodule openconfig-bgp-peer-group {
     uses bgp-common-structure-neighbor-group-ebgp-multihop;
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
-    container auto-generated-link-bandwidth {
-      description
-        "Parameters related to automatic generation link-bandwidth
-        extended community base on underlaying interface speed.";
-      uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
-    }
+    uses bgp-common-structure-neighbor-group-auto-link-bandwidth;
     uses bgp-common-global-group-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -361,6 +361,7 @@ submodule openconfig-bgp-peer-group {
     uses bgp-common-structure-neighbor-group-ebgp-multihop;
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
+    uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
     uses bgp-common-global-group-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 
@@ -393,6 +394,7 @@ submodule openconfig-bgp-peer-group {
 
       uses bgp-peer-group-base;
       uses oc-bfd:bfd-enable;
+      uses 
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -399,7 +399,6 @@ submodule openconfig-bgp-peer-group {
 
       uses bgp-peer-group-base;
       uses oc-bfd:bfd-enable;
-      uses 
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -361,7 +361,12 @@ submodule openconfig-bgp-peer-group {
     uses bgp-common-structure-neighbor-group-ebgp-multihop;
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
-    uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
+    container auto-generated-link-bandwidth {
+      description
+        "Parameters related to automatic generation link-bandwidth
+        extended community base on underlaying interface speed.";
+      uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
+    }
     uses bgp-common-global-group-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,14 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,14 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.8.0";
+  oc-ext:openconfig-version "9.9.0";
+
+  revision "2025-03-30" {
+    description
+      "Add schema for auto-generated link-bandwidth extended community
+      for learned routes.";
+    reference "9.9.0";
+  }
 
   revision "2024-09-06" {
     description


### PR DESCRIPTION
### Change Scope

Introduces OpenConfig schema to enable automatic generation of link-bandwidth extended community based on underlaying interface speed and peer-group and neighbour level.
Not available on global level because it is applicable only for sessions soucerd to physical interface, and not applicable to interfaces of uncnown speed like "loopback", "irb/svi", etc.
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw neighbors
                    +--rw neighbor* [neighbor-address]
                       +--rw auto-link-bandwidth
                          +--rw import
                             +--rw config
                             |  +--rw enabled?          boolean
                             |  +--rw hold-down-time?   uint16
                             |  +--rw transitive?       boolean
                             +--rw state
                                +--rw enabled?          boolean
                                +--rw hold-down-time?   uint16
                                +--rw transitive?       boolean
```
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw peer-groups
                    +--rw peer-group* [peer-group-name]
                       +--rw auto-link-bandwidth
                          +--rw import
                             +--rw config
                             |  +--rw enabled?          boolean
                             |  +--rw hold-down-time?   uint16
                             |  +--rw transitive?       boolean
                             +--rw state
                                +--rw enabled?          boolean
                                +--rw hold-down-time?   uint16
                                +--rw transitive?       boolean
```
The schema is extedable to export direction and link-bandwidth regenaration.

This change is backward compatible.

### Platform Implementations

#### JUNIPER JUNOS, JUNOS-EVO [link-bandwidth autosense](https://www.juniper.net/documentation/us/en/software/junos/ai-ml-evo/topics/topic-map/bgp-link-bandwidth.html#concept_kjn_vyx_2bc__section_a1p_ngh_gcc)
```
set protocols bgp group group-name link-bandwith auto-sense
set protocols bgp group group-name neighbor link-bandwith auto-sense
set protocols bgp group group-name link-bandwith auto-sense hold-down time-in-seconds
```
#### CISCO IOS-XR [DMZ link-bandwidth](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/bgp/cumulative/command/reference/b-bgp-cr-cisco8000/m-bgp-commands-8k.html#wp2318208407)
```
Router(config)# router bgp 1
Router(config-bgp)#neighbor 10.67.89.01 
Router(config-bgp-nbr)#dmz-link-bandwidth 
```
ARISTA EoS [Enabling BGP Link Bandwidth attribute setting inbound](https://www.arista.com/en/support/toi/eos-4-24-1f/14534-bgp-ucmp#enabling-bgp-link-bandwidth-attribute-setting-inbound)
```
[no|default] neighbor <peer|peer-group> link-bandwidth auto
[no|default] neighbor <peer|peer-group> link-bandwidth update-delay <0-600>
```
