### PR TITLE
Add ip-ttl policy forwarding action

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -430,13 +430,13 @@ submodule openconfig-pf-forwarding-policies {
     leaf ip-ttl {
       type uint8;
       description
-        "If set, this leaf causes the local system to re-write the IP TTL of
-         matching packets to the specified value and then passed to the next
-         stage of packet processing.
+        "If set, this leaf causes the local system to not decrement the TTL
+        and instead re-write the IP TTL of matching packets to the specified
+        value.
 
-         When this leaf is not set, the TTL value of the matching packet is
-         not affected by this policy and should be processed according to
-         normal forwarding rules.";
+        When this leaf is not set, the TTL value of the matching packet is
+        not affected by this policy and should be processed according to
+        normal forwarding rules.";
     }
 
   }

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-05-27" {
+    description
+      "Add action to set IP TTL.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description
@@ -404,6 +410,16 @@ submodule openconfig-pf-forwarding-policies {
         the rule. Following the decapsulation it should subsequently forward the
         encapsulated packet according to the underlying IPv4 or IPv6 header.";
     }
+
+    leaf ip-ttl {
+      type uint8;
+      description
+        "If set, this leaf causes the local system to re-write the IP TTL of
+         matching packets to the specified value. When this leaf is not set,
+         the TTL value of the matching packet is not affected by this policy
+         and should be processed according to normal forwarding rules.";
+    }
+
   }
 
   grouping pf-forwarding-policy-action-encapsulate-gre {

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -415,9 +415,12 @@ submodule openconfig-pf-forwarding-policies {
       type uint8;
       description
         "If set, this leaf causes the local system to re-write the IP TTL of
-         matching packets to the specified value. When this leaf is not set,
-         the TTL value of the matching packet is not affected by this policy
-         and should be processed according to normal forwarding rules.";
+         matching packets to the specified value and then passed to the next
+         stage of packet processing.
+
+         When this leaf is not set, the TTL value of the matching packet is
+         not affected by this policy and should be processed according to
+         normal forwarding rules.";
     }
 
   }

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,13 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2025-09-19" {
+    description
+      "Add action to set IP TTL.";
+    reference "0.9.0";
+  }
 
   revision "2025-07-08" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,13 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2025-09-19" {
+    description
+      "Add action to set IP TTL.";
+    reference "0.9.0";
+  }
 
   revision "2025-07-08" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -86,7 +86,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.8.0";
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2025-09-19" {
+    description
+      "Add action to set IP TTL.";
+    reference "0.9.0";
+  }
 
   revision "2025-07-08" {
     description


### PR DESCRIPTION
### Change Scope

* Add a new leaf to the policy-forwarding action container `ip-ttl` which re-writes the matching packet's ttl value.
* This change is backwards compatible

### Platform Implementations

 * [Arista EOS traffic policy, set ttl](https://www.arista.com/en/um-eos/eos-traffic-management#topic_r14_l2q_ksb)
* IOS XR defines [ACL based forwarding](https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/ip-addresses/711x/configuration/guide/b-ip-addresses-cg-ncs5500-711x/implementing-access-lists-and-prefix-lists.html#id_60000) which is similar to this capability.
* JunOS defines [filter based forwarding](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/firewall-filter-option-filter-based-forwarding-overview.html).    
