### PR TITLE
Proposed change associated with #1298

### DIFF
--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -403,13 +403,23 @@ submodule openconfig-qos-interfaces {
     leaf ecn-marked-pkts {
       type oc-yang:counter64;
       description
-        "number of packets for which ECN codepoint has been changed from ECT to CE";
+        "Number of ECN capable packets that experienced congestion on this
+         interface and which are marked as CE.
+
+         This count includes packets that have previously experienced
+         congestion and have already been marked as CE.";
     }
 
     leaf ecn-marked-octets {
       type oc-yang:counter64;
       description
-        "Number of octets for which ECN codepoint has been changed from ECT to CE";
+        "Number of octets for capable packets that experienced congestion on this
+         interface and which are marked as CE. 
+
+         This count includes packets that have previously experienced
+         congestion and have already been marked as CE.";
+
+         Octet equivalent counter for ecn-marked-pkts.";
     }
 
     leaf ecn-selected-pkts {


### PR DESCRIPTION
### Change Scope

* Clarify meaning of ecn-marked-pkts and ecn-marked-octets
* Not backwards compatible, but unclear if there are any existing implementations.
* See #1298 for more details
*
### Platform Implementations

 * Implementation A: Cisco IOS XR

This PR is intended to act as a discussion point to determine whether this change is acceptable.

