### PR TITLE
Update lag-speed definition in openconfig-if-aggregate.yang

### DIFF
--- a/release/models/interfaces/openconfig-if-aggregate.yang
+++ b/release/models/interfaces/openconfig-if-aggregate.yang
@@ -148,7 +148,7 @@ module openconfig-if-aggregate {
       units Mbps;
       description
         "Reports effective speed of the aggregate interface,
-        based on speed of active member interfaces";
+        based on speed of forwarding-viable member interfaces";
     }
 
     leaf-list member {


### PR DESCRIPTION
### Change Scope

* The OC model definition of lag-speed leaf is changed to reflect the current behavior. 
* Lag-speed will now be calculated on the aggregate speed of forwarding-viable member interfaces as opposed to just the active interfaces as used before. 

