### PR TITLE
ADD CS Connector Type (http://csconnector.net/)

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
+
+  revision "2024-11-21" {
+    description
+      "Add CS connector type";
+    reference "1.2.0";
+  }
 
   revision "2024-11-21" {
     description
@@ -1098,6 +1104,14 @@ module openconfig-transport-types {
     base FIBER_CONNECTOR_TYPE;
     description
       "DAC (direct attach copper) type fiber connector";
+  }
+
+  identity CS_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "CS Connector Type";
+    reference
+       "http://csconnector.net/";
   }
 
   identity ETHERNET_PMD_TYPE {


### PR DESCRIPTION
There is a new CS Connector type that was not modeled, it is added

### Change Scope
* Some recent pluggables come with a new connector type more compact called CS connector. The proposal is to add a new connector type to indicate such connector. 
* 
### Platform Implementations

* The CS connector is found in, for example:

  * https://apps.juniper.net/hct/model/?component=QDD-2X100G-LR4 
  
  The CS connector is explained in http://csconnector.net/  

SFF has already included the CS connector type:

<img width="459" alt="image" src="https://github.com/user-attachments/assets/deaa8c49-2de4-4c58-98ef-eec87f42a7b3" />

