### PR TITLE
Added OpenConfig Support for Static Multicast RPF Routes

### DIFF
--- a/release/models/multicast/openconfig-mrib.yang
+++ b/release/models/multicast/openconfig-mrib.yang
@@ -1,0 +1,180 @@
+module openconfig-mrib {
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/mrib";
+
+  prefix "oc-mrib";
+
+  // import some basic types/interfaces
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-inet-types { prefix "openconfig-inet-types"; }
+  import openconfig-interfaces { prefix "openconfig-interfaces"; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Support for Static MRIB Routes.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2025-05-12" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping mrib-next-hop-config {
+    description
+      "Configuration parameters relating to the next-hop entry.";
+
+    leaf index {
+      type string;
+      description
+        "An user-specified identifier utilised to uniquely reference the next-hop
+        entry in the next-hop list. The value of this index has no semantic meaning
+        other than for referencing the entry. It is observed that implementations
+        typically only support a numeric value for this string.";
+    }
+
+    leaf next-hop-addr {
+      type openconfig-inet-types:ip-address;
+      description
+        "The next-hop that is to be used for the static MRIB route - this one is
+        specified as an IP address.";
+    }
+
+    leaf preference {
+      type uint8;
+      description
+        "Administrative Distance (preference) of the entry. The preference defines
+        the order of selection when multiple sources (protocols, static, etc.)
+        contribute to the same prefix entry. The lower the preference, the more
+        preferable the prefix is. When this value is not specified, the preference
+        is inherited from the default preference of the implementation for
+        static MRIB routes.";
+    }
+  }
+
+  grouping static-mrib-config {
+    description
+      "Configuration data for static MRIB routes.";
+
+    leaf prefix {
+      type openconfig-inet-types:ip-prefix;
+      description
+        "Reference to the source prefix.";
+    }
+  }
+
+  grouping mrib-nexthops-container {
+    description
+      "Grouping for the next-hops container.";
+
+    container next-hops {
+      description
+        "Configuration and state parameters relating to the
+        next-hops that are to be utilised for the MRIB route being specified.";
+
+      list next-hop {
+        key "index";
+        description
+          "A list of next-hops to be utilised for the static MRIB
+          route being specified.";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "A reference to the index of the current next-hop.
+            The index is intended to be a user-specified value
+            which can be used to reference the next-hop in
+            question, without any other semantics being
+            assigned to it.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the
+            next-hop entry.";
+
+          uses mrib-next-hop-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the next-hop entry.";
+
+          uses mrib-next-hop-config;
+        }
+
+        uses oc-if:interface-ref;
+      }
+    }
+  }
+
+  grouping mrib-routes-list {
+    description
+      "Grouping for the list of Static MRIB Routes.";
+
+    container routes {
+      description
+        "Enclosing container for the list of Static MRIB Routes.";
+
+      list route {
+        key "prefix";
+        description
+          "List of MRIB routes.";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+          description
+            "Reference to the source prefix.";
+        }
+
+        container config {
+          description
+            "Configuration data for static MRIB routes.";
+
+          uses static-mrib-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for static MRIB routes.";
+
+          uses static-mrib-config;
+        }
+
+        uses mrib-nexthops-container;
+      }
+    }
+  }
+
+  grouping mrib-top {
+    description
+      "Top-level grouping for Static MRIB Routes.";
+
+    container static-mrib {
+      description
+        "Top-level container to globally configure all Static MRIB routes.";
+      reference
+        "section 2.1 of RFC 4601";
+
+      uses mrib-routes-list;
+    }
+  }
+
+}

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -28,6 +28,7 @@ module openconfig-network-instance {
   import openconfig-isis { prefix "oc-isis"; }
   import openconfig-aft { prefix "oc-aft"; }
   import openconfig-pim { prefix "oc-pim"; }
+  import openconfig-mrib { prefix "oc-mrib"; }
   import openconfig-igmp { prefix "oc-igmp"; }
   import openconfig-evpn { prefix "oc-evpn"; }
   import openconfig-pcep { prefix "oc-pcep"; }
@@ -50,7 +51,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.6.0";
+  oc-ext:openconfig-version "4.7.0";
+
+  revision "2025-05-12" {
+    description
+      "Add Static MRIB Routes to network instance";
+    reference "4.7.0";
+  }
 
   revision "2025-03-26" {
     description
@@ -993,6 +1000,16 @@ module openconfig-network-instance {
               description
                 "Configuration and state parameters relating to Protocol
                 Indepdendent Multicast (PIM).";
+            }
+
+            uses oc-mrib:mrib-top {
+              when "./config/identifier = 'oc-pol-types:MRIB'" {
+                description
+                  "Include MRIB configuration when the protocol is of type
+                  MRIB";
+              }
+              description
+                "Configuration and state parameters relating to MRIB";
             }
 
             uses oc-igmp:igmp-top {

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -25,7 +25,13 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2025-05-12" {
+    description
+      "Add MRIB to INSTALL_PROTOCOL_TYPE";
+    reference "3.4.0";
+  }
 
   revision "2024-05-14" {
     description
@@ -248,6 +254,14 @@ revision "2022-11-08" {
       "Protocol Independent Multicast";
     reference
       "RFC 7761";
+  }
+
+  identity MRIB {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Static MRIB Routes";
+    reference
+      "RFC 4601: Section 2.1";
   }
 
   identity IGMP {


### PR DESCRIPTION
* (M) release/models/multicast/openconfig-mrib.yang
* (M) release/models/network-instance/openconfig-network-instance.yang
* (M) release/models/policy/openconfig-policy-types.yang

### Change Scope

* In the multicast forwarding table (MFIB), each (*,G) and (S, G) route has an expected incoming interface for traffic. This interface is determined through a RPF lookup. To influence this lookup, static RPF routes can be manually configured. These static routes are stored in the MRIB and are used during the RPF check to ensure multicast traffic is forwarded correctly.
* Today it is not possible to set a static RPF route for multicast via OpenConfig. The proposal is to have a container named static-mrib for supporting rpf routes. There exists a static-routes container under protocol. Hence, we would like to have the static-mrib container at the same level, under protocol. At the same time, we had to consider adding another top level container that allows for config/state to globally configure all MRIB routes. Hence we propose another container named routes that goes under static-mrib. This way we will be able to create /network-instances/network-instance/protocols/protocol/static-mrib/{config|state} if needed, in future.

* The pyang output is given below.
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw static-mrib
                 +--rw routes
                    +--rw route* [prefix]
                       +--rw prefix       -> ../config/prefix
                       +--rw config
                       |  +--rw prefix?   openconfig-inet-types:ip-prefix
                       +--ro state
                       |  +--ro prefix?   openconfig-inet-types:ip-prefix
                       +--rw next-hops
                          +--rw next-hop* [index]
                             +--rw index            -> ../config/index
                             +--rw config
                             |  +--rw index?           string
                             |  +--rw next-hop-addr?   openconfig-inet-types:ip-address
                             |  +--rw preference?      uint8
                             +--ro state
                             |  +--ro index?           string
                             |  +--ro next-hop-addr?   openconfig-inet-types:ip-address
                             |  +--ro preference?      uint8
                             +--rw interface-ref
                                +--rw config
                                |  +--rw interface?      -> /oc-if:interfaces/interface/name
                                |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
                                +--ro state
                                   +--ro interface?      -> /oc-if:interfaces/interface/name
                                   +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
``` 
### Platform Implementations

 * Arista: https://www.arista.com/en/um-eos/eos-multicast-architecture
 
 * CLI Configuration:
```
switch(config)# router multicast
switch(config-router-multicast)# ipv4
switch(config-router-multicast-ipv4)# rpf route {source_prefix | source_address | mask}{rpf_interface | rpf_neighbor>} [admin_distance]
``` 