### PR TITLE
Add exclude-prefix/port leaf list

### DIFF
--- a/release/models/defined-sets/openconfig-defined-sets.yang
+++ b/release/models/defined-sets/openconfig-defined-sets.yang
@@ -27,6 +27,12 @@ module openconfig-defined-sets {
 
   oc-ext:openconfig-version "1.0.0";
 
+  revision "2025-05-30" {
+    description
+      "Add support for exclude-prefix";
+    reference "1.0.1";
+  }
+
   revision "2022-12-14" {
     description
       "Initial version of the defined set model";
@@ -57,6 +63,13 @@ module openconfig-defined-sets {
          "A user defined list of IPv4 prefixes to be used in match
          conditions. Each entry is a IPv4 + mask combination.";
     }
+
+    leaf-list exclude-prefix {
+       type oc-inet:ipv4-prefix;
+       description
+         "A user defined list of IPv4 prefixes to be excluded from
+         match conditions. Each entry is a IPv4 + mask combination.";
+    }
   }
 
   grouping ipv6-prefix-sets-config {
@@ -79,6 +92,13 @@ module openconfig-defined-sets {
        description
          "A user defined list of IPv6 prefixes to be used in match
          conditions. Each entry is a IPv6 + mask combination.";
+    }
+
+    leaf-list exclude-prefix {
+       type oc-inet:ipv6-prefix;
+       description
+         "A user defined list of IPv6 prefixes to be excluded from
+         match conditions. Each entry is a IPv6 + mask combination.";
     }
   }
 
@@ -103,6 +123,13 @@ module openconfig-defined-sets {
         description
           "A user defined set of ports to be
           used in the match conditions.";
+      }
+
+      leaf-list exclude-port {
+        type oc-pkt-match-types:port-num-range;
+        description
+          "A user defined set of ports to be excluded
+          from the match conditions.";
       }
   }
 

--- a/release/models/defined-sets/openconfig-defined-sets.yang
+++ b/release/models/defined-sets/openconfig-defined-sets.yang
@@ -25,7 +25,7 @@ module openconfig-defined-sets {
     for example, in network access control lists (i.e., filters,
     rules, etc.) in the matching fields.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
 
   revision "2025-05-30" {
     description

--- a/release/models/defined-sets/openconfig-defined-sets.yang
+++ b/release/models/defined-sets/openconfig-defined-sets.yang
@@ -25,12 +25,12 @@ module openconfig-defined-sets {
     for example, in network access control lists (i.e., filters,
     rules, etc.) in the matching fields.";
 
-  oc-ext:openconfig-version "1.0.1";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2025-05-30" {
     description
       "Add support for exclude-prefix";
-    reference "1.0.1";
+    reference "1.1.0";
   }
 
   revision "2022-12-14" {
@@ -61,14 +61,20 @@ module openconfig-defined-sets {
        type oc-inet:ipv4-prefix;
        description
          "A user defined list of IPv4 prefixes to be used in match
-         conditions. Each entry is a IPv4 + mask combination.";
+         conditions. Each entry is a IPv4 + mask combination. Addresses
+         within these prefixes will be considered for matching,
+         unless they also fall within any of the 'exclude-prefix' entries.";
     }
 
     leaf-list exclude-prefix {
        type oc-inet:ipv4-prefix;
        description
-         "A user defined list of IPv4 prefixes to be excluded from
-         match conditions. Each entry is a IPv4 + mask combination.";
+         "A user-defined list of IPv4 prefixes to be excluded from the
+         'prefix' list. Each entry is an IPv4 address with a mask.
+         Let P be the union of all addresses in the 'prefix' list,
+         and E be the union of all addresses in the 'exclude-prefix' list.
+         The effective match set is ( P - E ), i.e., addresses in 'prefix'
+         that are not in 'exclude-prefix'.";
     }
   }
 
@@ -91,14 +97,20 @@ module openconfig-defined-sets {
        type oc-inet:ipv6-prefix;
        description
          "A user defined list of IPv6 prefixes to be used in match
-         conditions. Each entry is a IPv6 + mask combination.";
+         conditions. Each entry is a IPv6 + mask combination. Addresses
+         within these prefixes will be considered for matching,
+         unless they also fall within any of the 'exclude-prefix' entries.";
     }
 
     leaf-list exclude-prefix {
        type oc-inet:ipv6-prefix;
        description
-         "A user defined list of IPv6 prefixes to be excluded from
-         match conditions. Each entry is a IPv6 + mask combination.";
+         "A user-defined list of IPv6 prefixes to be excluded from the
+         'prefix' list. Each entry is an IPv6 address with a mask.
+         Let P be the union of all addresses in the 'prefix' list,
+         and E be the union of all addresses in the 'exclude-prefix' list.
+         The effective match set is ( P - E ), i.e., addresses in 'prefix'
+         that are not in 'exclude-prefix'.";
     }
   }
 
@@ -121,15 +133,19 @@ module openconfig-defined-sets {
       leaf-list port {
         type oc-pkt-match-types:port-num-range;
         description
-          "A user defined set of ports to be
-          used in the match conditions.";
+          "A user defined set of ports to be used in the match conditions.
+          Ports listed here will be considered for matching, unless they
+          are also included in 'exclude-ports'.";
       }
 
       leaf-list exclude-port {
         type oc-pkt-match-types:port-num-range;
         description
-          "A user defined set of ports to be excluded
-          from the match conditions.";
+          "A user-defined list of ports to be excluded from the 'ports'
+          list. Let P be the union of the ports in the 'ports' list,
+          and E be the union of ports in the 'exclude-ports' list.
+          The effective match set is ( P - E ) i.e., ports in 'ports'
+          that are not in 'exclude-ports'.";
       }
   }
 

--- a/release/models/defined-sets/openconfig-defined-sets.yang
+++ b/release/models/defined-sets/openconfig-defined-sets.yang
@@ -61,7 +61,7 @@ module openconfig-defined-sets {
        type oc-inet:ipv4-prefix;
        description
          "A user defined list of IPv4 prefixes to be used in match
-         conditions. Each entry is a IPv4 + mask combination. Addresses
+         conditions. Each entry is an IPv4 + mask combination. Addresses
          within these prefixes will be considered for matching,
          unless they also fall within any of the 'exclude-prefix' entries.";
     }
@@ -97,7 +97,7 @@ module openconfig-defined-sets {
        type oc-inet:ipv6-prefix;
        description
          "A user defined list of IPv6 prefixes to be used in match
-         conditions. Each entry is a IPv6 + mask combination. Addresses
+         conditions. Each entry is an IPv6 + mask combination. Addresses
          within these prefixes will be considered for matching,
          unless they also fall within any of the 'exclude-prefix' entries.";
     }
@@ -141,11 +141,11 @@ module openconfig-defined-sets {
       leaf-list exclude-port {
         type oc-pkt-match-types:port-num-range;
         description
-          "A user-defined list of ports to be excluded from the 'ports'
-          list. Let P be the union of the ports in the 'ports' list,
-          and E be the union of ports in the 'exclude-ports' list.
-          The effective match set is ( P - E ) i.e., ports in 'ports'
-          that are not in 'exclude-ports'.";
+          "A user-defined list of ports to be excluded from the 'port'
+          list. Let P be the union of the ports in the 'port' list,
+          and E be the union of ports in the 'exclude-port' list.
+          The effective match set is ( P - E ) i.e., ports in 'port'
+          that are not in 'exclude-port'.";
       }
   }
 

--- a/release/models/defined-sets/openconfig-defined-sets.yang
+++ b/release/models/defined-sets/openconfig-defined-sets.yang
@@ -29,7 +29,7 @@ module openconfig-defined-sets {
 
   revision "2025-05-30" {
     description
-      "Add support for exclude-prefix";
+      "Add support for exclude-prefix and exclude-port";
     reference "1.1.0";
   }
 
@@ -135,7 +135,7 @@ module openconfig-defined-sets {
         description
           "A user defined set of ports to be used in the match conditions.
           Ports listed here will be considered for matching, unless they
-          are also included in 'exclude-ports'.";
+          are also included in 'exclude-port'.";
       }
 
       leaf-list exclude-port {


### PR DESCRIPTION
### Change Scope

- Add exlude-prefix in oc-defined-sets:ipv4-prefix-sets container
- Add exlude-prefix in oc-defined-sets:ipv6-prefix-sets container
- Add exclude-port in oc-defined-sets:port-sets container

Users may sometimes need to allow traffic from a broad subnet while excluding specific subnets. To achieve this, they must manually subdivide the larger subnet into smaller non-overlapping subnets that exclude the exceptions. As the number of exceptions increases, this process becomes increasingly complex and cumbersome. Hence, proposing a new attribute, exclude-prefix, which allows users to specify subnets to be excluded from the prefix list, simplifying subnet management and reducing manual effort. Similarly, exclude-port will provide the list of range of ports that has to be excluded from the port list.

This change is backwards compatible

### Tree view

```diff
module: openconfig-defined-sets
   +--rw defined-sets
      +--rw ipv4-prefix-sets
      |  +--rw ipv4-prefix-set* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?             string
      |     |  +--rw description?      string
      |     |  +--rw prefix*           oc-inet:ipv4-prefix
+     |     |  +--rw exclude-prefix*   oc-inet:ipv4-prefix
      |     +--ro state
      |        +--ro name?             string
      |        +--ro description?      string
      |        +--ro prefix*           oc-inet:ipv4-prefix

+     |        +--ro exclude-prefix*   oc-inet:ipv4-prefix

      +--rw ipv6-prefix-sets
      |  +--rw ipv6-prefix-set* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?             string
      |     |  +--rw description?      string
      |     |  +--rw prefix*           oc-inet:ipv6-prefix
+     |     |  +--rw exclude-prefix*   oc-inet:ipv6-prefix
      |     +--ro state
      |        +--ro name?             string
      |        +--ro description?      string
      |        +--ro prefix*           oc-inet:ipv6-prefix
+     |        +--ro exclude-prefix*   oc-inet:ipv6-prefix
      +--rw port-sets
         +--rw port-set* [name]
            +--rw name      -> ../config/name
            +--rw config
            |  +--rw name?           string
            |  +--rw description?    string
            |  +--rw port*           oc-pkt-match-types:port-num-range
+           |  +--rw exclude-port*   oc-pkt-match-types:port-num-range
            +--ro state
               +--ro name?           string
               +--ro description?    string
               +--ro port*           oc-pkt-match-types:port-num-range
+              +--ro exclude-port*   oc-pkt-match-types:port-num-range
```

### Platform Implementations

in Arista EOS, keyword - `except` is used to exclude prefixes or ports from the set. 

sets ( a.k.a. Field Set ) with IPv4 prefixes are configured using following syntax:
```
traffic-policies
   field-set ipv4 prefix <field-set-name>
      A.B.C.D/E      IPv4 prefix
      except         Add an exception prefix
```
Similarly for IPv6 prefixes:
```
traffic-policies
   field-set ipv6 prefix <field-set-name>
```
For Ports
```
traffic-policies
   field-set l4-port <field-set-name>
      <0-65535>       port values(s) or range(s) of port values
      except               except
```

Example:
```
traffic-policies
   field-set ipv4 prefix foo
      10.0.0.0/8
      except 10.10.0.0/16 10.20.0.0/16
```

### Are there any restrictions on the Inputs?
As long as the `exlude-prefix` entries are of the appropriate type ( IPv4, IPv6 or Port ), there are no additional restrictions. The `exclude-prefix` doesn't need to be a subset of the `prefix`. If for any reason, exclude-prefix and prefix are disjoint sets, the exclude-prefix list will be simply ignored as it will have no operational impact.

