### PR TITLE
Add two new enums for scheduler-policy priority.

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "0.11.2";
+  oc-ext:openconfig-version "0.11.3";
+
+  revision "2025-05-22" {
+    description
+      "Add two new enums for scheduler-policy priority.";
+    reference "0.11.3";
+  }
 
   revision "2023-10-13" {
     description
@@ -1230,6 +1236,18 @@ submodule openconfig-qos-elements {
             "This scheduler term is considered as a strict priority
             term - such that packets that arrive in the queue are
             immediately serviced.";
+        }
+        enum DWRR {
+          description
+            "This scheduler term is considered as a deficit weighted
+            round robin term - such that packets that arrive in the queue are
+            serviced based on deficit counter with weighted round robin fashion.";
+        }
+        enum WRR {
+          description
+            "This scheduler term is considered as a deficit weighted
+            round robin term - such that packets that arrive in the queue are
+            serviced based on weighted round robin fashion.";
         }
       }
       description

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -1245,7 +1245,7 @@ submodule openconfig-qos-elements {
         }
         enum WRR {
           description
-            "This scheduler term is considered as a deficit weighted
+            "This scheduler term is considered as a weighted
             round robin term - such that packets that arrive in the queue are
             serviced based on weighted round robin fashion.";
         }


### PR DESCRIPTION
### Change Scope

* Add two new enums for qos scheduler-policy priority.
* This change is backwards compatible.
### Platform Implementations

 * Implementation from Dell: [Egress QoS](https://infohub.delltechnologies.com/en-us/l/dell-enterprise-sonic-quality-of-service-qos/egress-qos-flow/#:~:text=With%20a%20scheduler%20policy%2C%20the,burst%20size%20(pbs)%20parameters.)
 * Implementation from Cicso: [Weighted deficit round robin](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/mds9000/sw/7_3/configuration/qos/cisco_mds9000_qos_config_guide/configuring_qos.pdf). [Weighted round robin](https://www.cisco.com/en/US/docs/switches/lan/csb_switching_general/olh/Sx200/1.3.0/en/Qos_Queues.html#:~:text=When%20the%20queuing%20mode%20is%20Weighted%20Round%20Robin%2C%20queues%20are,higher%20queues%20in%20strict%20priority.)
