### PR TITLE
Update openconfig-bgp-common.yang to support ExRR

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,12 +24,12 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -28,7 +28,7 @@ submodule openconfig-bgp-common-multiprotocol {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -25,7 +25,7 @@ submodule openconfig-bgp-common-structure {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,12 +21,12 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -28,7 +28,7 @@ submodule openconfig-bgp-common {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -616,11 +616,11 @@ submodule openconfig-bgp-common {
   
       This feature is distinct from IETF Long-Lived Graceful Restart (LLGR,
       RFC 9494). The fundamental differences are:
-      - ERR processes stale routes through an operator-defined, configurable
+      - ExRR processes stale routes through an operator-defined, configurable
         routing policy, providing granular control over attributes and
         acceptance.
-      - ERR is a purely local behavior of the receiving speaker (helper) and
-        does not require negotiation via BGP capabilities. This allows ERR to
+      - ExRR is a purely local behavior of the receiving speaker (helper) and
+        does not require negotiation via BGP capabilities. This allows ExRR to
         be enabled unilaterally.";
   
     leaf enabled {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,12 +24,12 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -614,14 +614,13 @@ submodule openconfig-bgp-common {
       speaker to hold stale routes from a failed peer for a configurable
       duration.
   
-      This feature is distinct from IETF Long-Lived Graceful Restart (LLGR,
-      RFC 9494). The fundamental differences are:
-      - ExRR processes stale routes through an operator-defined, configurable
-        routing policy, providing granular control over attributes and
-        acceptance.
-      - ExRR is a purely local behavior of the receiving speaker (helper) and
-        does not require negotiation via BGP capabilities. This allows ExRR to
-        be enabled unilaterally.";
+      key difference from RFC 9494 Long-Lived Graceful Restart (LLGR).";
+        - ExRR processes stale routes through an operator-defined, configurable
+          routing policy, providing granular control over attributes and
+          acceptance.
+        - ExRR is a purely local behavior of the receiving speaker (helper) and
+          does not require negotiation via BGP capabilities. This allows ExRR to
+          be enabled unilaterally.";
   
     leaf enabled {
       type boolean;

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -604,7 +604,7 @@ submodule openconfig-bgp-common {
     }
   }
 
-grouping bgp-extended-route-retention-config {
+  grouping bgp-extended-route-retention-config {
     description "Configuration parameters relating to BGP
     Extended Route Retention (ERR).
     Extended Route Retention is a mechanism to retain routing

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description
@@ -598,7 +604,59 @@ submodule openconfig-bgp-common {
     }
   }
 
-  grouping bgp-common-use-multiple-paths-config {
+grouping bgp-extended-route-retention-config {
+    description "Configuration parameters relating to BGP
+    Extended Route Retention (ERR).
+    Extended Route Retention is a mechanism to retain routing
+    functionality in the event of a long-lived BGP control-plane
+    failure of a neighbor. It allows a BGP speaker to hold stale
+    routes from a failed peer for a long, configurable duration, far
+    beyond the standard Graceful Restart timers.
+
+    This feature is triggered when a BGP session fails and does not
+    recover within the configured Graceful Restart periods, such as upon
+    the expiration of the BGP hold-timer or the graceful-restart timer.
+
+    When ERR is active, the stale routes are processed through a special,
+    configurable routing policy. This provides granular, operator-defined
+    control over how the stale routes are treated (e.g., modifying
+    attributes, selectively accepting or rejecting them), which is a
+    key difference from the more prescriptive IETF Long-Lived Graceful
+    Restart (LLGR) draft.";
+
+    leaf enabled {
+    type boolean;
+    default false;
+    description
+        "Enable or disable Extended Route Retention. When enabled, upon
+        certain BGP session failure conditions, stale routes from a neighbor
+        are held for a configurable duration.";
+    }
+
+    leaf retention-time {
+    type uint32;
+    units "seconds";
+    description
+        "Time duration in seconds for which the device will retain stale
+        routes under Extended Route Retention conditions. A NOS Must
+        support at least 180 days of retention-time";
+    }
+
+    leaf retention-policy {
+    type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+            "oc-rpol:policy-definition/oc-rpol:name";
+    }
+    description
+        "References a routing policy definition that is applied to stale
+        routes. This policy can modify attributes or selectively
+        accept/reject routes. Per the requirements, this policy is additive
+        and does not override other import policies. If no policy is
+        specified, the default action should be to reject the stale routes.";
+    }
+}
+
+grouping bgp-common-use-multiple-paths-config {
     description
       "Generic configuration options relating to use of multiple
       paths for a referenced AFI-SAFI, group or neighbor";

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -625,34 +625,34 @@ submodule openconfig-bgp-common {
     Restart (LLGR) draft.";
 
     leaf enabled {
-    type boolean;
-    default false;
-    description
-        "Enable or disable Extended Route Retention. When enabled, upon
-        certain BGP session failure conditions, stale routes from a neighbor
-        are held for a configurable duration.";
+      type boolean;
+      default false;
+      description
+          "Enable or disable Extended Route Retention. When enabled, upon
+          certain BGP session failure conditions, stale routes from a neighbor
+          are held for a configurable duration.";
     }
 
     leaf retention-time {
-    type uint32;
-    units "seconds";
-    description
-        "Time duration in seconds for which the device will retain stale
-        routes under Extended Route Retention conditions. A NOS Must
-        support at least 180 days of retention-time";
+      type uint32;
+      units "seconds";
+      description
+          "Time duration in seconds for which the device will retain stale
+          routes under Extended Route Retention conditions. A NOS Must
+          support at least 180 days of retention-time";
     }
 
     leaf retention-policy {
-    type leafref {
-        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
-            "oc-rpol:policy-definition/oc-rpol:name";
-    }
-    description
-        "References a routing policy definition that is applied to stale
-        routes. This policy can modify attributes or selectively
-        accept/reject routes. Per the requirements, this policy is additive
-        and does not override other import policies. If no policy is
-        specified, the default action should be to reject the stale routes.";
+      type leafref {
+          path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+              "oc-rpol:policy-definition/oc-rpol:name";
+      }
+      description
+          "References a routing policy definition that is applied to stale
+          routes. This policy can modify attributes or selectively
+          accept/reject routes. Per the requirements, this policy is additive
+          and does not override other import policies. If no policy is
+          specified, the default action should be to reject the stale routes.";
     }
 }
 

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -605,55 +605,85 @@ submodule openconfig-bgp-common {
   }
 
   grouping bgp-extended-route-retention-config {
-    description "Configuration parameters relating to BGP
-    Extended Route Retention (ERR).
-    Extended Route Retention is a mechanism to retain routing
-    functionality in the event of a long-lived BGP control-plane
-    failure of a neighbor. It allows a BGP speaker to hold stale
-    routes from a failed peer for a long, configurable duration, far
-    beyond the standard Graceful Restart timers.
-
-    This feature is triggered when a BGP session fails and does not
-    recover within the configured Graceful Restart periods, such as upon
-    the expiration of the BGP hold-timer or the graceful-restart timer.
-
-    When ERR is active, the stale routes are processed through a special,
-    configurable routing policy. This provides granular, operator-defined
-    control over how the stale routes are treated (e.g., modifying
-    attributes, selectively accepting or rejecting them), which is a
-    key difference from the more prescriptive IETF Long-Lived Graceful
-    Restart (LLGR) draft.";
-
+    description
+      "Configuration parameters relating to BGP Extended Route Retention (ERR).
+  
+      Extended Route Retention is a mechanism to retain routing information
+      in the Local-RIB and maintain forwarding functionality in the event of
+      a prolonged BGP control-plane failure of a neighbor. It allows a BGP
+      speaker to hold stale routes from a failed peer for a configurable
+      duration.
+  
+      This feature is distinct from IETF Long-Lived Graceful Restart (LLGR,
+      RFC 9494). The fundamental differences are:
+      - ERR processes stale routes through an operator-defined, configurable
+        routing policy, providing granular control over attributes and
+        acceptance.
+      - ERR is a purely local behavior of the receiving speaker (helper) and
+        does not require negotiation via BGP capabilities. This allows ERR to
+        be enabled unilaterally.";
+  
     leaf enabled {
       type boolean;
       default false;
       description
-          "Enable or disable Extended Route Retention. When enabled, upon
-          certain BGP session failure conditions, stale routes from a neighbor
-          are held for a configurable duration.";
+        "Enable or disable Extended Route Retention. When enabled, upon
+        certain BGP session failure conditions, stale routes from a neighbor
+        are held for a configurable duration.";
     }
-
+  
     leaf retention-time {
       type uint32;
       units "seconds";
       description
-          "Time duration in seconds for which the device will retain stale
-          routes under Extended Route Retention conditions. A NOS Must
-          support at least 180 days of retention-time";
+        "Time duration in seconds for which the device will retain stale
+        routes under Extended Route Retention conditions. A NOS Must
+        support at least 180 days of retention-time";
     }
-
-    leaf retention-policy {
+  
+    leaflist retention-policy {
       type leafref {
-          path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
-              "oc-rpol:policy-definition/oc-rpol:name";
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+             "oc-rpol:policy-definition/oc-rpol:name";
       }
+      ordered-by user;
       description
-          "References a routing policy definition that is applied to stale
-          routes. This policy can modify attributes or selectively
-          accept/reject routes. Per the requirements, this policy is additive
-          and does not override other import policies. If no policy is
-          specified, the default action should be to reject the stale routes.";
+        "A list of routing policy definitions that are applied to stale
+        routes, evaluated in the specified order. This policy chain can
+        modify attributes or selectively accept/reject routes.";
     }
+  
+    leaf default-retention-policy {
+      type oc-pol-types:default-policy-type;
+      default "REJECT_ROUTE";
+      description
+        "Explicitly defines the action to take for stale routes that do not
+        match any of the policies in the retention-policy chain. If no
+        policy is specified in the retention-policy leaflist, this
+        default action is applied.";
+    }
+  }
+
+grouping bgp-extended-route-retention-state {
+  description
+    "Operational state parameters relating to BGP Extended Route
+    Retention (ERR).";
+
+  leaf extended-retention-active {
+    type boolean;
+    description
+      "Indicates whether Extended Route Retention is currently
+      active for the BGP session.";
+  }
+
+  leaf remaining-retention-time {
+    type uint32;
+    units "seconds";
+    description
+      "The time remaining, in seconds, before the stale routes are
+      purged. This value is present only when extended-retention-active
+      is true.";
+  }
 }
 
 grouping bgp-common-use-multiple-paths-config {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -675,13 +675,18 @@ grouping bgp-extended-route-retention-state {
       active for the BGP session.";
   }
 
-  leaf remaining-retention-time {
-    type uint32;
-    units "seconds";
-    description
-      "The time remaining, in seconds, before the stale routes are
-      purged. This value is present only when extended-retention-active
-      is true.";
+  leaf remaining-retention-time { 
+    type uint32; 
+    units "seconds"; 
+    description 
+    "The time remaining, in seconds, before the stale routes are purged. 
+    Its behavior will be as follow: 
+      1. When ExRR is not active (extended-retention-active =
+      false), remaining-retention-time will report the full configured 
+      retention-time.
+      2. When ExRR is active (extended-retention-active = true),
+      remaining-retention-time will count down from the configured 
+      retention-time."; 
   }
 }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -462,6 +462,7 @@ submodule openconfig-bgp-global {
               description
               "State information for BGP Extended Route Retention.";
               uses bgp-extended-route-retention-config;
+              uses bgp-extended-route-retention-state;
             }
           }
       }
@@ -562,6 +563,7 @@ submodule openconfig-bgp-global {
           description
             "State information for BGP Extended Route Retention.";
           uses bgp-extended-route-retention-config;
+          uses bgp-extended-route-retention-state;
         }
       }
     }

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,14 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Defined a new container bgp-extended-route-retention-config
+       under the cointainer for graceful-restart";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description
@@ -439,6 +446,26 @@ submodule openconfig-bgp-global {
           description
             "State information for BGP graceful-restart";
           uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+      }
+
+      container extended-route-retention {
+        description
+          "Configuration for the extended retention of stale routes upon
+           BGP session failure, beyond the standard graceful restart
+           period.";
+  
+        container config {
+          description
+            "Configuration options for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
+        }
+  
+        container state {
+          config false;
+          description
+            "State information for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
         }
       }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -447,26 +447,23 @@ submodule openconfig-bgp-global {
             "State information for BGP graceful-restart";
           uses bgp-common-mp-afi-safi-graceful-restart-config;
         }
-      }
-
-      container extended-route-retention {
-        description
-          "Configuration for the extended retention of stale routes upon
-           BGP session failure, beyond the standard graceful restart
-           period.";
-  
-        container config {
-          description
-            "Configuration options for BGP Extended Route Retention.";
-          uses bgp-extended-route-retention-config;
-        }
-  
-        container state {
-          config false;
-          description
-            "State information for BGP Extended Route Retention.";
-          uses bgp-extended-route-retention-config;
-        }
+        container extended-route-retention {
+            description
+            "Per-AFI-SAFI configuration for the extended retention of stale routes.
+            This configuration overrides any settings at the parent global level.";
+            container config {
+              description
+                  "Configuration options for BGP Extended Route Retention.";
+              uses bgp-extended-route-retention-config;
+            }
+        
+            container state {
+              config false;
+              description
+              "State information for BGP Extended Route Retention.";
+              uses bgp-extended-route-retention-config;
+            }
+          }
       }
 
       uses bgp-common-route-selection-options;
@@ -546,6 +543,26 @@ submodule openconfig-bgp-global {
         description
           "State information associated with graceful-restart";
         uses bgp-common-graceful-restart-config;
+      }
+
+      container extended-route-retention {
+        description
+          "Configuration for the extended retention of stale routes upon
+           BGP session failure, beyond the standard graceful restart
+           period.";
+  
+        container config {
+          description
+            "Configuration options for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
+        }
+  
+        container state {
+          config false;
+          description
+            "State information for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
+        }
       }
     }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,13 +27,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Defined a new container bgp-extended-route-retention-config
        under the cointainer for graceful-restart";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,12 +30,12 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -34,7 +34,7 @@ submodule openconfig-bgp-neighbor {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -765,25 +765,23 @@ submodule openconfig-bgp-neighbor {
           uses bgp-common-mp-afi-safi-graceful-restart-config;
           uses bgp-neighbor-afi-safi-graceful-restart-state;
         }
-      }
-
-      container extended-route-retention {
-        description
-          "Per-AFI-SAFI configuration for the extended retention of
-           stale routes. This configuration overrides any settings
-           at the parent neighbor level.";
-
-        container config {
+        container extended-route-retention {
           description
-            "Configuration options for BGP Extended Route Retention.";
-          uses bgp-extended-route-retention-config;
-        }
-
-        container state {
-          config false;
-          description
-            "State information for BGP Extended Route Retention.";
-          uses bgp-extended-route-retention-config;
+            "Per-AFI-SAFI configuration for the extended retention of
+             stale routes. This configuration overrides any settings
+             at the parent neighbor level.";
+  
+          container config {
+            description
+              "Configuration options for BGP Extended Route Retention.";
+              uses bgp-extended-route-retention-config;
+          }
+          container state {
+            config false;
+            description
+              "State information for BGP Extended Route Retention.";
+              uses bgp-extended-route-retention-config;
+          }
         }
       }
 
@@ -886,6 +884,26 @@ submodule openconfig-bgp-neighbor {
           "State information associated with graceful-restart";
         uses bgp-common-graceful-restart-config;
         uses bgp-neighbor-graceful-restart-state;
+      }
+
+      container extended-route-retention {
+        description
+        "Neighbor level configuration for the extended retention of 
+        stale routes upon BGP session failure, beyond the standard 
+        graceful restart period. This  configuration acts as a 
+        default for all address families.";
+    
+        container config {
+            description
+            "Configuration options for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }
+        container state {
+            config false;
+            description
+            "State information for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }
       }
     }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description
@@ -758,6 +764,26 @@ submodule openconfig-bgp-neighbor {
             "State information for BGP graceful-restart";
           uses bgp-common-mp-afi-safi-graceful-restart-config;
           uses bgp-neighbor-afi-safi-graceful-restart-state;
+        }
+      }
+
+      container extended-route-retention {
+        description
+          "Per-AFI-SAFI configuration for the extended retention of
+           stale routes. This configuration overrides any settings
+           at the parent neighbor level.";
+
+        container config {
+          description
+            "Configuration options for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information for BGP Extended Route Retention.";
+          uses bgp-extended-route-retention-config;
         }
       }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -781,6 +781,7 @@ submodule openconfig-bgp-neighbor {
             description
               "State information for BGP Extended Route Retention.";
               uses bgp-extended-route-retention-config;
+              uses bgp-extended-route-retention-state;
           }
         }
       }
@@ -903,6 +904,7 @@ submodule openconfig-bgp-neighbor {
             description
             "State information for BGP Extended Route Retention.";
             uses bgp-extended-route-retention-config;
+            uses bgp-extended-route-retention-state;
         }
       }
     }

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -291,7 +291,7 @@ submodule openconfig-bgp-peer-group {
                 "State information for BGP Extended Route Retention.";
                 uses bgp-extended-route-retention-config;
             }
-        }
+         }
       }
       uses bgp-common-structure-neighbor-group-add-paths;
       uses bgp-common-global-group-use-multiple-paths;

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description
@@ -270,7 +276,22 @@ submodule openconfig-bgp-peer-group {
           uses bgp-common-mp-afi-safi-graceful-restart-config;
         }
       }
-
+      container extended-route-retention {
+        description
+          "Configuration for the extended retention of stale routes,
+           applied to all neighbors in this peer-group.";
+        container config {
+          description
+            "Configuration options for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }  
+        container state {
+          config false;
+          description
+            "State information for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }
+      }
       uses bgp-common-structure-neighbor-group-add-paths;
       uses bgp-common-global-group-use-multiple-paths;
       uses bgp-common-mp-all-afi-safi-list-contents;

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -275,21 +275,22 @@ submodule openconfig-bgp-peer-group {
             "State information for BGP graceful-restart";
           uses bgp-common-mp-afi-safi-graceful-restart-config;
         }
-      }
-      container extended-route-retention {
-        description
-          "Configuration for the extended retention of stale routes,
-           applied to all neighbors in this peer-group.";
-        container config {
-          description
-            "Configuration options for BGP Extended Route Retention.";
-            uses bgp-extended-route-retention-config;
-        }  
-        container state {
-          config false;
-          description
-            "State information for BGP Extended Route Retention.";
-            uses bgp-extended-route-retention-config;
+        container extended-route-retention {
+            description
+            "Per-AFI-SAFI configuration for the extended retention 
+            of stale routes. This configuration overrides any 
+            settings at the parent peer-group level.";
+            container config {
+                description
+                "Configuration options for BGP Extended Route Retention.";
+                uses bgp-extended-route-retention-config;
+            }     
+            container state {
+                config false;
+                description
+                "State information for BGP Extended Route Retention.";
+                uses bgp-extended-route-retention-config;
+            }
         }
       }
       uses bgp-common-structure-neighbor-group-add-paths;
@@ -389,6 +390,22 @@ submodule openconfig-bgp-peer-group {
         description
           "State information associated with graceful-restart";
         uses bgp-common-graceful-restart-config;
+      }
+      container extended-route-retention {
+        description
+          "Configuration for the extended retention of stale routes,
+           applied to all neighbors in this peer-group.";
+        container config {
+          description
+            "Configuration options for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }  
+        container state {
+          config false;
+          description
+            "State information for BGP Extended Route Retention.";
+            uses bgp-extended-route-retention-config;
+        }
       }
     }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,12 +25,12 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -29,7 +29,7 @@ submodule openconfig-bgp-peer-group {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -290,6 +290,7 @@ submodule openconfig-bgp-peer-group {
                 description
                 "State information for BGP Extended Route Retention.";
                 uses bgp-extended-route-retention-config;
+                uses bgp-extended-route-retention-state;
             }
          }
       }
@@ -405,6 +406,7 @@ submodule openconfig-bgp-peer-group {
           description
             "State information for BGP Extended Route Retention.";
             uses bgp-extended-route-retention-config;
+            uses bgp-extended-route-retention-state;
         }
       }
     }

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,13 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2025-05-19" {
+    description
+      "Support for Extended-route-retention (ERR)";
+          reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,12 +68,12 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.2";
+  oc-ext:openconfig-version "9.10.0";
 
   revision "2025-05-19" {
     description
       "Support for Extended-route-retention (ERR)";
-          reference "9.9.2";
+          reference "9.10.0";
   }
 
   revision "2025-04-18" {

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -72,7 +72,7 @@ module openconfig-bgp {
 
   revision "2025-05-19" {
     description
-      "Support for Extended-route-retention (ERR)";
+      "Support for Extended-route-retention (ExRR)";
           reference "9.10.0";
   }
 


### PR DESCRIPTION
Support for extended route retention (ERR) which is an extension to graceful restart.


Scope of Change:
This pull request introduces a new feature to the OpenConfig BGP model called BGP Extended Route Retention (ExRR). This feature provides a mechanism for a BGP speaker to retain stale routes from a failed peer for a long, configurable duration, independent of standard Graceful Restart timers.

The core of this feature is a flexible, policy-driven approach. Key changes include:

- A new bgp-extended-route-retention-config grouping is added to openconfig-bgp-common.yang . This grouping includes new configuration leaves such as:
     - enabled: To activate or deactivate the feature.
     - retention-time: A configurable timer for how long stale routes are held .
     - retention-policy: A leaflist that allows an operator to apply an ordered chain of routing policies to stale routes.
     - default-retention-policy: An explicit control for the default action (accept or reject) for routes that do not match the policy chain.

- A new bgp-extended-route-retention-state grouping is added to provide operational state, including extended-retention-active to indicate if the feature is active and remaining-retention-time to show the time left before routes are purged.
- The description clarifies that this feature is distinct from the IETF's Long-Lived Graceful Restart (LLGR, RFC 9494) because ExRR is a purely local behavior that does not require BGP capability negotiation .
- These new configuration and state capabilities have been added to the BGP model at the global, peer-group, and neighbor levels to allow for flexible application.


**Current vendor implementations**

- [Arista_ExRR_Implementation](https://www.arista.com/en/support/toi/eos-4-28-2f/16101-bgp-extended-route-retention-with-custom-policy)
- [Juniper_Implementation](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/long-lived-edit-protocols-bgp-graceful-restart.html): Search for Extended-Route-Retention)
- [Cisco implementation](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/bgp/25xx/configuration/guide/b-bgp-cg-8k-25xx/implementing-bgp.html?bookSearch=true#concept_hbb_q2s_hsb): search for BGP Extended Route Retention


Snippet of different proposals below

Path: network-instances/network-instance/protocols/protocol/bgp/global/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:default-policy-type
           +--ro extended-retention-active?    boolean
           +--ro remaining-retention-time?     uint32
```

Pat: network-instances/network-instance/protocols/protocol/bgp/global/afi-safis/afi-safi/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:default-policy-type
           +--ro extended-retention-active?    boolean
           +--ro remaining-retention-time?     uint32
```

Path: network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:default-policy-type
           +--ro extended-retention-active?    boolean
           +--ro remaining-retention-time?     uint32
```

Path: network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:default-policy-type
           +--ro extended-retention-active?    boolean
           +--ro remaining-retention-time?     uint32
```

Path: network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:default-policy-type
           +--ro extended-retention-active?    boolean
           +--ro remaining-retention-time?     uint32
```

Path: network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/graceful-restart

```
module: openconfig-network-instance
  +--rw graceful-restart
     +--rw config
     |  +--rw enabled?            boolean
     |  +--rw restart-time?       uint16
     |  +--rw stale-routes-time?  decimal64
     |  +--rw helper-enabled?     boolean
     +--ro state
     |  +--ro enabled?            boolean
     |  +--ro restart-time?       uint16
     |  +--ro stale-routes-time?  decimal64
     |  +--ro helper-enabled?     boolean
     |  +--ro local-restarting?   boolean
     |  +--ro peer-restarting?    boolean
     |  +--ro peer-restart-time?  uint16
     |  +--ro mode?               identityref
     +--rw extended-route-retention
        +--rw config
        |  +--rw enabled?                      boolean
        |  +--rw retention-time?               uint32
        |  +--rw retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
        |  +--rw default-retention-policy?     oc-pol-types:default-policy-type
        +--ro state
           +--ro enabled?                      boolean
           +--ro retention-time?               uint32
           +--ro retention-policy*             -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
           +--ro default-retention-policy?     oc-pol-types:
```



