### PR TITLE
Fix enclosing container name for openconfig-mpls-te.yang p2p-primary-path list

### DIFF
--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,12 +30,12 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.6.1";
+  oc-ext:openconfig-version "4.0.0";
 
   revision "2025-04-07" {
     description
       "Fix enclosing container name for p2p-primary-path list";
-    reference "3.6.1";
+    reference "4.0.0";
   }
 
   revision "2024-06-19" {

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,13 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.6.1";
+
+  revision "2025-04-07" {
+    description
+      "Fix enclosing container name for p2p-primary-path list";
+    reference "3.6.1";
+  }
 
   revision "2024-06-19" {
     description
@@ -1334,7 +1340,7 @@ submodule openconfig-mpls-te {
     description
       "Top level grouping for p2p primary paths";
 
-    container p2p-primary-path {
+    container p2p-primary-paths {
       description
         "Primary paths associated with the LSP";
 


### PR DESCRIPTION
`/openconfig-network-instance:network-instances/network-instance/mpls/lsps/constrained-path/tunnels/tunnel/p2p-tunnel-attributes/p2p-primary-path/p2p-primary-path`

### Change Scope

* This small change fixes `p2p-primary-path` list enclosing container name so it matches conventional OC naming (i.e., plural of enclosed list name). What makes this particularly distracting when interacting with this datamodel is that the `p2p-secondary` counterpart of this container (`.../p2p-tunnel-attributes/p2p-secondary-paths`) is following the convention correctly.

* This change is not backwards compatible.