### PR TITLE
Change pathz telemetry to be per policy rather than per path

### DIFF
--- a/release/models/gnsi/openconfig-gnsi-pathz.yang
+++ b/release/models/gnsi/openconfig-gnsi-pathz.yang
@@ -34,6 +34,12 @@ module openconfig-gnsi-pathz {
 
   oc-ext:openconfig-version "0.3.0";
 
+  revision 2025-04-15 {
+    description
+      "Refactor gnsi counters to be only per policy.";
+    reference "0.4.0";
+  }
+
   revision 2024-02-13 {
     description
       "Major style updates and move to openconfig/public from openconfig/gnsi.
@@ -109,62 +115,43 @@ module openconfig-gnsi-pathz {
     description
       "A collection of counters collected by the gNSI.pathz module.";
 
-    container gnmi-pathz-policy-counters {
-      config false;
+    container policy {
       description
-        "A collection of per-OpenConfig path counters.";
+        "Container for a collection of per-Pathz policy counters.";
 
-      uses gnmi-pathz-policy-xpath-success-failure-counters;
-    }
-  }
-
-  grouping gnmi-pathz-policy-xpath-success-failure-counters {
-    description
-      "A collection of per-OpenConfig path counters.";
-
-    container paths {
-      description
-        "Container for a collection of per-OpenConfig path counters.";
-
-      list path {
+      list policy {
         description
-          "List for a collection of per-OpenConfig path counters.";
+          "List for a collection of per-Pathz policy counters.";
         key "name";
         leaf name {
           type leafref {
             path "../state/name";
           }
           description
-            "A OpenConfig schema path the counter were
-            collected for.
-
-            For documentation on the naming of paths, see
-            https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-path-conventions.md";
+            "A OpenConfig Pathz policy the counters were
+            collected for.";
         }
         container state {
           description
-            "Operational state for per-OpenConfig path counters.";
+            "Operational state for per-Pathz policy counters.";
           leaf name {
             type string;
             description
-              "A OpenConfig schema path the counter were
-              collected for.
-
-              For documentation on the naming of paths, see
-              https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-path-conventions.md";
+              "A per-Pathz policy the counters were
+              collected for.";
           }
           container reads {
             description
               "The counter were collected while
-              performing a read operation on the
-              schema path.";
+              performing a read operations on the
+              policy.";
             uses counters;
           }
           container writes {
             description
               "The counter were collected while
-              performing a write operation on the
-              schema path.";
+              performing a write operations on the
+              policy.";
             uses counters;
           }
         }

--- a/release/models/gnsi/openconfig-gnsi-pathz.yang
+++ b/release/models/gnsi/openconfig-gnsi-pathz.yang
@@ -32,7 +32,7 @@ module openconfig-gnsi-pathz {
     OpenConfig-path-based authorization policies installed on a networking
     device.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.4.0";
 
   revision 2025-04-15 {
     description
@@ -115,7 +115,8 @@ module openconfig-gnsi-pathz {
     description
       "A collection of counters collected by the gNSI.pathz module.";
 
-    container policy {
+    container policies {
+      config false;
       description
         "Container for a collection of per-Pathz policy counters.";
 
@@ -128,7 +129,7 @@ module openconfig-gnsi-pathz {
             path "../state/name";
           }
           description
-            "A OpenConfig Pathz policy the counters were
+            "A OpenConfig Pathz policy name the counters were
             collected for.";
         }
         container state {

--- a/release/models/gnsi/openconfig-gnsi-pathz.yang
+++ b/release/models/gnsi/openconfig-gnsi-pathz.yang
@@ -36,7 +36,7 @@ module openconfig-gnsi-pathz {
 
   revision 2025-04-15 {
     description
-      "Refactor gnsi counters to be only per policy.";
+      "Refactor gNSI counters to be only per policy.";
     reference "0.4.0";
   }
 
@@ -144,14 +144,14 @@ module openconfig-gnsi-pathz {
           container reads {
             description
               "The counter were collected while
-              performing a read operations on the
+              performing read operations on the
               policy.";
             uses counters;
           }
           container writes {
             description
               "The counter were collected while
-              performing a write operations on the
+              performing write operations on the
               policy.";
             uses counters;
           }


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* Refactoring the pathz yang telemetry to be based on per policy rather than by path.
This has been requested by multiple vendors as per path is not needed and causes a very large memory and state management issue

* this is not backwards compatible but currently these counters should be in production

### Platform Implementations

