### PR TITLE
Update openconfig-sampling-sflow.yang

### DIFF
--- a/release/models/sampling/openconfig-sampling-sflow.yang
+++ b/release/models/sampling/openconfig-sampling-sflow.yang
@@ -304,11 +304,24 @@ module openconfig-sampling-sflow {
       units bytes;
       default 128;
       description
-        "Sets the maximum number of bytes to be copied from a
-        sampled packet.";
+        "Sets the maximum number of bytes to be copied from a sampled
+        packet (content within one specific sample of a packet).";
       reference
         "RFC 3176 - InMon Corporation's sFlow: A Method for
         Monitoring Traffic in Switched and Routed Networks";
+    }
+
+   leaf datagram-size {
+      type uint16;
+      units bytes;
+      default 1400;
+      description
+        "Sets the maximum total size (in bytes) for an sFlow datagram
+        (the UDP export packet sent to a collector, which may bundles
+        many samples).";
+      reference
+        "RFC 3176 - InMon Corporation's sFlow: The maximum number of data
+        bytes that can be sent in a single sample datagram.";
     }
 
     uses sflow-polling-interval-config;


### PR DESCRIPTION
Clarify sample-size description & add datagram-size to global config

1) sample-size description: clarified to define max bytes for "content within one specific sample of a packet," distinguishing it from overall datagram size.
2) new datagram-size leaf: sets max total byte size for sFlow UDP export datagrams (sent to collectors)

[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* [Please briefly describe the change that is being made to the models.]
* [Please indicate whether this change is backwards compatible.]
### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].
