### PR TITLE
Add next-hop-group to local-routing-network-instance.

### DIFF
--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -21,14 +21,7 @@ module openconfig-local-routing-network-instance {
     "This module adds leaves that relate to network-instances
      to the local routing subtree.";
 
-  oc-ext:openconfig-version "1.1.0";
-
-  revision "2025-07-01" {
-    description
-      "Add next-hop-group, which contains a leafref to network-instances
-      for local routing module.";
-    reference "1.1.0";
-  }
+  oc-ext:openconfig-version "1.0.0";
 
   revision "2025-06-30" {
     description
@@ -89,6 +82,33 @@ module openconfig-local-routing-network-instance {
     }
   }
 
+  grouping static-next-hop-group-networkinstance {
+    container next-hop-group {
+      description
+        "Configuration and state parameters relating to the
+        next-hop-group. In the future, this container will replace the container
+        /network-instances/network-instance/protocols/protocol/static-routes/static/next-hops.
+        If a statically configured next-hop-group is used for a static route
+        prefix then the 'static-routes/static/next-hops' container must not
+        be used.";
+
+      container config {
+        description
+          "Configuration parameters relating to the next-hop-group.";
+
+        uses next-hop-group-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational parameters relating to the next-hop-group.";
+
+        uses next-hop-group-config;
+      }
+    }
+  }
+
   grouping next-hop-group-config {
     description
       "Grouping of configuration parameters for a static route's reference
@@ -96,7 +116,7 @@ module openconfig-local-routing-network-instance {
 
     leaf name {
       type leafref {
-        path "/network-instances/network-instance/static/next-hop-groups/next-hop-group/name";
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }
 
       description
@@ -104,32 +124,12 @@ module openconfig-local-routing-network-instance {
     }
   }
 
-  container next-hop-group {
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static" {
     description
-      "Configuration and state parameters relating to the
-      next-hop-group. In the future, this container will replace the container
-      /network-instances/network-instance/protocols/protocol/static-routes/static/next-hops.
-      If a statically configured next-hop-group is used for a static route
-      prefix then the 'static-routes/static/next-hops' container must not
-      be used.";
+      "Add network-instance leaves to static routing next-hop container.";
 
-    container config {
-      description
-        "Configuration parameters relating to the next-hop-group.";
-
-      uses next-hop-group-config;
-    }
-
-    container state {
-      config false;
-      description
-        "Operational parameters relating to the next-hop-group.";
-
-      uses next-hop-group-config;
-    }
+    uses static-next-hop-group-networkinstance;
   }
-
-
 
   augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:config" {
     description
@@ -158,20 +158,4 @@ module openconfig-local-routing-network-instance {
 
     uses static-nexthop-networkinstance;
   }
-
-  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hop-group/oc-ni:config" {
-    description
-      "Add network-instance leaves to static routing next-hop container.";
-
-    uses next-hop-group-config;
-  }
-
-  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hop-group/oc-ni:state" {
-    description
-      "Add network-instance leaves to static routing next-hop container.";
-
-    uses next-hop-group-config;
-  }
-
 }
-

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -25,7 +25,7 @@ module openconfig-local-routing-network-instance {
 
   revision "2025-07-01" {
     description
-      "Add refernce to static next-hop-group and augment the local routing
+      "Add reference to static next-hop-group and augment the local routing
       module.";
     reference "1.1.0";
   }

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -21,7 +21,14 @@ module openconfig-local-routing-network-instance {
     "This module adds leaves that relate to network-instances
      to the local routing subtree.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2025-07-01" {
+    description
+      "Add refernce to static next-hop-group and augment the local routing
+      module.";
+    reference "1.1.0";
+  }
 
   revision "2025-06-30" {
     description
@@ -83,6 +90,9 @@ module openconfig-local-routing-network-instance {
   }
 
   grouping static-next-hop-group-networkinstance {
+    description
+      "Grouping of nodes for a reference to a static next-hop-group.";
+
     container next-hop-group {
       description
         "Configuration and state parameters relating to the
@@ -111,8 +121,8 @@ module openconfig-local-routing-network-instance {
 
   grouping next-hop-group-config {
     description
-      "Grouping of configuration parameters for a static route's reference
-      to a next-hop-group.";
+      "Grouping of configuration parameters for a reference to a
+      static next-hop-group.";
 
     leaf name {
       type leafref {

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -21,7 +21,14 @@ module openconfig-local-routing-network-instance {
     "This module adds leaves that relate to network-instances
      to the local routing subtree.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2025-07-01" {
+    description
+      "Add next-hop-group, which contains a leafref to network-instances
+      for local routing module.";
+    reference "1.1.0";
+  }
 
   revision "2025-06-30" {
     description
@@ -82,6 +89,48 @@ module openconfig-local-routing-network-instance {
     }
   }
 
+  grouping next-hop-group-config {
+    description
+      "Grouping of configuration parameters for a static route's reference
+      to a next-hop-group.";
+
+    leaf name {
+      type leafref {
+        path "/network-instances/network-instance/static/next-hop-groups/next-hop-group/name";
+      }
+
+      description
+        "A user defined name for a next-hop-group.";
+    }
+  }
+
+  container next-hop-group {
+    description
+      "Configuration and state parameters relating to the
+      next-hop-group. In the future, this container will replace the container
+      /network-instances/network-instance/protocols/protocol/static-routes/static/next-hops.
+      If a statically configured next-hop-group is used for a static route
+      prefix then the 'static-routes/static/next-hops' container must not
+      be used.";
+
+    container config {
+      description
+        "Configuration parameters relating to the next-hop-group.";
+
+      uses next-hop-group-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational parameters relating to the next-hop-group.";
+
+      uses next-hop-group-config;
+    }
+  }
+
+
+
   augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hops/oc-ni:next-hop/oc-ni:config" {
     description
       "Add network-instance leaves to static routing next-hop container.";
@@ -109,4 +158,20 @@ module openconfig-local-routing-network-instance {
 
     uses static-nexthop-networkinstance;
   }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hop-group/oc-ni:config" {
+    description
+      "Add network-instance leaves to static routing next-hop container.";
+
+    uses next-hop-group-config;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:protocols/oc-ni:protocol/oc-ni:static-routes/oc-ni:static/oc-ni:next-hop-group/oc-ni:state" {
+    description
+      "Add network-instance leaves to static routing next-hop container.";
+
+    uses next-hop-group-config;
+  }
+
 }
+

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -125,12 +125,13 @@ module openconfig-local-routing-network-instance {
       static next-hop-group.";
 
     leaf name {
+      description
+        "A user defined name to reference a static next-hop-group.";
+      // we are at /network-instances/network-instance/protocols/protocol/static-routes/static/next-hop-group/config/name	
       type leafref {
-        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
+        path "../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }
 
-      description
-        "A user defined name for a next-hop-group.";
     }
   }
 

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,13 +43,13 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "3.1.0";
+  oc-ext:openconfig-version "4.0.0";
 
   revision "2025-07-01" {
     description
-      "Add reference to static next-hop-group and augment the local routing
-      module.";
-    reference "3.1.0";
+      "Move static next-hop-group to local-routing-network-instance and
+      augment the local routing module.";
+    reference "4.0.0";
   }
 
   revision "2025-06-30" {

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,14 +43,7 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "3.1.0";
-  
-  revision "2025-07-01" {
-    description
-      "Add next-hop-group, which contains a leafref to network-instances
-      for local routing module.";
-    reference "3.1.0";
-  }
+  oc-ext:openconfig-version "3.0.0";
 
   revision "2025-06-30" {
     description
@@ -331,27 +324,6 @@ module openconfig-local-routing {
           uses local-static-state;
         }
 
-        container next-hop-group {
-          description
-            "Configuration and state parameters relating to the
-            next-hop-group. In the future, this container will replace the container
-            /network-instances/network-instance/protocols/protocol/static-routes/static/next-hops.
-            If a statically configured next-hop-group is used for a static route
-            prefix then the 'static-routes/static/next-hops' container must not
-            be used.";
-
-          container config {
-            description
-              "Configuration parameters relating to the next-hop-group.";
-          }
-
-          container state {
-            config false;
-            description
-              "Operational parameters relating to the next-hop-group.";
-          }
-        }
-
         container next-hops {
           description
             "Configuration and state parameters relating
@@ -486,7 +458,5 @@ module openconfig-local-routing {
       }
     }
   }
-
-
 
 }

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,14 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+  
+  revision "2025-07-01" {
+    description
+      "Add next-hop-group, which contains a leafref to network-instances
+      for local routing module.";
+    reference "3.1.0";
+  }
 
   revision "2025-06-30" {
     description
@@ -336,16 +343,12 @@ module openconfig-local-routing {
           container config {
             description
               "Configuration parameters relating to the next-hop-group.";
-
-            uses next-hop-group-config;
           }
 
           container state {
             config false;
             description
               "Operational parameters relating to the next-hop-group.";
-
-            uses next-hop-group-config;
           }
         }
 
@@ -484,19 +487,6 @@ module openconfig-local-routing {
     }
   }
 
-  grouping next-hop-group-config {
-    description
-      "Grouping of configuration parameters for a static route's reference
-      to a next-hop-group.";
 
-    leaf name {
-      type leafref {
-        path "/network-instances/network-instance/static/next-hop-groups/next-hop-group/name";
-      }
-
-      description
-        "A user defined name for a next-hop-group.";
-    }
-  }
 
 }

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -47,7 +47,7 @@ module openconfig-local-routing {
 
   revision "2025-07-01" {
     description
-      "Add refernce to static next-hop-group and augment the local routing
+      "Add reference to static next-hop-group and augment the local routing
       module.";
     reference "3.1.0";
   }

--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,14 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-01" {
+    description
+      "Add refernce to static next-hop-group and augment the local routing
+      module.";
+    reference "3.1.0";
+  }
 
   revision "2025-06-30" {
     description


### PR DESCRIPTION
 ### Change Scope

This is a follow up to #1324, refactoring of yang model groupings for openconfig-local-routing.  This moves the `static/next-hop-group` grouping into the local-routing-network-instances module, allowing it to be reusable in modules that do not include network-instances.

No paths are changed, just the module in which they are contained.

```diff
         |     +--rw static-routes
         |     |  +--rw static* [prefix]
         |     |     +--rw prefix            -> ../config/prefix
         |     |     +--rw config
         |     |     |  +--rw prefix?        inet:ip-prefix
         |     |     |  +--rw set-tag?       oc-pt:tag-type
         |     |     |  +--rw description?   string
         |     |     +--ro state
         |     |     |  +--ro prefix?        inet:ip-prefix
         |     |     |  +--ro set-tag?       oc-pt:tag-type
         |     |     |  +--ro description?   string
-        |     |     +--rw next-hop-group
+        |     |     +--rw oc-loc-rt-netinst:next-hop-group
        |     |        +--rw oc-loc-rt-netinst:config
-        |     |     |  |  +--rw name?   -> /network-instances/network-instance/static/next-hop-groups/next-hop-group/name
+        |     |        |  +--rw oc-loc-rt-netinst:name?   -> ../../../../../../../oc-ni:static/next-hop-groups/next-hop-group/config/name
        |     |        +--ro oc-loc-rt-netinst:state
-        |     |     |  |  +--rw name?   -> /network-instances/network-instance/static/next-hop-groups/next-hop-group/name
+        |     |        |  +--rw oc-loc-rt-netinst:name?   -> ../../../../../../../oc-ni:static/next-hop-groups/next-hop-group/config/name
```
