### PR TITLE
Add GRE and MPLS encap-headers to network-instance/static

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -329,7 +329,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to GRE encapsulation headers.";
 
-                uses aft-common-entry-nexthop-encap-gre-config;
+                uses aft-common-entry-nexthop-gre-state;
               }
             }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -270,7 +270,7 @@ submodule openconfig-aft-common {
             description
               "State parameters relating to GRE encapsulation.";
 
-            uses aft-common-entry-nexthop-gre-state;
+            uses aft-common-entry-nexthop-encap-gre-config;
           }
         }
 
@@ -323,7 +323,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to GRE encapsulation headers.";
 
-                uses aft-common-entry-nexthop-gre-state;
+                uses aft-common-entry-nexthop-encap-gre-config;
               }
             }
 
@@ -627,7 +627,7 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-gre-state {
+  grouping aft-common-entry-nexthop-encap-gre-config {
     description
       "GRE encapsulation applied on a IPv4 and IPv6 next-hop.";
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -28,7 +28,7 @@ submodule openconfig-aft-common {
   revision "2025-05-15" {
     description
       "Add GRE and MPLS to encap-headers.";
-    reference "3.0.0";
+    reference "3.1.0";
   }
 
   revision "2025-03-12" {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-17" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description
@@ -691,7 +697,7 @@ submodule openconfig-aft-common {
         "The value of the MPLS traffic class (TC) bits, formerly known as the
          EXP bits.";
     }
-    leaf mpls-label {
+    leaf label {
       type oc-mplst:mpls-label;
       description
         "A MPLS label value.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -640,9 +640,11 @@ submodule openconfig-aft-common {
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "The source IP address for the GRE encapsulation may be expressed
-        using this leaf (src-ip) or if may be derived from
-        '../../interface-ref/state/subinterface'";
+        "The src-ip for the encapsulation is statically configured using this
+        leaf. If not populated the src-ip is expected to be dynamically
+        derived from the subinterface that the packet is forwarded from. If
+        an implementation requires a static src-ip, then it should return
+        an error if this is unspecified.";
     }
 
     leaf dst-ip {
@@ -668,9 +670,11 @@ submodule openconfig-aft-common {
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "The source IP address for the GRE encapsulation may be expressed
-        using this leaf (src-ip) or if may be derived from
-        '../../interface-ref/state/subinterface'";
+        "The src-ip for the encapsulation is statically configured using this
+        leaf. If not populated the src-ip is expected to be dynamically
+        derived from the subinterface that the packet is forwarded from. If
+        an implementation requires a static src-ip, then it should return
+        an error if this is unspecified.";
     }
 
     leaf dst-ip {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.0.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,13 +23,7 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.1.0";
-
-  revision "2025-05-15" {
-    description
-      "Add GRE and MPLS to encap-headers.";
-    reference "3.1.0";
-  }
+  oc-ext:openconfig-version "3.0.0";
 
   revision "2025-03-12" {
     description
@@ -635,16 +629,12 @@ submodule openconfig-aft-common {
 
   grouping aft-common-entry-nexthop-gre-state {
     description
-      "GRE encapsulation applied on next-hop.";
+      "GRE encapsulation applied on a IPv4 and IPv6 next-hop.";
 
     leaf src-ip {
       type oc-inet:ip-address;
       description
-        "The src-ip for the encapsulation is statically configured using this
-        leaf. If not populated the src-ip is expected to be dynamically
-        derived from the subinterface that the packet is forwarded from. If
-        an implementation requires a static src-ip, then it should return
-        an error if this is unspecified.";
+        "The source IP address for the GRE encapsulation.";
     }
 
     leaf dst-ip {
@@ -656,31 +646,9 @@ submodule openconfig-aft-common {
     leaf ttl {
       type uint8;
       description
-        "This leaf reflects the configured/default TTL value that is used in the
-         outer header during packet encapsulation. When this leaf is not set,
-         the TTL value of the inner packet is copied over as the outer packet's
-         TTL value during encapsulation.";
-    }
-  }
-
-  grouping aft-common-entry-nexthop-encap-gre-config {
-    description
-      "Configuration of GRE encapsulation applied on next-hop.";
-
-    leaf src-ip {
-      type oc-inet:ip-address;
-      description
-        "The src-ip for the encapsulation is statically configured using this
-        leaf. If not populated the src-ip is expected to be dynamically
-        derived from the subinterface that the packet is forwarded from. If
-        an implementation requires a static src-ip, then it should return
-        an error if this is unspecified.";
-    }
-
-    leaf dst-ip {
-      type oc-inet:ip-address;
-      description
-        "Destination IP address to use for the encapsulated packet.";
+        "If specified, this TTL value is used on the GRE header during
+        encapsulation. If unspecified, the TTL value of the inner packet is
+        copied to the GRE header TTL value during encapsulation.";
     }
   }
 
@@ -710,24 +678,6 @@ submodule openconfig-aft-common {
 
         Note: a swap operation is reflected by entries in the
         popped-mpls-label-stack and the pushed-mpls-label-stack";
-    }
-  }
-
-  grouping aft-common-entry-nexthop-encap-mpls-config {
-    description
-      "Configuration of MPLS encapsulation of a packet.";
-
-    leaf traffic-class {
-      type oc-mplst:mpls-tc;
-      description
-        "The value of the MPLS traffic class (TC) bits, formerly known as the
-         EXP bits.";
-    }
-
-    leaf mpls-label {
-      type oc-mplst:mpls-label;
-      description
-        "An MPLS label value.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -270,7 +270,7 @@ submodule openconfig-aft-common {
             description
               "State parameters relating to GRE encapsulation.";
 
-            uses aft-common-entry-nexthop-gre-state;
+            uses aft-common-entry-nexthop-encap-gre-state;
           }
         }
 
@@ -323,7 +323,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to GRE encapsulation headers.";
 
-                uses aft-common-entry-nexthop-gre-state;
+                uses aft-common-entry-nexthop-encap-gre-state;
               }
             }
 
@@ -366,7 +366,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to MPLS encapsulation headers.";
 
-                uses aft-common-entry-nexthop-mpls-state;
+                uses aft-common-entry-nexthop-encap-mpls-state;
               }
             }
 
@@ -627,9 +627,9 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-gre-state {
+  grouping aft-common-entry-nexthop-encap-gre-state {
     description
-      "GRE encapsulation applied on a IPv4 and IPv6 next-hop.";
+      "GRE encapsulation applied on next-hop.";
 
     leaf src-ip {
       type oc-inet:ip-address;
@@ -655,7 +655,7 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-mpls-state {
+  grouping aft-common-entry-nexthop-encap-mpls-state {
     description
       "MPLS encapsulation of a packet.";
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -681,6 +681,22 @@ submodule openconfig-aft-common {
     }
   }
 
+  grouping aft-common-entry-nexthop-encap-mpls-config {
+    description
+      "MPLS encapsulation of a packet.";
+
+    leaf traffic-class {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS traffic class (TC) bits, formerly known as the
+         EXP bits.";
+    }
+    leaf mpls-label {
+      type oc-mplst:mpls-label;
+      description
+        "A MPLS label value.";
+    }
+  }
 
   grouping aft-common-entry-nexthop-encap-udp-v4-state {
     description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -276,7 +276,7 @@ submodule openconfig-aft-common {
             description
               "State parameters relating to GRE encapsulation.";
 
-            uses aft-common-entry-nexthop-encap-gre-state;
+            uses aft-common-entry-nexthop-gre-state;
           }
         }
 
@@ -329,7 +329,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to GRE encapsulation headers.";
 
-                uses aft-common-entry-nexthop-encap-gre-state;
+                uses aft-common-entry-nexthop-encap-gre-config;
               }
             }
 
@@ -372,7 +372,7 @@ submodule openconfig-aft-common {
                 description
                   "State parameters relating to MPLS encapsulation headers.";
 
-                uses aft-common-entry-nexthop-encap-mpls-state;
+                uses aft-common-entry-nexthop-mpls-state;
               }
             }
 
@@ -633,7 +633,7 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-encap-gre-state {
+  grouping aft-common-entry-nexthop-gre-state {
     description
       "GRE encapsulation applied on next-hop.";
 
@@ -661,7 +661,26 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-common-entry-nexthop-encap-mpls-state {
+  grouping aft-common-entry-nexthop-encap-gre-config {
+    description
+      "Configuration of GRE encapsulation applied on next-hop.";
+
+    leaf src-ip {
+      type oc-inet:ip-address;
+      description
+        "The source IP address for the GRE encapsulation may be expressed
+        using this leaf (src-ip) or if may be derived from
+        '../../interface-ref/state/subinterface'";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-mpls-state {
     description
       "MPLS encapsulation of a packet.";
 
@@ -687,6 +706,24 @@ submodule openconfig-aft-common {
 
         Note: a swap operation is reflected by entries in the
         popped-mpls-label-stack and the pushed-mpls-label-stack";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-encap-mpls-config {
+    description
+      "Configuration of MPLS encapsulation of a packet.";
+
+    leaf traffic-class {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS traffic class (TC) bits, formerly known as the
+         EXP bits.";
+    }
+
+    leaf mpls-label {
+      type oc-mplst:mpls-label;
+      description
+        "An MPLS label value.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -44,7 +44,7 @@ module openconfig-aft {
 
   oc-ext:openconfig-version "3.1.0";
 
-  revision "2025-05-15" {
+  revision "2025-07-17" {
     description
       "Add GRE and MPLS to encap-headers.";
     reference "3.1.0";

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-05-15" {
+    description
+      "Add GRE and MPLS to encap-headers.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -302,7 +302,6 @@ module openconfig-network-instance-static {
 
             uses oc-aft:aft-common-entry-nexthop-encap-gre-config;
           }
-
           container state {
             config false;
             description

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -300,7 +300,7 @@ module openconfig-network-instance-static {
             description
               "Configuration parameters relating to GRE encapsulation headers.";
 
-            uses oc-aft:aft-common-entry-nexthop-encap-gre-state;
+            uses oc-aft:aft-common-entry-nexthop-encap-gre-config;
           }
 
           container state {
@@ -308,7 +308,7 @@ module openconfig-network-instance-static {
             description
               "State parameters relating to GRE encapsulation headers.";
 
-            uses oc-aft:aft-common-entry-nexthop-encap-gre-state;
+            uses oc-aft:aft-common-entry-nexthop-encap-gre-config;
           }
         }
 
@@ -323,7 +323,7 @@ module openconfig-network-instance-static {
             description
               "Configuration parameters relating to MPLS encapsulation headers.";
 
-            uses oc-aft:aft-common-entry-nexthop-encap-mpls-state;
+            uses oc-aft:aft-common-entry-nexthop-encap-mpls-config;
           }
 
           container state {
@@ -331,7 +331,7 @@ module openconfig-network-instance-static {
             description
               "State parameters relating to GRE encapsulation headers.";
 
-            uses oc-aft:aft-common-entry-nexthop-encap-mpls-state;
+            uses oc-aft:aft-common-entry-nexthop-encap-mpls-config;
           }
         }
 

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -317,7 +317,8 @@ module openconfig-network-instance-static {
           description
             "Container of nodes for MPLS encapsulation.  When this
             container is used, a MPLS header is added to the encapsulation
-            list.";
+            list.  Only client configured leaves are defined.  The system
+            should set the MPLS TTL and Bottom of Stack bit per RFC 3032.";
 
           container config {
             description

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -22,7 +22,13 @@ module openconfig-network-instance-static {
   description
     "Static configurations associated with a network instance";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2025-05-15" {
+    description
+      "Adding static encapsulation headers for GRE and MPLS.";
+    reference "0.2.0";
+  }
 
   revision "2025-02-20" {
     description
@@ -280,6 +286,52 @@ module openconfig-network-instance-static {
               "State parameters relating to encapsulation headers.";
 
             uses oc-aft:aft-common-entry-nexthop-encap-udp-v4-state;
+          }
+        }
+
+        container gre {
+          when "../config/type = 'oc-aftt:GRE'";
+          description
+            "Container of nodes for GRE encapsulation.  When this
+            container is used, a GRE header is added to the encapsulation
+            list.";
+
+          container config {
+            description
+              "Configuration parameters relating to GRE encapsulation headers.";
+
+            uses oc-aft:aft-common-entry-nexthop-encap-gre-state;
+          }
+
+          container state {
+            config false;
+            description
+              "State parameters relating to GRE encapsulation headers.";
+
+            uses oc-aft:aft-common-entry-nexthop-encap-gre-state;
+          }
+        }
+
+        container mpls {
+          when "../config/type = 'oc-aftt:MPLS'";
+          description
+            "Container of nodes for MPLS encapsulation.  When this
+            container is used, a MPLS header is added to the encapsulation
+            list.";
+
+          container config {
+            description
+              "Configuration parameters relating to MPLS encapsulation headers.";
+
+            uses oc-aft:aft-common-entry-nexthop-encap-mpls-state;
+          }
+
+          container state {
+            config false;
+            description
+              "State parameters relating to GRE encapsulation headers.";
+
+            uses oc-aft:aft-common-entry-nexthop-encap-mpls-state;
           }
         }
 

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -24,7 +24,7 @@ module openconfig-network-instance-static {
 
   oc-ext:openconfig-version "0.2.0";
 
-  revision "2025-05-15" {
+  revision "2025-07-17" {
     description
       "Adding static encapsulation headers for GRE and MPLS.";
     reference "0.2.0";

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -318,7 +318,9 @@ module openconfig-network-instance-static {
             "Container of nodes for MPLS encapsulation.  When this
             container is used, a MPLS header is added to the encapsulation
             list.  Only client configured leaves are defined.  The system
-            should set the MPLS TTL and Bottom of Stack bit per RFC 3032.";
+            should set the MPLS TTL and Bottom of Stack bit per RFC 3032.
+            To specify multiple labels, the client should create multiple
+            encap-header list entries.";
 
           container config {
             description


### PR DESCRIPTION
### Change Scope

* Add GRE and MPLS encap-headers to network-instance/static
* This change is backwards compatible
 
### Platform Implementations
While device implementations today widely support encapsulation of MPLS, GRE and MPLS into GRE packets this PR provides a method to configure a static next-hop-group for the purpose of encapsulation.  Using static next-hops for MPLS in GRE encapsulation is a new feature being pursued from multiple device implementations to unify a single vendor neutral way to configure this encapsulation.  

* Arista EOS supports [MPLS in GRE encapsulation](https://www.arista.com/en/um-eos/eos-nexthop-groups) 
* Cisco IOS XR supports [MPLS in GRE encapsulation](https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/17-2/configuration_guide/mpls/b_172_mpls_9400_cg/configuring_mpls_over_gre.pdf)
* JunOS supports [MPLS in GRE encapsulation](https://www.juniper.net/documentation/us/en/software/junos/interfaces-encryption/topics/topic-map/configuring-flexible-tunnel-interfaces.html)


### Tree view
```diff
         +--rw static
         |  +--rw next-hop-groups
         |  |  +--rw next-hop-group* [name]
         |  |     +--rw name         -> ../config/name
         |  |     +--rw config
         |  |     |  +--rw name?   string
         |  |     +--ro state
         |  |     |  +--ro name?   string
         |  |     +--rw next-hops
         |  |        +--rw next-hop* [index]
         |  |           +--rw index     -> ../config/index
         |  |           +--rw config
         |  |           |  +--rw index?   -> ../../../../../../next-hops/next-hop/index
         |  |           +--ro state
         |  |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
         |  +--rw next-hops
         |     +--rw next-hop* [index]
         |        +--rw index            -> ../config/index
         |        +--rw config
         |        |  +--rw index?                   string
         |        |  +--rw next-network-instance?   -> /network-instances/network-instance/config/name
         |        |  +--rw next-hop?                union
         |        |  +--rw nh-network-instance?     -> /network-instances/network-instance/config/name
         |        |  +--rw recurse?                 boolean
         |        |  +--rw metric?                  uint32
         |        |  +--rw preference?              uint32
         |        +--ro state
         |        |  +--ro index?                   string
         |        |  +--ro next-network-instance?   -> /network-instances/network-instance/config/name
         |        |  +--ro next-hop?                union
         |        |  +--ro nh-network-instance?     -> /network-instances/network-instance/config/name
         |        |  +--ro recurse?                 boolean
         |        |  +--ro metric?                  uint32
         |        |  +--ro preference?              uint32
         |        +--rw encap-headers
         |           +--rw encap-header* [index]
         |              +--rw index     -> ../config/index
         |              +--rw config
         |              |  +--rw index?   uint8
         |              |  +--rw type?    oc-aftt:encapsulation-header-type
         |              +--ro state
         |              |  +--ro index?   uint8
         |              |  +--ro type?    oc-aftt:encapsulation-header-type
         |              +--rw udp-v4
         |              |  +--rw config
         |              |  |  +--rw src-ip?         oc-inet:ipv4-address
         |              |  |  +--rw dst-ip?         oc-inet:ipv4-address
         |              |  |  +--rw dscp?           oc-inet:dscp
         |              |  |  +--rw src-udp-port?   oc-inet:port-number
         |              |  |  +--rw dst-udp-port?   oc-inet:port-number
         |              |  |  +--rw ip-ttl?         uint8
         |              |  +--ro state
         |              |     +--ro src-ip?         oc-inet:ipv4-address
         |              |     +--ro dst-ip?         oc-inet:ipv4-address
         |              |     +--ro dscp?           oc-inet:dscp
         |              |     +--ro src-udp-port?   oc-inet:port-number
         |              |     +--ro dst-udp-port?   oc-inet:port-number
         |              |     +--ro ip-ttl?         uint8
+        |              +--rw gre
+        |              |  +--rw config
+        |              |  |  +--rw src-ip?   oc-inet:ip-address
+        |              |  |  +--rw dst-ip?   oc-inet:ip-address
+        |              |  |  +--rw ttl?   oc-inet:ip-address
+        |              |  +--ro state
+        |              |     +--ro src-ip?   oc-inet:ip-address
+        |              |     +--ro dst-ip?   oc-inet:ip-address
+        |              |  |  +--rw ttl?   oc-inet:ip-address
+        |              +--rw mpls
+        |                 +--rw config
+        |                 |  +--rw traffic-class?   oc-mplst:mpls-tc
+        |                 |  +--rw label?      oc-mplst:mpls-label
+        |                 +--ro state
+        |                 |  +--rw traffic-class?   oc-mplst:mpls-tc
+        |                 |  +--rw label?      oc-mplst:mpls-label
```


### Example configuration for static next-hops with 1 MPLS label inside GRE encapsulation
```json
{
  "next-hops": {
    "next-hop": [
      {
        "config": {
          "index": "Dest A-NH1",
          "metric": 10,
          "next-hop": "1.2.3.4"
        },
        "encap-headers": {
          "encap-header": [
            {
              "config": {
                "index": 1
                "type": "GRE",
              },
              "index": 1,
              "gre": {
                "config": {
                  "dst-ip": "1.1.1.1",
                  "src-ip": "2.2.2.2",
                  "dscp": 8,
                  "ttl": 32
                }
              }
            },
            {
              "config": {
                "index": 2
                "type": "MPLS",
              },
              "index": 2,
              "mpls": {
                "config": {
                  "label": 100,
                  "traffic-class": 1
                }
              }
            }
          ]
        },
        "index": "Dest A-NH1"
      }
    ]
  }
}
```