### PR TITLE
Add an enum value of EXCLUDE to the mpls-hop-type

### DIFF
--- a/release/models/mpls/openconfig-mpls-igp.yang
+++ b/release/models/mpls/openconfig-mpls-igp.yang
@@ -21,7 +21,14 @@ submodule openconfig-mpls-igp {
     "Configuration generic configuration parameters for IGP-congruent
     LSPs";
 
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.6.1";
+
+  revision "2025-06-24" {
+    description
+      "Added a new enum EXCLUDE to the mpls-hop-type to specify
+      the exclude address for RSVP-TE explicit path";
+    reference "3.6.1";
+  }
 
   revision "2024-06-19" {
     description

--- a/release/models/mpls/openconfig-mpls-static.yang
+++ b/release/models/mpls/openconfig-mpls-static.yang
@@ -24,7 +24,14 @@ submodule openconfig-mpls-static {
     "Defines static LSP configuration";
 
 
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.6.1";
+
+  revision "2025-06-24" {
+    description
+      "Added a new enum EXCLUDE to the mpls-hop-type to specify
+      the exclude address for RSVP-TE explicit path";
+    reference "3.6.1";
+  }
 
   revision "2024-06-19" {
     description

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -34,7 +34,7 @@ submodule openconfig-mpls-te {
 
   revision "2025-06-24" {
     description
-      "Added a new enum EXCLUDE to the mpls-hop-type to specify 
+      "Added a new enum EXCLUDE to the mpls-hop-type to specify
       the exclude address for RSVP-TE explicit path";
     reference "3.6.1";
   }

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -207,7 +207,13 @@ submodule openconfig-mpls-te {
         description
           "strict hop in an explicit path";
       }
-    }
+      enum EXCLUDE {
+        description
+          "exclude hop in an explicit path";
+      }
+}
+
+
     description
      "enumerated type for specifying loose or strict
       paths";

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -30,7 +30,14 @@ submodule openconfig-mpls-te {
     signaling protocol or mechanism (see related submodules for
     signaling protocol-specific configuration).";
 
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.6.1";
+
+  revision "2025-06-24" {
+    description
+      "Added a new enum EXCLUDE to the mpls-hop-type to specify 
+      the exclude address for RSVP-TE explicit path";
+    reference "3.6.1";
+  }
 
   revision "2024-06-19" {
     description
@@ -213,7 +220,7 @@ submodule openconfig-mpls-te {
       }
     }
     description
-     "enumerated type for specifying loose or strict
+     "enumerated type for specifying loose, strict or exclude
       paths";
   }
 

--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -211,9 +211,7 @@ submodule openconfig-mpls-te {
         description
           "exclude hop in an explicit path";
       }
-}
-
-
+    }
     description
      "enumerated type for specifying loose or strict
       paths";

--- a/release/models/mpls/openconfig-mpls.yang
+++ b/release/models/mpls/openconfig-mpls.yang
@@ -70,7 +70,14 @@ module openconfig-mpls {
                +------+      |ROUTING|      +-----+
                              +-------+
     ";
-  oc-ext:openconfig-version "3.6.0";
+  oc-ext:openconfig-version "3.6.1";
+
+  revision "2025-06-24" {
+    description
+      "Added a new enum EXCLUDE to the mpls-hop-type to specify
+      the exclude address for RSVP-TE explicit path";
+    reference "3.6.1";
+  }
 
   revision "2024-06-19" {
     description


### PR DESCRIPTION
**Change Scope**
- Add an enum value of EXCLUDE to the mpls-hop-type under the mpls-te model
- This change is backwards compatible.

Users may specify the exclude address in explicit path specification for RSVP-TE LSP setup.

The configuration in Cisco shows the following
```
explicit-path name PATH1
 index 1 exclude-address ipv4 unicast 172.16.0.2

interface tunnel-te1
 destination 2.2.2.2
 path-option 10 explicit name PATH1
 path-option 20 dynamic
```
Given that several vendors' native YANG models are closely aligned with the description in EXRS (RFC4874 Sec.4.1)

**Platform Implementations**

 * Implementation from Cicso: https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/792/Cisco-IOS-XR-ip-iep-cfg.yang
 * Implementation from Arista: https://www.arista.com/en/um-eos/eos-rsvp-te-commands#reference_vjp_cmq_w2c
 * Implementation from DriveNets: DNOS CLI command
```
dnRouter# configure
dnRouter(cfg)# protocols
dnRouter(cfg-protocols) # rsvp
dnRouter(cfg-protocols-rsvp)# explicit-path PATH_1
dnRouter(cfg-protocols-rsvp-expl-path)# index 1 ipv4-address 192.168.3.2 include-strict
dnRouter(cfg-protocols-rsvp-expl-path)# index 2 ipv4-address 192.168.3.3 include-strict
dnRouter(cfg-protocols-rsvp-expl-path)# index 3 ipv4-address 192.168.3.4 include-loose
dnRouter(cfg-protocols-rsvp-expl-path)# index 4 ipv4-address 192.168.3.5 exclude
```