### PR TITLE
Move all Counters out of Atomic Sub-Containers in the `.../afts/` Tree

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,8 +23,14 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.0.0";
-
+  oc-ext:openconfig-version "3.1.0";
+  
+  revision "2025-07-04" {
+    description
+      "Factor out AFT counters from atomic container into a unified subtree.";
+    reference "3.1.0";
+  }
+  
   revision "2025-03-12" {
     description
       "Use IP address-family specific types for UDP-V4 and UDP-V6 encapsulations in AFT.";
@@ -221,13 +227,6 @@ submodule openconfig-aft-common {
 
           uses aft-common-entry-nexthop-state;
           uses aft-labeled-entry-state;
-
-          container counters {
-            description
-              "Surrounding container for counters.";
-
-            uses aft-common-entry-counter-state;
-          }
 
           uses aft-evpn-entry-state;
 
@@ -444,14 +443,6 @@ submodule openconfig-aft-common {
   grouping aft-common-entry-state {
     description
       "Operational state parameters relating to a forwarding entry";
-
-    container counters {
-      config false;
-      description
-        "Surrounding container for counters.";
-
-      uses aft-common-entry-counter-state;
-    }
 
     leaf entry-metadata {
       type binary {
@@ -1142,45 +1133,5 @@ submodule openconfig-aft-common {
     }
 
     uses oc-if:interface-ref-common;
-  }
-
-  grouping aft-common-entry-counter-state {
-    oc-ext:telemetry-atomic-exempt;
-    description
-      "Counters relating to a forwarding entry";
-
-    leaf packets-forwarded {
-      type oc-yang:counter64;
-      description
-        "The number of packets which have matched, and been forwarded,
-         based on the AFT entry.";
-    }
-
-    leaf octets-forwarded {
-      type oc-yang:counter64;
-      description
-        "The number of octets which have matched, and been forwarded,
-         based on the AFT entry";
-    }
-  }
-
-  grouping aft-common-backup-entry-counter-state {
-    oc-ext:telemetry-atomic-exempt;
-    description
-      "Counters relating to a backup forwarding entry";
-
-    leaf packets-forwarded-backup {
-      type oc-yang:counter64;
-      description
-        "The number of packets which have matched, and been forwarded,
-         based on the AFT backup entry.";
-    }
-
-    leaf octets-forwarded-backup {
-      type oc-yang:counter64;
-      description
-        "The number of octets which have matched, and been forwarded,
-         based on the AFT backup entry";
-    }
   }
 }

--- a/release/models/aft/openconfig-aft-counters.yang
+++ b/release/models/aft/openconfig-aft-counters.yang
@@ -1,0 +1,233 @@
+submodule openconfig-aft-counters {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule providing a unified subtree for AFT entry counters.";
+
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Factor out AFT counters into a unified subtree.";
+    reference "3.1.0";
+  }
+
+  grouping aft-common-entry-counter-state {
+    description
+      "Counters relating to a forwarding entry";
+
+    leaf packets-forwarded {
+      type oc-yang:counter64;
+      description
+        "The number of packets which have matched, and been forwarded,
+        based on the AFT entry.";
+    }
+
+    leaf octets-forwarded {
+      type oc-yang:counter64;
+      description
+        "The number of octets which have matched, and been forwarded,
+        based on the AFT entry";
+    }
+  }
+
+  grouping aft-common-backup-entry-counter-state {
+    description
+      "Counters relating to a backup forwarding entry";
+
+    leaf packets-forwarded-backup {
+      type oc-yang:counter64;
+      description
+        "The number of packets which have matched, and been forwarded,
+        based on the AFT backup entry.";
+    }
+
+    leaf octets-forwarded-backup {
+      type oc-yang:counter64;
+      description
+        "The number of octets which have matched, and been forwarded,
+        based on the AFT backup entry";
+    }
+  }
+
+  grouping aft-counters {
+    description
+      "Unified subtree for AFT entry counters, organized by protocol and entry.";
+
+    container counters {
+      config false;
+      description
+        "Unified subtree for AFT entry counters, organized by protocol and entry.";
+
+      container ipv4-unicast {
+        description
+          "Counters for IPv4 unicast AFT entries.";
+
+        list ipv4-entry {
+          key "prefix";
+          description
+            "Counters for each IPv4 unicast AFT entry, keyed by prefix.";
+
+          leaf prefix {
+            type oc-inet:ipv4-prefix;
+            description
+              "The IPv4 destination prefix that should be matched to
+              utilise the AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the IPv4 unicast AFT entry.";
+
+            uses aft-common-entry-counter-state;
+            uses aft-common-backup-entry-counter-state;
+          }
+        }
+      }
+
+      container ipv6-unicast {
+        description
+          "Counters for IPv6 unicast AFT entries.";
+
+        list ipv6-entry {
+          key "prefix";
+          description
+            "Counters for each IPv6 unicast AFT entry, keyed by prefix.";
+
+          leaf prefix {
+            type oc-inet:ipv6-prefix;
+            description
+              "The IPv6 destination prefix that should be matched to
+              utilise the AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the IPv6 unicast AFT entry.";
+
+            uses aft-common-entry-counter-state;
+            uses aft-common-backup-entry-counter-state;
+          }
+        }
+      }
+
+      container mpls {
+        description
+          "Counters for MPLS AFT entries.";
+
+        list label-entry {
+          key "label";
+          description
+            "Counters for each MPLS AFT entry, keyed by label.";
+
+          leaf label {
+            type uint32;
+            description
+              "The MPLS label that should be matched to utilise the AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the MPLS AFT entry.";
+
+            uses aft-common-entry-counter-state;
+            uses aft-common-backup-entry-counter-state;
+          }
+        }
+      }
+
+      container ethernet {
+        description
+          "Counters for Ethernet AFT entries.";
+
+        list mac-entry {
+          key "mac-address";
+          description
+            "Counters for each Ethernet AFT entry, keyed by MAC address.";
+
+          leaf mac-address {
+            type oc-yang:mac-address;
+            description
+              "The MAC address that should be matched to utilise the AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the Ethernet AFT entry.";
+
+            uses aft-common-entry-counter-state;
+            uses aft-common-backup-entry-counter-state;
+          }
+        }
+      }
+
+      container policy-forwarding {
+        description
+          "Counters for Policy Forwarding AFT entries.";
+
+        list policy-forwarding-entry {
+          key "index";
+          description
+            "Counters for each Policy Forwarding AFT entry, keyed by index.";
+
+          leaf index {
+            type uint64;
+            description
+              "The index that should be matched to utilise the Policy Forwarding AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the Policy Forwarding AFT entry.";
+
+            uses aft-common-entry-counter-state;
+            uses aft-common-backup-entry-counter-state;
+          }
+        }
+      }
+
+      container next-hops {
+        description
+          "Counters for Next-Hop AFT entries.";
+
+        list next-hop {
+          key "index";
+          description
+            "Counters for each Next-Hop AFT entry, keyed by index.";
+
+          leaf index {
+            type uint64;
+            description
+              "The index that should be matched to utilise the Next-Hop AFT entry.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the Next-Hop AFT entry.";
+
+            uses aft-common-entry-counter-state;
+          }
+        }
+      }
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-counters.yang
+++ b/release/models/aft/openconfig-aft-counters.yang
@@ -147,7 +147,6 @@ submodule openconfig-aft-counters {
               "Counter state for the MPLS AFT entry.";
 
             uses aft-common-entry-counter-state;
-            uses aft-common-backup-entry-counter-state;
           }
         }
       }
@@ -173,7 +172,6 @@ submodule openconfig-aft-counters {
               "Counter state for the Ethernet AFT entry.";
 
             uses aft-common-entry-counter-state;
-            uses aft-common-backup-entry-counter-state;
           }
         }
       }
@@ -199,7 +197,6 @@ submodule openconfig-aft-counters {
               "Counter state for the Policy Forwarding AFT entry.";
 
             uses aft-common-entry-counter-state;
-            uses aft-common-backup-entry-counter-state;
           }
         }
       }

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Factor out AFT counters from atomic container into a unified subtree.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description
@@ -214,15 +220,7 @@ submodule openconfig-aft-ipv4 {
           "The IPv4 destination prefix that should be matched to
           utilise the AFT entry.";
     }
-    uses aft-common-entry-state {
-      augment counters {
-        description
-          "The number of packets and octets matched the AFT entry
-          and routed to next-hops within the backup next-hop-group";
-
-        uses aft-common-backup-entry-counter-state;
-      }
-    }
+    uses aft-common-entry-state;
     uses aft-common-ip-state;
   }
 }

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Factor out AFT counters into a unified subtree.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description
@@ -215,15 +221,7 @@ submodule openconfig-aft-ipv6 {
           "The IPv6 destination prefix that should be matched to
           utilise the AFT entry.";
     }
-    uses aft-common-entry-state {
-      augment counters {
-        description
-          "The number of packets and octets matched the AFT entry
-          and routed to next-hops within the backup next-hop-group";
-
-        uses aft-common-backup-entry-counter-state;
-      }
-    }
+    uses aft-common-entry-state;
     uses aft-common-ip-state;
   }
 }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -22,6 +22,8 @@ module openconfig-aft {
   include openconfig-aft-common;
   // Include the state synced submodule.
   include openconfig-aft-state-synced;
+  // Include the counters submodule.
+  include openconfig-aft-counters;
 
   organization
     "OpenConfig working group";
@@ -42,7 +44,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Factor out AFT counters from atomic container into a unified subtree.";
+    reference "3.1.0";
+  }
 
   revision "2025-03-12" {
     description
@@ -304,6 +312,12 @@ module openconfig-aft {
           client that AFT data/view is consistent.";
 
         uses aft-state-synced-structural;
+      }
+
+      container counters {
+        description
+          "Unified subtree for AFT entry counters, organized by protocol and entry.";
+        uses aft-counters;
       }
 
       uses aft-next-hop-groups-structural;

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -314,12 +314,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
-      container counters {
-        description
-          "Unified subtree for AFT entry counters, organized by protocol and entry.";
-        uses aft-counters;
-      }
-
+      uses aft-counters;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }


### PR DESCRIPTION
We propose a container `network-instances/network-instance/afts/counters/...` which contains all the `packets-forwarded` and `octets-forwarded` counters that are currently a part of an atomic subcontainer in the `afts` tree.

The reason for this is because the containers are `atomic`, and so, were a proper implementation to be created, one would need to send the entire atomic container whenever the packets incremented. (which of course, no one does because that would be silly.)

There was a previous attempt to fix this via the introduction of an `atomic-exempt` tag, but this misses the point of [atomicity in gNMI](https://github.com/openconfig/gnmi/blob/833747e39f20b3a5b4da786ae0782ca971bd7c83/proto/gnmi/gnmi.proto#L91), which is completely divorced from any schema definition on atomicity. (in-fact, `atomic-exempt` is incompatible with the gNMI definition.)

```
  // This notification contains a set of paths that are always updated together
  // referenced by a globally unique prefix.
  bool atomic = 6;
```

## Parsing Atomic gNMI Notifications

Handling atomic notifications in gNMI is something that can be done independent of the OpenConfig (or any other schema) specification on account of the mention of `referenced by a globally unique prefix.` (A bit of discussion [here](https://github.com/openconfig/gnmi/issues/111#issuecomment-921072341).)

To give simple examples (omitting the values, which are not important to the concept), the notification

```
Prefix: a/b
Update: c/d
Update: c/e
Update: f/g
atomic: True
time:123
```
being marked as atomic means that "Here are 'all' the leaves under `a/b`."

Note: One does not have to (and should not) reference a schema of any sort to know which container is being updated atomically. (Just read at the prefix.)

One can use this information to invalidate all previous information gathered under the prefix. E.g. The notification above  "implicitly deletes" all leaves under `a/b`. e.g. it would invalidate this entire notification:

```
Prefix: a/b
Update: x/y
Update: x/z
Update: v/w
atomic: True
time:122  <-- some notification received before this one (temporally)
```

All such leaves are rendered invalid, as they were explicitly omitted from the most recent notification.

Even if an old notification is not atomic, it can still be disregarded, as the new notification has all the required information. E.g.,

```
prefix: a/b
Update: some_counter
time: 121
```

can be ignored after we receive the new notification since it is in the `a/b` container.

With this in mind, we briefly note that, of course, this means that the following notification is fundamentally different than the one previous, despite containing the same leaves:

```
Prefix: a
Update: b/c/d
Update: b/c/e
Update: b/f/g
atomic: True
time:123
```

This is because such a notification would implicitly invalidate any notifications received under the entire `a/` tree.

-----

## Tree Diff

```
  module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--ro afts
            +--ro ipv4-unicast
            |  +--ro ipv4-entry* [prefix]
            |     +--ro prefix    -> ../state/prefix
            |     +--ro state
            |        +--ro prefix?               oc-inet:ipv4-prefix
-           |        +--ro counters
-           |        |  +--ro packets-forwarded?          oc-yang:counter64
-           |        |  +--ro octets-forwarded?           oc-yang:counter64
-           |        |  +--ro packets-forwarded-backup?   oc-yang:counter64
-           |        |  +--ro octets-forwarded-backup?    oc-yang:counter64
            |        +--ro entry-metadata?       binary
            |        +--ro origin-protocol?      identityref
            |        +--ro decapsulate-header?   oc-aftt:encapsulation-header-type
            +--ro ipv6-unicast
            |  +--ro ipv6-entry* [prefix]
            |     +--ro prefix    -> ../state/prefix
            |     +--ro state
            |        +--ro prefix?               oc-inet:ipv6-prefix
-           |        +--ro counters
-           |        |  +--ro packets-forwarded?          oc-yang:counter64
-           |        |  +--ro octets-forwarded?           oc-yang:counter64
-           |        |  +--ro packets-forwarded-backup?   oc-yang:counter64
-           |        |  +--ro octets-forwarded-backup?    oc-yang:counter64
            |        +--ro entry-metadata?       binary
            |        +--ro origin-protocol?      identityref
            |        +--ro decapsulate-header?   oc-aftt:encapsulation-header-type
            +--ro policy-forwarding
            |  +--ro policy-forwarding-entry* [index]
            |     +--ro index    -> ../state/index
            |     +--ro state
            |        +--ro index?            uint64
            |        +--ro ip-prefix?        oc-inet:ip-prefix
            |        +--ro mac-address?      oc-yang:mac-address
            |        +--ro mpls-label?       oc-mplst:mpls-label
            |        +--ro mpls-tc?          oc-mplst:mpls-tc
            |        +--ro ip-dscp?          oc-inet:dscp
            |        +--ro ip-protocol?      oc-pkt-match-types:ip-protocol-type
            |        +--ro l4-src-port?      oc-inet:port-number
            |        +--ro l4-dst-port?      oc-inet:port-number
-           |        +--ro counters
-           |        |  +--ro packets-forwarded?   oc-yang:counter64
-           |        |  +--ro octets-forwarded?    oc-yang:counter64
            |        +--ro entry-metadata?   binary
            +--ro mpls
            |  +--ro label-entry* [label]
            |     +--ro label    -> ../state/label
            |     +--ro state
            |        +--ro label?                     oc-mplst:mpls-label
-           |        +--ro counters
-           |        |  +--ro packets-forwarded?   oc-yang:counter64
-           |        |  +--ro octets-forwarded?    oc-yang:counter64
            |        +--ro entry-metadata?            binary
            |        +--ro popped-mpls-label-stack*   oc-mplst:mpls-label
            +--ro ethernet
            |  +--ro mac-entry* [mac-address]
            |     +--ro mac-address    -> ../state/mac-address
            |     +--ro state
            |        +--ro mac-address?      oc-yang:mac-address
-           |        +--ro counters
-           |        |  +--ro packets-forwarded?   oc-yang:counter64
-           |        |  +--ro octets-forwarded?    oc-yang:counter64
            |        +--ro entry-metadata?   binary
            +--ro state-synced
            |  +--ro state
            |     +--ro ipv4-unicast?   boolean
            |     +--ro ipv6-unicast?   boolean
+           +--ro counters
+           |  +--ro ipv4-unicast
+           |  |  +--ro ipv4-entry* [prefix]
+           |  |     +--ro prefix    oc-inet:ipv4-prefix
+           |  |     +--ro state
+           |  |        +--ro packets-forwarded?          oc-yang:counter64
+           |  |        +--ro octets-forwarded?           oc-yang:counter64
+           |  |        +--ro packets-forwarded-backup?   oc-yang:counter64
+           |  |        +--ro octets-forwarded-backup?    oc-yang:counter64
+           |  +--ro ipv6-unicast
+           |  |  +--ro ipv6-entry* [prefix]
+           |  |     +--ro prefix    oc-inet:ipv6-prefix
+           |  |     +--ro state
+           |  |        +--ro packets-forwarded?          oc-yang:counter64
+           |  |        +--ro octets-forwarded?           oc-yang:counter64
+           |  |        +--ro packets-forwarded-backup?   oc-yang:counter64
+           |  |        +--ro octets-forwarded-backup?    oc-yang:counter64
+           |  +--ro mpls
+           |  |  +--ro label-entry* [label]
+           |  |     +--ro label    uint32
+           |  |     +--ro state
+           |  |        +--ro packets-forwarded?   oc-yang:counter64
+           |  |        +--ro octets-forwarded?    oc-yang:counter64
+           |  +--ro ethernet
+           |  |  +--ro mac-entry* [mac-address]
+           |  |     +--ro mac-address    oc-yang:mac-address
+           |  |     +--ro state
+           |  |        +--ro packets-forwarded?   oc-yang:counter64
+           |  |        +--ro octets-forwarded?    oc-yang:counter64
+           |  +--ro policy-forwarding
+           |  |  +--ro policy-forwarding-entry* [index]
+           |  |     +--ro index    uint64
+           |  |     +--ro state
+           |  |        +--ro packets-forwarded?   oc-yang:counter64
+           |  |        +--ro octets-forwarded?    oc-yang:counter64
+           |  +--ro next-hops
+           |     +--ro next-hop* [index]
+           |        +--ro index    uint64
+           |        +--ro state
+           |           +--ro packets-forwarded?   oc-yang:counter64
+           |           +--ro octets-forwarded?    oc-yang:counter64
            +--ro next-hop-groups
            |  +--ro next-hop-group* [id]
            |     +--ro id             -> ../state/id
            |     +--ro state
            |     |  +--ro id?                      uint64
            |     |  +--ro next-hop-group-name?     string
            |     |  +--ro programmed-id?           uint64
            |     |  +--ro color?                   uint64
            |     |  +--ro backup-next-hop-group?   -> ../../../next-hop-group/state/id
            |     |  +--ro backup-active?           boolean
            |     +--ro next-hops
            |     |  +--ro next-hop* [index]
            |     |     +--ro index    -> ../state/index
            |     |     +--ro state
            |     |        +--ro index?    -> ../../../../../../next-hops/next-hop/state/index
            |     |        +--ro weight?   uint64
            |     +--ro conditional
            |        +--ro condition* [id]
            |           +--ro id                  -> ../state/id
            |           +--ro state
            |           |  +--ro id?               uint64
            |           |  +--ro dscp*             oc-inet:dscp
            |           |  +--ro next-hop-group?   -> ../../../../../next-hop-group/state/id
            |           +--ro input-interfaces
            |              +--ro input-interface* [id]
            |                 +--ro id       -> ../state/id
            |                 +--ro state
            |                    +--ro id?             string
            |                    +--ro interface?      -> /oc-if:interfaces/interface/name
            |                    +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
            +--ro next-hops
               +--ro next-hop* [index]
                  +--ro index            -> ../state/index
                  +--ro state
                  |  +--ro index?                     uint64
                  |  +--ro programmed-index?          uint64
                  |  +--ro ip-address?                oc-inet:ip-address
                  |  +--ro mac-address?               oc-yang:mac-address
                  |  +--ro pop-top-label?             boolean
                  |  +--ro pushed-mpls-label-stack*   oc-mplst:mpls-label
                  |  +--ro encapsulate-header?        oc-aftt:encapsulation-header-type
                  |  +--ro decapsulate-header?        oc-aftt:encapsulation-header-type
                  |  +--ro origin-protocol?           identityref
                  |  +--ro lsp-name?                  string
-                 |  +--ro counters
-                 |  |  +--ro packets-forwarded?   oc-yang:counter64
-                 |  |  +--ro octets-forwarded?    oc-yang:counter64
                  |  +--ro vni-label?                 oc-evpn-types:evi-id
                  |  +--ro tunnel-src-ip-address?     oc-inet:ip-address
                  +--ro ip-in-ip
                  |  +--ro state
                  |     +--ro src-ip?   oc-inet:ip-address
                  |     +--ro dst-ip?   oc-inet:ip-address
                  +--ro gre
                  |  +--ro state
                  |     +--ro src-ip?   oc-inet:ip-address
                  |     +--ro dst-ip?   oc-inet:ip-address
                  |     +--ro ttl?      uint8
                  +--ro encap-headers
                  |  +--ro encap-header* [index]
                  |     +--ro index     -> ../state/index
                  |     +--ro state
                  |     |  +--ro index?   uint8
                  |     |  +--ro type?    oc-aftt:encapsulation-header-type
                  |     +--ro gre
                  |     |  +--ro state
                  |     |     +--ro src-ip?   oc-inet:ip-address
                  |     |     +--ro dst-ip?   oc-inet:ip-address
                  |     |     +--ro ttl?      uint8
                  |     +--ro ipv4
                  |     |  +--ro state
                  |     |     +--ro src-ip?   oc-inet:ip-address
                  |     |     +--ro dst-ip?   oc-inet:ip-address
                  |     +--ro ipv6
                  |     |  +--ro state
                  |     |     +--ro src-ip?   oc-inet:ip-address
                  |     |     +--ro dst-ip?   oc-inet:ip-address
                  |     +--ro mpls
                  |     |  +--ro state
                  |     |     +--ro traffic-class?      oc-mplst:mpls-tc
                  |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
                  |     +--ro udp-v4
                  |     |  +--ro state
                  |     |     +--ro src-ip?         oc-inet:ipv4-address
                  |     |     +--ro dst-ip?         oc-inet:ipv4-address
                  |     |     +--ro dscp?           oc-inet:dscp
                  |     |     +--ro src-udp-port?   oc-inet:port-number
                  |     |     +--ro dst-udp-port?   oc-inet:port-number
                  |     |     +--ro ip-ttl?         uint8
                  |     +--ro udp-v6
                  |     |  +--ro state
                  |     |     +--ro src-ip?         oc-inet:ipv6-address
                  |     |     +--ro dst-ip?         oc-inet:ipv6-address
                  |     |     +--ro dscp?           oc-inet:dscp
                  |     |     +--ro src-udp-port?   oc-inet:port-number
                  |     |     +--ro dst-udp-port?   oc-inet:port-number
                  |     |     +--ro ip-ttl?         uint8
                  |     +--ro vxlan
                  |        +--ro state
                  |           +--ro vni-label?               oc-evpn-types:evi-id
                  |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
                  +--ro interface-ref
                     +--ro state
                        +--ro interface?      -> /oc-if:interfaces/interface/name
                        +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
```

-----

## Copilot summary

This pull request refactors the AFT (Abstract Forwarding Table) YANG models to factor out counters from atomic containers into a unified subtree. It introduces a new submodule, `openconfig-aft-counters`, and updates several existing submodules to integrate this change. The refactoring improves modularity and organization of AFT entry counters across protocols.

### Refactoring of AFT Counters

* **Introduction of `openconfig-aft-counters` submodule**: A new submodule was created to provide a unified subtree for AFT entry counters, including groupings for counters related to IPv4, IPv6, MPLS, Ethernet, Policy Forwarding, and Next-Hop entries. (`release/models/aft/openconfig-aft-counters.yang`)

* **Removal of counter definitions from `openconfig-aft-common`**: Counter-related groupings and containers were removed from `openconfig-aft-common` and moved to the new `openconfig-aft-counters` submodule. (`release/models/aft/openconfig-aft-common.yang`) [[1]](diffhunk://#diff-3c3efc01df1e58a694a2036c2660d625067662559a8b32f9327f145e45a782e6L225-L231) [[2]](diffhunk://#diff-3c3efc01df1e58a694a2036c2660d625067662559a8b32f9327f145e45a782e6L448-L455) [[3]](diffhunk://#diff-3c3efc01df1e58a694a2036c2660d625067662559a8b32f9327f145e45a782e6L1146-L1185)

### Updates to Existing Submodules

* **Integration of unified counters in `openconfig-aft-ipv4` and `openconfig-aft-ipv6`**: Counter augmentations were removed, and references to the unified counter groupings were added to streamline the structure. (`release/models/aft/openconfig-aft-ipv4.yang`, `release/models/aft/openconfig-aft-ipv6.yang`) [[1]](diffhunk://#diff-6a974025ed746a5b21eb0047e47d0b6f11e1d573b5c12059732d2cc66c99354eL217-R223) [[2]](diffhunk://#diff-fe7235304d83f787c114dc4fef5b8a87f311a0ee815a1cd9d1eeb6e98c2ca8c2L218-R224)

### Updates to the Main AFT Module

* **Inclusion of `openconfig-aft-counters`**: The main `openconfig-aft` module now includes the new `openconfig-aft-counters` submodule. (`release/models/aft/openconfig-aft.yang`) [[1]](diffhunk://#diff-fcdf93b4c5072b9e2e30184c20bc176b55315155b472943f8618d0c7aaef0a9eR25-R26) [[2]](diffhunk://#diff-fcdf93b4c5072b9e2e30184c20bc176b55315155b472943f8618d0c7aaef0a9eR317)

* **Version bump to 3.1.0**: All affected modules and submodules were updated to version `3.1.0` to reflect the changes. (`release/models/aft/openconfig-aft.yang`, `release/models/aft/openconfig-aft-common.yang`, `release/models/aft/openconfig-aft-ipv4.yang`, `release/models/aft/openconfig-aft-ipv6.yang`) [[1]](diffhunk://#diff-fcdf93b4c5072b9e2e30184c20bc176b55315155b472943f8618d0c7aaef0a9eL45-R53) [[2]](diffhunk://#diff-3c3efc01df1e58a694a2036c2660d625067662559a8b32f9327f145e45a782e6L26-R32) [[3]](diffhunk://#diff-6a974025ed746a5b21eb0047e47d0b6f11e1d573b5c12059732d2cc66c99354eL23-R29) [[4]](diffhunk://#diff-fe7235304d83f787c114dc4fef5b8a87f311a0ee815a1cd9d1eeb6e98c2ca8c2L23-R29)