### PR TITLE
Add fragment-offsets as a match criteria for Policy Forwarding

### DIFF
--- a/release/models/acl/openconfig-packet-match-types.yang
+++ b/release/models/acl/openconfig-packet-match-types.yang
@@ -23,7 +23,13 @@ module openconfig-packet-match-types {
     "This module defines common types for use in models requiring
     data definitions related to packet matches.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.3.4";
+
+  revision "2025-06-10" {
+    description
+      "Add pattern regex for Fragment Offset range";
+    reference "1.3.4";
+  }
 
   revision "2023-01-29" {
     description
@@ -371,4 +377,35 @@ module openconfig-packet-match-types {
       decimal notation, or using a type defined by the
       ETHERTYPE identity";
   }
+
+  typedef fragment-offset-range {
+    type union {
+      type string {
+        pattern
+          '(0{0,3}[0-9]|0{0,2}[1-9][0-9]|0?[1-9][0-9]{2}|[1-7][0-9]{3}|'
+          + '80[0-9]{2}|81[0-8][0-9]|819[0-1])\\.\\.(0{0,3}[0-9]|'
+          + '0{0,2}[1-9][0-9]|0?[1-9][0-9]{2}|[1-7][0-9]{3}|'
+          + '80[0-9]{2}|81[0-8][0-9]|819[0-1])';
+        oc-ext:posix-pattern
+          '^((0{0,3}[0-9]|0{0,2}[1-9][0-9]|0?[1-9][0-9]{2}|[1-7][0-9]{3}|'
+          + '80[0-9]{2}|81[0-8][0-9]|819[0-1])\\.\\.(0{0,3}[0-9]|'
+          + '0{0,2}[1-9][0-9]|0?[1-9][0-9]{2}|[1-7][0-9]{3}|'
+          + '80[0-9]{2}|81[0-8][0-9]|819[0-1]))$';
+      }
+      type uint16 {
+        range 0..8191;
+      }
+      type enumeration {
+        enum ANY {
+          description
+            "Indicates any valid fragment, including first fragment";
+        }
+      }
+    }
+    description
+      "Fragment offset may be represented as a single value,
+      an inclusive range as <lower>..<higher>, or as ANY to
+      indicate a wildcard.";
+  }
+
 }

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -31,7 +31,13 @@ module openconfig-packet-match {
     wildcard ('any') for that field.";
 
 
-  oc-ext:openconfig-version "2.1.0";
+  oc-ext:openconfig-version "2.2.0";
+
+  revision "2025-06-10" {
+    description
+      "Add Fragment Offsets as a match condition";
+    reference "2.2.0";
+  }
 
   revision "2023-03-01" {
     description
@@ -337,6 +343,15 @@ module openconfig-packet-match {
       description
           "Reference to a IPv4 address prefix set
           to match the destination address";
+    }
+
+    leaf-list fragment-offsets {
+      type oc-pkt-match-types:fragment-offset-range;
+      description
+        "A list of Fragment Offset values to be matched for incoming packets.
+        An OR match should be performed, such that a packet must match one of
+        the values defined in this list. If the field is left empty then any
+        fragment matches. Ranges and single values may be overlapping";
     }
 
     uses ip-protocol-fields-common-config;

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -351,7 +351,7 @@ module openconfig-packet-match {
         "A list of Fragment Offset values to be matched for incoming packets.
         An OR match should be performed, such that a packet must match one of
         the values defined in this list. If the field is left empty then any
-        fragment matches. Ranges and single values may be overlapping";
+        packet matches. Ranges and single values may be overlapping";
     }
 
     uses ip-protocol-fields-common-config;


### PR DESCRIPTION
### Change Scope

- Add a new match condition `fragment-offsets` to the policy-forwarding ipv4 container.
   Match packet if the Fragment Offset field value is included in the `fragment-offsets` leaf-list. Each element of this leaf list may represent a single value, an inclusive range `<lower>..<higher>` or `ANY` ( wildcard that matches any fragments ).
- `state` i.e. the read path will return the configured values.

This change is backwards compatible

### Tree view

```diff
   +--rw policy-forwarding
   |  +--rw policies
   |  |  +--rw policy* [policy-id]
   |  |     +--rw policy-id    -> ../config/policy-id
   |  |     +--rw config
   |  |     +--ro state
   |  |     +--rw rules
   |  |        +--rw rule* [sequence-id]
   |  |           +--rw sequence-id    -> ../config/sequence-id
   |  |           +--rw config
   |  |           +--ro state
   |  |           +--rw ipv4
   |  |           |  +--rw config
   |  |           |  |  +--rw source-address?                   oc-inet:ipv4-prefix
   |  |           |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
   |  |           |  |  +--rw destination-address?              oc-inet:ipv4-prefix
   |  |           |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
+  |  |           |  |  +--rw fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
   |  |           |  |  +--rw dscp?                             oc-inet:dscp
   |  |           |  |  +--rw dscp-set*                         oc-inet:dscp
   |  |           |  |  +--rw length?                           uint16
   |  |           |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
   |  |           |  |  +--rw hop-limit?                        uint8
   |  |           |  +--ro state
   |  |           |  |  +--ro source-address?                   oc-inet:ipv4-prefix
   |  |           |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
   |  |           |  |  +--ro destination-address?              oc-inet:ipv4-prefix
   |  |           |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
+  |  |           |  |  +--ro fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
   |  |           |  |  +--ro dscp?                             oc-inet:dscp
   |  |           |  |  +--ro dscp-set*                         oc-inet:dscp
   |  |           |  |  +--ro length?                           uint16
   |  |           |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
   |  |           |  |  +--ro hop-limit?                        uint8
   |  |           |  +--rw icmpv4
```

### Platform Implementations

In Arista EOS, keyword `fragment` is used to add match condition for fragments.
Following is an example on how this is configured via EOS CLI.

```
traffic-policies
   traffic-policy foo
      match ipv4 ipv4
         fragment offset 100, 200-300
```

### More info on the Inputs

- Fragment Offset is a 13-bit field in the IPv4 header. Hence, the valid value range is 0 to 8191. This range is already restricted for the single value as well as the range.
- Single values and ranges can be overlapping. Union of all the values must be considered for matching.