### PR TITLE
Add accounting-method and authorization-method leaf-lists inside the /system/aaa/accounting/events/event and /system/aaa/authorization/events/event lists, respectively.

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,15 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Add accounting-method and authorization-method leaf-lists
+      inside accounting/events/event and authorization/events/event
+      lists, respectively.";
+    reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,15 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Add accounting-method and authorization-method leaf-lists
+      inside accounting/events/event and authorization/events/event
+      lists, respectively.";
+    reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -36,8 +36,8 @@ module openconfig-aaa {
 
   revision "2025-07-04" {
     description
-      "Moved accounting-method and authorization-method leaf-lists
-      inside the accounting/events/event and authorization/events/event
+      "Add accounting-method and authorization-method leaf-lists
+      inside accounting/events/event and authorization/events/event
       lists, respectively.";
     reference "1.1.0";
   }
@@ -575,6 +575,10 @@ module openconfig-aaa {
   grouping aaa-accounting-config {
     description
       "Configuration data for event accounting";
+
+    uses aaa-accounting-methods-common {
+      status deprecated;
+    }
   }
 
   grouping aaa-accounting-state {
@@ -700,6 +704,10 @@ module openconfig-aaa {
   grouping aaa-authorization-config {
     description
       "Configuration data for AAA authorization";
+
+    uses aaa-authorization-methods-common {
+      status deprecated;
+    }
   }
 
   grouping aaa-authorization-state {

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -32,7 +32,15 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2025-07-04" {
+    description
+      "Moved accounting-method and authorization-method leaf-lists
+      inside the accounting/events/event and authorization/events/event
+      lists, respectively.";
+    reference "1.1.0";
+  }
 
   revision "2022-07-29" {
     description
@@ -467,7 +475,7 @@ module openconfig-aaa {
           base oc-aaa-types:AAA_METHOD_TYPE;
         }
         type string;
-        //TODO:  in YANG 1.1 this should be converted to a leafref to
+        //TODO: in YANG 1.1 this should be converted to a leafref to
         //point to the server group name.
       }
       ordered-by user;
@@ -547,6 +555,7 @@ module openconfig-aaa {
             "Configuration data for accounting events";
 
           uses aaa-accounting-events-config;
+          uses aaa-accounting-methods-common;
         }
 
         container state {
@@ -557,6 +566,7 @@ module openconfig-aaa {
 
           uses aaa-accounting-events-config;
           uses aaa-accounting-events-state;
+          uses aaa-accounting-methods-common;
         }
       }
     }
@@ -565,9 +575,6 @@ module openconfig-aaa {
   grouping aaa-accounting-config {
     description
       "Configuration data for event accounting";
-
-    uses aaa-accounting-methods-common;
-
   }
 
   grouping aaa-accounting-state {
@@ -605,10 +612,9 @@ module openconfig-aaa {
     }
   }
 
-  grouping aaa-authorization-methods-config {
+  grouping aaa-authorization-methods-common {
     description
-      "Common definitions for authorization methods for global
-      and per-event type";
+      "Common definitions for authorization methods";
 
     leaf-list authorization-method {
       type union {
@@ -674,6 +680,7 @@ module openconfig-aaa {
             "Configuration data for each authorized event";
 
           uses aaa-authorization-events-config;
+          uses aaa-authorization-methods-common;
         }
 
         container state {
@@ -684,6 +691,7 @@ module openconfig-aaa {
 
           uses aaa-authorization-events-config;
           uses aaa-authorization-events-state;
+          uses aaa-authorization-methods-common;
         }
       }
     }
@@ -692,8 +700,6 @@ module openconfig-aaa {
   grouping aaa-authorization-config {
     description
       "Configuration data for AAA authorization";
-
-    uses aaa-authorization-methods-config;
   }
 
   grouping aaa-authorization-state {


### PR DESCRIPTION
(M) system/openconfig-aaa.yang

### Change Scope

AAA `accounting-method` and `authorization-method` should be able to be configured per `event-type`.
For example `event-type=AAA_ACCOUNTING_EVENT_COMMAND` can have a different `accounting-method` configured vs. `event-type=AAA_ACCOUNTING_EVENT_LOGIN`.

This change is an addition of AAA capabilities for `accounting-method` and `authorization-method` and is a non-breaking (backwards-compatible) change.

### Platform Implementations

Arista AAA configuration:
accounting and authorization can have different accounting-methods and authorization-methods configured (e.g. `group tacacs+`, `group radius`, `local`, `logging`) per event type (e.g. `commands`, `exec`, etc.). 

```
(config)#aaa accounting commands all console start-stop group tacacs+
(config)#aaa accounting exec console start-stop group radius logging
(config)#aaa authorization commands all default group radius
(config)#aaa authorization exec default group tacacs+ local
```
Arista documentation for [authorization](https://www.arista.com/en/um-eos/eos-user-security#xx1348035:~:text=lockout-,Authorization,-Authorization)

Arista documentation for [accounting](https://www.arista.com/en/um-eos/eos-user-security#xx1348035:~:text=console-,Accounting,-The)

Pyang output for the new model:
```
module: openconfig-system
  +--rw system
     +--rw aaa
        +--rw config
        +--ro state
        +--rw authorization
        |  +--rw config
        |  |  +--rw authorization-method*   union [DEPRECATED]
        |  +--ro state
        |  |  +--ro authorization-method*   union [DEPRECATED]
        |  +--rw events
        |     +--rw event* [event-type]
        |        +--rw event-type    -> ../config/event-type
        |        +--rw config
        |        |  +--rw event-type?             identityref
        |        |  +--rw authorization-method*   union [NEW]
        |        +--ro state
        |           +--ro event-type?             identityref
        |           +--ro authorization-method*   union [NEW]
        +--rw accounting
        |  +--rw config
        |  |  +--rw accounting-method*   union [DEPRECATED]
        |  +--ro state
        |  |  +--ro accounting-method*   union [DEPRECATED]
        |  +--rw events
        |     +--rw event* [event-type]
        |        +--rw event-type    -> ../config/event-type
        |        +--rw config
        |        |  +--rw event-type?          identityref
        |        |  +--rw record?              enumeration
        |        |  +--rw accounting-method*   union [NEW]
        |        +--ro state
        |           +--ro event-type?          identityref
        |           +--ro record?              enumeration
        |           +--ro accounting-method*   union [NEW]
```

--------------------------------------
P. S. As an aside (not the topic of this PR), certain event types (e.g. `commands`) can have privilege levels associated, usually between 0 (unprivileged) to 15 (full privilege). To accommodate privilege levels, we can either:
1. add more `event-type` identities with privilege level suffix attached such as `AAA_ACCOUNTING_EVENT_COMMAND_07` and `AAA_ACCOUNTING_EVENT_COMMAND_15` and keep the current tree structure (i.e. backwards compatible)
2. or add an additional list such as `privilege-level[level=?]` under `.../events/event/...`, such as
```
        |     +--rw event* [event-type]
        |        +--rw event-type    -> ../config/event-type
        |        +--rw privilege-level* [level]
        |        |  +--rw level
        |        |  +--rw config
        |        |    +--rw event-type?          identityref
        |        |    +--rw record?              enumeration
        |        |    +--rw accounting-method*   union
        |        |  +--ro state
        |        |    +--ro event-type?          identityref
        |        |    +--ro record?              enumeration
        |        |    +--ro accounting-method*   union
```
 For `event-type` with only 1 privilege-level, the key could be `level=all`, and for `event-type` with multiple privilege levels, the level can be more customized such as `level=5`. This better delineates between `event-type` and `privilege-level` but is a breaking change.
 
 Without either of the 2 changes above, the YANG model would not be able to configure or represent full Aaa accounting and authorization on a vendor switch.
