### PR TITLE
ADD 100G lambda MSA Types

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,12 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision "2025-07-11" {
     description
       "Add 100G lambda MSA PMD types: 100G-LR, 4X100G-LR, 100G-FR,
-      4X100G-FR" 
+      4X100G-FR";
+    reference "1.2.0";
   }
   revision "2024-11-21" {
     description

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -24,6 +24,11 @@ module openconfig-transport-types {
 
   oc-ext:openconfig-version "1.1.0";
 
+  revision "2025-07-11" {
+    description
+      "Add 100G lambda MSA PMD types: 100G-LR, 4X100G-LR, 100G-FR,
+      4X100G-FR" 
+  }
   revision "2024-11-21" {
     description
       "Add PROT_OTSI_A protocol type.";
@@ -1209,6 +1214,31 @@ module openconfig-transport-types {
   identity ETH_100GBASE_LR4 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 100GBASE_LR4";
+  }
+
+  identity ETH_2X100GBASE_LR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 2x100GBASE_LR4";
+  }
+
+  identity ETH_100GBASE_LR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_LR";
+  }
+
+  identity ETH_4X100GBASE_LR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 4x100GBASE_LR";
+  }
+
+  identity ETH_100GBASE_FR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_FR";
+  }
+
+  identity ETH_4X100GBASE_FR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 4x100GBASE_FR";
   }
 
   identity ETH_100GBASE_ER4L {


### PR DESCRIPTION
### Change Scope

The requested change is to include new PMD types:

* 100G lambda MSA Types: 100G-LR, 100G-FR, 4X100G-LR, 4X100G-FR
See https://100glambda.com/ 

* 2X100G-LR4 is also added.

* Pluggables with those PMDs have been found in the live network and were not being properly reported today as the PMD code was missing.

### Platform Implementations
 
 * 100G lambda MSA is available at https://100glambda.com/  and is supported by major vendors. Multiple pluggables are in the market following the specifications. 