### PR TITLE
Static wecmp

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -124,6 +124,17 @@ module openconfig-local-routing {
       link-layer address discovery against";
   }
 
+  identity LOCAL_DEFINED_WEIGHT {
+    description
+      "A base identity type of local defined next-hops weight";
+  }
+
+  identity AUTO {
+    base LOCAL_DEFINED_WEIGHT;
+    description
+      "Inherit weight from egress interface bandwidth";
+  }
+
   // typedef statements
 
   typedef local-defined-next-hop {
@@ -133,6 +144,15 @@ module openconfig-local-routing {
     description
       "Pre-defined next-hop designation for locally generated
       routes";
+  }
+
+  typedef local-defined-weight {
+    type identityref {
+      base LOCAL_DEFINED_WEIGHT;
+    }
+    description
+      "Pre-defined wECMP weight for locally generated
+      static route next-hops";
   }
 
   // grouping statements
@@ -188,6 +208,26 @@ module openconfig-local-routing {
         inherited from the default preference of the implementation for
         static routes.";
     }
+
+    leaf wecmp-weight {
+      type union {
+        type uint64;
+        type local-defined-weight";
+      }
+      description
+        "The weight of next-hop used for WECMP (a.k.a. UCMP, WCMP). This
+        leaf has significance only if multiple next-hops of given prefix
+        form ECMP group, AND all of this next-hops have wecmp-weight leaf
+        specified. Else, wecmp-weight should be ignored.
+        The value "AUTO" sets value to be equall to egress interface
+        bandwidt expressed in bps (not Bps as BGP link-bandwidth
+        extended-community does).
+        It is recommended to express explicit value in bps, what alows
+        mixing next-hops with explicit value and next-hops with "AUTO".
+        This leaf is valid only if recurse leaf is set to false, or 
+        if interface-ref is specified.";
+    }
+
   }
 
   grouping local-static-config {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -212,7 +212,7 @@ module openconfig-local-routing {
     leaf wecmp-weight {
       type union {
         type uint64;
-        type local-defined-weight";
+        type local-defined-weight;
       }
       description
         "The weight of next-hop used for WECMP (a.k.a. UCMP, WCMP). This

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -219,7 +219,7 @@ module openconfig-local-routing {
         leaf has significance only if multiple next-hops of given prefix
         form ECMP group, AND all of this next-hops have wecmp-weight leaf
         specified. Else, wecmp-weight should be ignored.
-        The value "AUTO" sets value to be equall to egress interface
+        The value 'AUTO' sets value to be equall to egress interface
         bandwidt expressed in bps (not Bps as BGP link-bandwidth
         extended-community does).
         It is recommended to express explicit value in bps, what alows

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -223,7 +223,7 @@ module openconfig-local-routing {
         bandwidt expressed in bps (not Bps as BGP link-bandwidth
         extended-community does).
         It is recommended to express explicit value in bps, what alows
-        mixing next-hops with explicit value and next-hops with "AUTO".
+        mixing next-hops with explicit value and next-hops with 'AUTO'.
         This leaf is valid only if recurse leaf is set to false, or 
         if interface-ref is specified.";
     }


### PR DESCRIPTION
### Change Scope
This change introduce WECMP weight attribute for static route next-hop. 
The new `wecmp-weight`leaf has significance only if multiple next-hops of given prefix form ECMP group, AND all of this next-hops have wecmp-weight leaf specified. Else, wecmp-weight should be ignored.

The wecmp-weight could be either uint64  or "AUTO".
The value 'AUTO' sets value to be equall to egress interface bandwidt expressed in bps (not Bps as BGP link-bandwidth extended-community does).

This leaf is valid only if recurse leaf is set to false, or if interface-ref is specified.
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw static-routes
                 +--rw static* [prefix]
                    +--rw next-hops
                       +--rw next-hop* [index]
                          +--rw index            -> ../config/index
                          +--rw config
                          |  +--rw index?          string
                          |  +--rw next-hop?       union
                          |  +--rw recurse?        boolean
                          |  +--rw metric?         uint32
                          |  +--rw preference?     uint32
+                         |  +--rw wecmp-weight?   union
                          +--ro state
                          |  +--ro index?          string
                          |  +--ro next-hop?       union
                          |  +--ro recurse?        boolean
                          |  +--ro metric?         uint32
                          |  +--ro preference?     uint32
+                         |  +--ro wecmp-weight?   union
```

### Platform Implementations

* Cisco XR: [Configure Native UCMP for Static Routing](https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/routing/75x/b-routing-cg-ncs5500-75x/implementing-static-routes.html#id_15043)
Note: In XR implementation presence of 'metric' with equal value set WECMP in "Local" mode what is functional equivalent to "AUTO". Lack of 'metric' make simple ECMP.
* Arista EoS: [link to documentation](https://www.arista.com/en/support/toi/eos-4-32-1f/19859-static-route-ucmp-local-forwarding)
```
ip route 10.0.0.1/8 192.168.2.2 weight 5
ip route 10.0.0.1/8 192.168.1.2 weight 3
```