### PR TITLE
Static route next network instance

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -313,25 +313,25 @@ module openconfig-local-routing {
 
         container next-network-instance {
           description
-          "The network instance in which context packet destination address
-          lookup shall be performed.";
-          
+            "The network instance in which context packet destination address
+            lookup shall be performed.";
+
           container config {
             leaf next-network-instance {
               description
                 "The network instance in which context packet destination address
-                lookup shall be performed."
+                lookup shall be performed.";
               type leafref {
                 path "../../../../../../../config/name";
               }
             }
-          } 
+          }
 
           container state {
             leaf next-network-instance {
               description
                 "The network instance in which context packet destination address
-                lookup is be performed."
+                lookup is be performed.";
               type leafref {
                 path "../../../../../../../state/name";
               }

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -235,13 +235,13 @@ module openconfig-local-routing {
     leaf next-network-instance {
       description
         "Instead of finding the next-hop for a destination address in the current
-	      network-instance, look up the destination address in the routing table
-	      of the specified network-instance.
-	      For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
+	network-instance, look up the destination address in the routing table
+	of the specified network-instance.
+	 For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
         in the 'BLUE' network-instance and the destination address matches this
         route, the destination address will be looked up again in the 'DEFAULT'
-	      network-instance to find the next-hop.  
-	      This leaf is mutually exclusive with 'next-hop', 'nh-network-instance' 
+	network-instance to find the next-hop.
+	This leaf is mutually exclusive with 'next-hop', 'nh-network-instance'
         leaves";
       type leafref {
         path "/network-instances/network-instance/config/name";

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -234,10 +234,15 @@ module openconfig-local-routing {
 
     leaf next-network-instance {
       description
-        "The network instance in which context packet destination address
-        lookup shall be performed.
-        This leaf is mutualy exclusive with 'next-hop', 'nh-network-instance',
-        'recurse' leaves";
+        "Instead of finding the next-hop for a destination address in the current
+	      network-instance, look up the destination address in the routing table
+	      of the specified network-instance.
+	      For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
+        in the 'BLUE' network-instance and the destination address matches this
+        route, the destination address will be looked up again in the 'DEFAULT'
+	      network-instance to find the next-hop.  
+	      This leaf is mutually exclusive with 'next-hop', 'nh-network-instance' 
+        leaves";
       type leafref {
         path "/network-instances/network-instance/config/name";
       }
@@ -272,8 +277,8 @@ module openconfig-local-routing {
         nh-network-instance.
         For example, let 'nh-network-instance' = 'DEFAULT'.  If a
         packet arrives on the 'BLUE' network-instance and the
-        destination address matches this route, look up the
-        configured next-hop in the 'DEFAULT' network-instance.
+        destination address matches this route, look up the IP
+        configured as next-hop in the 'DEFAULT' network-instance.
         This leaf is mutually exclusive with next-network-instance
         leaf";
       type leafref {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -380,7 +380,7 @@ module openconfig-local-routing {
             container must not be used.";
 
           list next-hop {
-            
+
             key "index";
 
             description

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -232,13 +232,21 @@ module openconfig-local-routing {
         only support a numeric value for this string. ";
     }
 
+    leaf next-network-instance {
+      description
+        "The network instance in which context packet destination address
+        lookup shall be performed.
+        This leaf is mutualy exclusive with 'next-hop', 'nh-network-instance',
+        'recurse' leaves";
+      type leafref {
+        path "../../../../../../../../network-instance/config/name";
+      }
+    }
+
     leaf next-hop {
       type union {
         type inet:ip-address;
         type local-defined-next-hop;
-        type leafref {
-          path "../../../../../../../../../network-instance/config/name";
-        }
       }
       description
         "The next-hop that is to be used for the static route
@@ -246,24 +254,24 @@ module openconfig-local-routing {
           -  an IP address or
           - a pre-defined next-hop type - for instance, DROP or
         LOCAL_LINK or
-          - next network-instance in which packet's destination
-          address should be looked up, to to find next-hop. It
-          must not be combined with nh-network-instance and
-          recurse leaf must be ignored.
         When this leaf is not set, and the interface-ref
         value is specified for the next-hop, then the system should
         treat the prefix as though it is directly connected to the
-        interface.";
+        interface.
+        This leaf is mutualy exclusive with next-network-instance
+        leaf";
     }
 
     leaf nh-network-instance {
       description
         "Network-instance in which IP address of next-hop should
-        be looked up inorder to find egress interface. This attribute
+        be looked up, to find egress interface. This attribute
         is only valid if next-hop is given as IP address.
         This attribute may be combined with recurse attribute of any
         value, in which case recurse setting applies to
-        nh-network-instance";
+        nh-network-instance.
+        This leaf is mutualy exclusive with next-network-instance
+        leaf";
       type leafref {
         path "../../../../../../../../network-instance/config/name";
       }
@@ -281,7 +289,9 @@ module openconfig-local-routing {
         instance. When the interface reference specified within the
         next-hop entry is set (i.e., is not null) then forwarding is
         restricted to being via the interface specified - and
-        recursion is hence disabled.";
+        recursion is hence disabled.
+        This leaf is mutualy exclusive with next-network-instance
+        leaf";
     }
 
     uses local-common-route-attributes;
@@ -331,34 +341,6 @@ module openconfig-local-routing {
 
           uses local-static-config;
           uses local-static-state;
-        }
-
-        container next-network-instance {
-          description
-            "The network instance in which context packet destination address
-            lookup shall be performed.";
-
-          container config {
-            leaf next-network-instance {
-              description
-                "The network instance in which context packet destination address
-                lookup shall be performed.";
-              type leafref {
-                path "../../../../../../../../network-instance/config/name";
-              }
-            }
-          }
-
-          container state {
-            leaf next-network-instance {
-              description
-                "The network instance in which context packet destination address
-                lookup is be performed.";
-              type leafref {
-                path "../../../../../../../../network-instance/state/name";
-              }
-            }
-          }
         }
 
         container next-hop-group {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -247,7 +247,7 @@ module openconfig-local-routing {
           - a pre-defined next-hop type - for instance, DROP or
         LOCAL_LINK or 
           - next network-instance in which packet's destination
-          address should be looked up, to to find next-hop."
+          address should be looked up, to to find next-hop.
         When this leaf is not set, and the interface-ref
         value is specified for the next-hop, then the system should
         treat the prefix as though it is directly connected to the

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -249,7 +249,7 @@ module openconfig-local-routing {
           - next network-instance in which packet's destination
           address should be looked up, to to find next-hop. It
           must not be combined with nh-network-instance and
-          recurce leaf must be ignored.
+          recurse leaf must be ignored.
         When this leaf is not set, and the interface-ref
         value is specified for the next-hop, then the system should
         treat the prefix as though it is directly connected to the
@@ -262,7 +262,7 @@ module openconfig-local-routing {
         be looked up inorder to find egress interface. This attribute
         is only valid if next-hop is given as IP address.
         This attribute may be combined with recurse attribute of any
-        value, in which case recurse setting applys to
+        value, in which case recurse setting applies to
         nh-network-instance";
       type leafref {
         path "../../../../../../../config/name";

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -237,7 +237,7 @@ module openconfig-local-routing {
         type inet:ip-address;
         type local-defined-next-hop;
         type leafref {
-          path "../../../../../../../../config/name";
+          path "../../../../../../../../../network-instance/config/name";
         }
       }
       description
@@ -265,7 +265,7 @@ module openconfig-local-routing {
         value, in which case recurse setting applies to
         nh-network-instance";
       type leafref {
-        path "../../../../../../../config/name";
+        path "../../../../../../../../network-instance/config/name";
       }
     }
 
@@ -344,7 +344,7 @@ module openconfig-local-routing {
                 "The network instance in which context packet destination address
                 lookup shall be performed.";
               type leafref {
-                path "../../../../../../../config/name";
+                path "../../../../../../../../network-instance/config/name";
               }
             }
           }
@@ -355,7 +355,7 @@ module openconfig-local-routing {
                 "The network instance in which context packet destination address
                 lookup is be performed.";
               type leafref {
-                path "../../../../../../../state/name";
+                path "../../../../../../../../network-instance/state/name";
               }
             }
           }

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -239,7 +239,7 @@ module openconfig-local-routing {
         This leaf is mutualy exclusive with 'next-hop', 'nh-network-instance',
         'recurse' leaves";
       type leafref {
-        path "../../../../../../../network-instance/config/name";
+        path "/network-instances/network-instance/config/name";
       }
     }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -380,6 +380,7 @@ module openconfig-local-routing {
             container must not be used.";
 
           list next-hop {
+            
             key "index";
 
             description

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,14 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "2.1.0";
+  oc-ext:openconfig-version "2.2.0";
+
+  revision "2025-03-31" {
+    description
+      "Add static routing to other network instance for destination
+      lookup";
+    reference "2.2.0";
+  }
 
   revision "2025-02-20" {
     description

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -258,9 +258,7 @@ module openconfig-local-routing {
       description
         "Network-instance in which IP address of next-hop should
         be looked up inorder to find egress interface";
-      type leafref {
-        path "../../../../../../../config/name";
-      }
+      type string;
     }
 
     leaf recurse {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -273,7 +273,7 @@ module openconfig-local-routing {
         This leaf is mutualy exclusive with next-network-instance
         leaf";
       type leafref {
-        path "../../../../../../../network-instance/config/name";
+        path "/network-instances/network-instance/config/name";
       }
     }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -243,11 +243,13 @@ module openconfig-local-routing {
       description
         "The next-hop that is to be used for the static route
         - this may be specified as:
-          - an IP address, an interface or
+          -  an IP address or
           - a pre-defined next-hop type - for instance, DROP or
         LOCAL_LINK or 
           - next network-instance in which packet's destination
-          address should be looked up, to to find next-hop.
+          address should be looked up, to to find next-hop. It
+          must not be combined with nh-network-instance and
+          recurce leaf must be ignored.
         When this leaf is not set, and the interface-ref
         value is specified for the next-hop, then the system should
         treat the prefix as though it is directly connected to the
@@ -257,7 +259,11 @@ module openconfig-local-routing {
     leaf nh-network-instance {
       description
         "Network-instance in which IP address of next-hop should
-        be looked up inorder to find egress interface";
+        be looked up inorder to find egress interface. This attribute
+        is only valid if next-hop is given as IP address.
+        This attribute may be combined with recurse attribute of any
+        value, in which case recurse setting applys to 
+        nh-network-instance";
       type string;
     }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -264,7 +264,9 @@ module openconfig-local-routing {
         This attribute may be combined with recurse attribute of any
         value, in which case recurse setting applys to 
         nh-network-instance";
-      type string;
+      type leafref {
+        path "../../../../../../../config/name";
+      }
     }
 
     leaf recurse {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -270,7 +270,11 @@ module openconfig-local-routing {
         This attribute may be combined with recurse attribute of any
         value, in which case recurse setting applies to
         nh-network-instance.
-        This leaf is mutualy exclusive with next-network-instance
+        For example, let 'nh-network-instance' = 'DEFAULT'.  If a
+        packet arrives on the 'BLUE' network-instance and the
+        destination address matches this route, look up the
+        configured next-hop in the 'DEFAULT' network-instance.
+        This leaf is mutually exclusive with next-network-instance
         leaf";
       type leafref {
         path "/network-instances/network-instance/config/name";

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -236,15 +236,31 @@ module openconfig-local-routing {
       type union {
         type inet:ip-address;
         type local-defined-next-hop;
+        type leafref {
+          path "../../../../../../../../config/name";
+        }
       }
       description
         "The next-hop that is to be used for the static route
-        - this may be specified as an IP address, an interface
-        or a pre-defined next-hop type - for instance, DROP or
-        LOCAL_LINK. When this leaf is not set, and the interface-ref
+        - this may be specified as:
+          - an IP address, an interface or
+          - a pre-defined next-hop type - for instance, DROP or
+        LOCAL_LINK or 
+          - next network-instance in which packet's destination
+          address should be looked up, to to find next-hop."
+        When this leaf is not set, and the interface-ref
         value is specified for the next-hop, then the system should
         treat the prefix as though it is directly connected to the
         interface.";
+    }
+
+    leaf nh-network-instance {
+      description
+        "Network-instance in which IP address of next-hop should
+        be looked up inorder to find egress interface";
+      type leafref {
+        path "../../../../../../../config/name";
+      }
     }
 
     leaf recurse {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -201,6 +201,29 @@ module openconfig-local-routing {
         IPv6.";
     }
 
+    container next-network-instance {
+      description
+      "The network instance in which context packet destination address
+      lookup shall be performed.";
+      
+      container config {
+        leaf next-network-instance {
+          type leafref {
+            path "../../../../../../../config/name";
+          }
+        }
+      } 
+
+      container state {
+        leaf next-network-instance {
+          type leafref {
+            path "../../../../../../../state/name";
+          }
+        }
+      } 
+
+    }
+
     uses local-generic-settings;
   }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -239,7 +239,7 @@ module openconfig-local-routing {
         This leaf is mutualy exclusive with 'next-hop', 'nh-network-instance',
         'recurse' leaves";
       type leafref {
-        path "../../../../../../../../network-instance/config/name";
+        path "../../../../../../../network-instance/config/name";
       }
     }
 
@@ -273,7 +273,7 @@ module openconfig-local-routing {
         This leaf is mutualy exclusive with next-network-instance
         leaf";
       type leafref {
-        path "../../../../../../../../network-instance/config/name";
+        path "../../../../../../../network-instance/config/name";
       }
     }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -208,29 +208,6 @@ module openconfig-local-routing {
         IPv6.";
     }
 
-    container next-network-instance {
-      description
-      "The network instance in which context packet destination address
-      lookup shall be performed.";
-      
-      container config {
-        leaf next-network-instance {
-          type leafref {
-            path "../../../../../../../config/name";
-          }
-        }
-      } 
-
-      container state {
-        leaf next-network-instance {
-          type leafref {
-            path "../../../../../../../state/name";
-          }
-        }
-      } 
-
-    }
-
     uses local-generic-settings;
   }
 
@@ -332,6 +309,28 @@ module openconfig-local-routing {
 
           uses local-static-config;
           uses local-static-state;
+        }
+
+        container next-network-instance {
+          description
+          "The network instance in which context packet destination address
+          lookup shall be performed.";
+          
+          container config {
+            leaf next-network-instance {
+              type leafref {
+                path "../../../../../../../config/name";
+              }
+            }
+          } 
+
+          container state {
+            leaf next-network-instance {
+              type leafref {
+                path "../../../../../../../state/name";
+              }
+            }
+          }
         }
 
         container next-hop-group {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -245,7 +245,7 @@ module openconfig-local-routing {
         - this may be specified as:
           -  an IP address or
           - a pre-defined next-hop type - for instance, DROP or
-        LOCAL_LINK or 
+        LOCAL_LINK or
           - next network-instance in which packet's destination
           address should be looked up, to to find next-hop. It
           must not be combined with nh-network-instance and
@@ -262,7 +262,7 @@ module openconfig-local-routing {
         be looked up inorder to find egress interface. This attribute
         is only valid if next-hop is given as IP address.
         This attribute may be combined with recurse attribute of any
-        value, in which case recurse setting applys to 
+        value, in which case recurse setting applys to
         nh-network-instance";
       type leafref {
         path "../../../../../../../config/name";

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -318,6 +318,9 @@ module openconfig-local-routing {
           
           container config {
             leaf next-network-instance {
+              description
+                "The network instance in which context packet destination address
+                lookup shall be performed."
               type leafref {
                 path "../../../../../../../config/name";
               }
@@ -326,6 +329,9 @@ module openconfig-local-routing {
 
           container state {
             leaf next-network-instance {
+              description
+                "The network instance in which context packet destination address
+                lookup is be performed."
               type leafref {
                 path "../../../../../../../state/name";
               }


### PR DESCRIPTION
### Change Scope

This change introduces **TWO** new option for static route:

#### 1. Redirecting packet to subsequent destination lookup in other network-instance.
This specify network-instance in which packet's destination address should be looked up, to to find next-hop. 
It must not be combined with `next-hop`, `nh-network-instance` and `recurce` leaf must be ignored.
The `metric` and `preference` semantics is the same as for `next-hop`

```
  module: openconfig-network-instance
    +--rw network-instances
       +--rw network-instance* [name]
          +--rw protocols
             +--rw protocol* [identifier name]
                +--rw static-routes
                   +--rw static* [prefix]
                      +--rw next-hops
                         +--rw next-hop* [index]
                            +--rw config
                               +--rw index?                   string
+                              +--rw next-network-instance?   -> /network-instances/network-instance/config/name
                               +--rw next-hop?                union
                               +--rw nh-network-instance?     -> /network-instances/network-instance/config/name
                               +--rw recurse?                 boolean
                               +--rw metric?                  uint32
                               +--rw preference?              uint32
```
Pleas enote that multiple elements of `next-network-instance` and `next-hop`  types could be present on sinle next-hop list keyed by unique`index`.  Therefore ECMP netween next-hop and next-network-instance is expressible. Also, it is possible to express `next-network-instance` as fallback for `next-hop` (IP or interface-ref).

This change is non-disruptive.

##### Platform Implementations

 * Juniper: [Enabling Internet Access for Layer 3 VPNs
](https://www.juniper.net/documentation/us/en/software/junos/vpn-l3/topics/topic-map/l3-vpns-internet-access.html) 

```
[edit]
routing-instances {
    vpna {
        instance-type vrf;
        routing-options {
            static {
                route 0.0.0.0/0 next-table inet.0;
            }
        }
```

 * Cisco XR: 
implementation output.

```
router static
  vrf vrf_A
    address ipv4 unicast
      172.168.50.0/24 vrf vrf_B 
      172.168.50.0/24 vrf vrf_C

```

####  2. Lookup for static route's next-hop in other network-instance


```
  module: openconfig-network-instance
    +--rw network-instances
       +--rw network-instance* [name]
          +--rw protocols
             +--rw protocol* [identifier name]
                +--rw static-routes
                   +--rw static* [prefix]
                      +--rw next-hops
                         +--rw next-hop* [index]
                            +--rw config
                               +--rw index?                   string
                               +--rw next-network-instance?   -> /network-instances/network-instance/config/name
                               +--rw next-hop?                union
+                              +--rw nh-network-instance?     -> /network-instances/network-instance/config/name
                               +--rw recurse?                 boolean
                               +--rw metric?                  uint32
                               +--rw preference?              uint32
```

This change is non-disruptive.

##### Platform Implementations

* Arista EoS [static-inter-vrf-route-support](https://www.arista.com/en/support/toi/eos-4-23-1f/14397-static-inter-vrf-route-support#configuration)

```
ip route 1.1.0.0/24 egress-vrf bar 2.2.2.2
```

 * Cisco XR [VFR for static routes](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/cumulative/command/reference/b-routing-cr-cisco8000/m-f63682-adhoc.html#wp1021470314)
implementation output.

```
router static
vrf vrf_A
address ipv4 unicast
172.168.50.0/24 vrf vrf_B 192.168.1.2
```