### PR TITLE
Fix additions of NI-referencing next-hops in openconfig-local-routing.

### DIFF
--- a/release/models/local-routing/.spec.yml
+++ b/release/models/local-routing/.spec.yml
@@ -4,3 +4,7 @@
   build:
     - yang/local-routing/openconfig-local-routing.yang
   run-ci: true
+- name: openconfig-local-routing-network-instance
+  docs:
+    - yang/network-instance/openconfig-network-instance.yang
+    - yang/local-routing/openconfig-local-routing-network-instance.yang

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -47,19 +47,19 @@ module openconfig-local-routing-network-instance {
         "Instead of finding the next-hop for a destination address in the current
         network-instance, look up the destination address in the routing table
         of the specified network-instance.
-      
+
         For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
         in the 'BLUE' network-instance and the destination address matches this
         route, the destination address will be looked up again in the 'DEFAULT'
         network-instance to find the next-hop.
         This leaf is mutually exclusive with 'next-hop', 'nh-network-instance'
         leaves";
-    
+
       type leafref {
         path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:config/oc-ni:name";
       }
-    } 
-      
+    }
+
     leaf nh-network-instance {
       description
         "Network-instance in which IP address of next-hop should

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -95,4 +95,18 @@ module openconfig-local-routing-network-instance {
 
     uses static-nexthop-networkinstance;
   }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:config" {
+    description
+      "Add network-instance leaves to static next-hop container.";
+
+    uses static-nexthop-networkinstance;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:state" {
+    description
+      "Add network-instance leaves to static next-hop container.";
+
+    uses static-nexthop-networkinstance;
+  }
 }

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -1,0 +1,98 @@
+module openconfig-local-routing-network-instance {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/local-routing-netinst";
+
+  prefix "oc-loc-rt-netinst";
+
+  import openconfig-network-instance { prefix "oc-ni"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module adds leaves that relate to network-instances
+     to the local routing subtree.";
+
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2025-06-30" {
+    description
+      "Add leaves that relate to network-instances to the
+       local routing module.";
+    reference "1.0.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping static-nexthop-networkinstance {
+    description
+      "This grouping define leaves that need references to the network-instance
+       subtree within the local routing module. It is used to augment the
+       /network-instances/network-instance/protocols/protocol/static-routes/ +
+       static-route/next-hops/next-hop/{config,state} containers.";
+
+    leaf next-network-instance {
+      description
+        "Instead of finding the next-hop for a destination address in the current
+        network-instance, look up the destination address in the routing table
+        of the specified network-instance.
+      
+        For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
+        in the 'BLUE' network-instance and the destination address matches this
+        route, the destination address will be looked up again in the 'DEFAULT'
+        network-instance to find the next-hop.
+        This leaf is mutually exclusive with 'next-hop', 'nh-network-instance'
+        leaves";
+    
+      type leafref {
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:config/oc-ni:name";
+      }
+    } 
+      
+    leaf nh-network-instance {
+      description
+        "Network-instance in which IP address of next-hop should
+        be looked up, to find egress interface. This attribute
+        is only valid if next-hop is given as IP address.
+        This attribute may be combined with recurse attribute of any
+        value, in which case recurse setting applies to
+        nh-network-instance.
+
+        For example, let 'nh-network-instance' = 'DEFAULT'.  If a
+        packet arrives on the 'BLUE' network-instance and the
+        destination address matches this route, look up the IP
+        configured as next-hop in the 'DEFAULT' network-instance.
+        This leaf is mutually exclusive with next-network-instance
+        leaf";
+
+      type leafref {
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:config/oc-ni:name";
+      }
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:config" {
+    description
+      "Add network-instance leaves to static routing next-hop container.";
+
+    uses static-nexthop-networkinstance;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:state" {
+    description
+      "Add network-instance leaves to static routing next-hop container.";
+
+    uses static-nexthop-networkinstance;
+  }
+}

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,14 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2025-06-30" {
+    description
+      "Remove leaves that referenced network instances (see 2.2.0)
+       and replace with augment";
+    reference "3.0.0";
+  }
 
   revision "2025-03-31" {
     description

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -232,22 +232,6 @@ module openconfig-local-routing {
         only support a numeric value for this string. ";
     }
 
-    leaf next-network-instance {
-      description
-        "Instead of finding the next-hop for a destination address in the current
-	network-instance, look up the destination address in the routing table
-	of the specified network-instance.
-	 For example, let 'next-network-instance' = 'DEFAULT'.  If a packet arrives
-        in the 'BLUE' network-instance and the destination address matches this
-        route, the destination address will be looked up again in the 'DEFAULT'
-	network-instance to find the next-hop.
-	This leaf is mutually exclusive with 'next-hop', 'nh-network-instance'
-        leaves";
-      type leafref {
-        path "/network-instances/network-instance/config/name";
-      }
-    }
-
     leaf next-hop {
       type union {
         type inet:ip-address;
@@ -265,25 +249,6 @@ module openconfig-local-routing {
         interface.
         This leaf is mutualy exclusive with next-network-instance
         leaf";
-    }
-
-    leaf nh-network-instance {
-      description
-        "Network-instance in which IP address of next-hop should
-        be looked up, to find egress interface. This attribute
-        is only valid if next-hop is given as IP address.
-        This attribute may be combined with recurse attribute of any
-        value, in which case recurse setting applies to
-        nh-network-instance.
-        For example, let 'nh-network-instance' = 'DEFAULT'.  If a
-        packet arrives on the 'BLUE' network-instance and the
-        destination address matches this route, look up the IP
-        configured as next-hop in the 'DEFAULT' network-instance.
-        This leaf is mutually exclusive with next-network-instance
-        leaf";
-      type leafref {
-        path "/network-instances/network-instance/config/name";
-      }
     }
 
     leaf recurse {

--- a/release/models/network-instance/.spec.yml
+++ b/release/models/network-instance/.spec.yml
@@ -10,13 +10,14 @@
     - yang/segment-routing/openconfig-rsvp-sr-ext.yang
     - yang/segment-routing/openconfig-segment-routing.yang
     - yang/rib/openconfig-rib-bgp-ext.yang
-
+    - yang/local-routing/openconfig-local-routing-network-instance.yang
   build:
     - yang/aft/openconfig-aft-network-instance.yang
     - yang/aft/openconfig-aft-summary.yang
     - yang/network-instance/openconfig-network-instance.yang
     - yang/network-instance/openconfig-programming-errors.yang
     - yang/segment-routing/openconfig-rsvp-sr-ext.yang
+    - yang/local-routing/openconfig-local-routing-network-instance.yang
   run-ci: true
 - name: openconfig-network-instance-bgp-rib-augment
   build:


### PR DESCRIPTION
```
 * (M) release/models/local-routing/openconfig-local-routing.yang
  - Remove leaves that require the network-instance model from the
    base openconfig-local-routing. Modules should be standalone so
    that they can be re-used outside of network-instance if required.
 * (A) release/models/local-routing/openconfig-local-routing-network-instance.yang
  - Add network-instance referencing leaves through augments.
 * (M) release/models/local-routing/.spec.yml
 * (M) release/models/network-instance/.spec.yml
   - Update spec to ensure that a build rule checks the new module.
```
