### PR TITLE
Add policy-forwarding action next-hop-group

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -21,7 +21,13 @@ submodule openconfig-pf-forwarding-policies {
     "This submodule contains configuration and operational state
     relating to the definition of policy-forwarding policies.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-07-08" {
+    description
+      "  Add action next-hop-group.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description
@@ -383,6 +389,16 @@ submodule openconfig-pf-forwarding-policies {
         packets matching the match criteria for the forwarding rule
         should be forwarded to the next-hop IP address, bypassing any
         lookup on the local system.";
+    }
+
+    leaf next-hop-group {
+      // we are at /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group	
+      type leafref {
+        path "../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
+      }
+      description
+        "When specified, the next-hop of a packet is resolved from referenced
+        static next-hop-group in the same network-instance.";
     }
 
     leaf decapsulate-mpls-in-udp {

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -394,7 +394,7 @@ submodule openconfig-pf-forwarding-policies {
     leaf next-hop-group {
       // we are at /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group	
       type leafref {
-        path "../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
+        path "../../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }
       description
         "When specified, the next-hop of a packet is resolved from referenced

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -394,7 +394,7 @@ submodule openconfig-pf-forwarding-policies {
     leaf next-hop-group {
       // we are at /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group	
       type leafref {
-        path "../../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
+        path "../../../../../../../../static/next-hop-groups/next-hop-group/config/name";
       }
       description
         "When specified, the next-hop of a packet is resolved from referenced

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -25,7 +25,7 @@ submodule openconfig-pf-forwarding-policies {
 
   revision "2025-07-08" {
     description
-      "  Add action next-hop-group.";
+      "Add policy-forwarding action next-hop-group.";
     reference "0.8.0";
   }
 
@@ -394,7 +394,7 @@ submodule openconfig-pf-forwarding-policies {
     leaf next-hop-group {
       // we are at /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group	
       type leafref {
-        path "../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
+        path "../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }
       description
         "When specified, the next-hop of a packet is resolved from referenced

--- a/release/models/policy-forwarding/openconfig-pf-interfaces.yang
+++ b/release/models/policy-forwarding/openconfig-pf-interfaces.yang
@@ -19,7 +19,13 @@ submodule openconfig-pf-interfaces {
     "This submodule contains groupings related to the association
     between interfaces and policy forwarding rules.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-07-08" {
+    description
+      "Add policy-forwarding action next-hop-group.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description

--- a/release/models/policy-forwarding/openconfig-pf-path-groups.yang
+++ b/release/models/policy-forwarding/openconfig-pf-path-groups.yang
@@ -18,7 +18,13 @@ submodule openconfig-pf-path-groups {
     forwarding entities together to be used as policy forwarding
     targets.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-07-08" {
+    description
+      "Add policy-forwarding action next-hop-group.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description

--- a/release/models/policy-forwarding/openconfig-policy-forwarding.yang
+++ b/release/models/policy-forwarding/openconfig-policy-forwarding.yang
@@ -86,7 +86,13 @@ module openconfig-policy-forwarding {
     The forwarding action of the corresponding policy is set to
     PATH_GROUP and references the configured group of LSPs.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2025-07-08" {
+    description
+      "Add policy-forwarding action next-hop-group.";
+    reference "0.8.0";
+  }
 
   revision "2024-11-14" {
     description


### PR DESCRIPTION
### Change Scope

* This adds a policy-forwarding action to set the next-hop-group
* In this use case, a next-hop-group is a statically defined with one or more next-hops
* If a packet matches the policy-forwarding rule, then the system resolves the next-hops using the referenced next-hop group.

Tree view
```diff
        +--rw policy-forwarding
        |  +--rw policies
        |  |  +--rw policy* [policy-id]
        |  |     +--rw rules
        |  |        +--rw rule* [sequence-id]
         |  |           +--rw action
         |  |           |  +--rw config
         |  |           |  |  +--rw discard?                           boolean
         |  |           |  |  +--rw decapsulate-gre?                   boolean
         |  |           |  |  +--rw decap-network-instance?            -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw decap-fallback-network-instance?   -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw network-instance?                  -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |           |  |  +--rw next-hop?                          oc-inet:ip-address
+        |  |           |  |  +--rw next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |           |  |  +--rw decapsulate-mpls-in-udp?           boolean
         |  |           |  |  +--rw decapsulate-gue?                   boolean
         |  |           |  +--ro state
         |  |           |  |  +--ro discard?                           boolean
         |  |           |  |  +--ro decapsulate-gre?                   boolean
         |  |           |  |  +--ro decap-network-instance?            -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro decap-fallback-network-instance?   -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro network-instance?                  -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |           |  |  +--ro next-hop?                          oc-inet:ip-address
+        |  |           |  |  +--ro next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |           |  |  +--ro decapsulate-mpls-in-udp?           boolean
         |  |           |  |  +--ro decapsulate-gue?                   boolean
```
### Platform Implementations

 * Arista EOS [traffic-policies](https://www.arista.com/en/support/toi/eos-4-31-2f/19194-support-for-redirect-in-traffic-policies-on-egress-interfaces) support setting [next-hop-group](https://www.arista.com/en/um-eos/eos-nexthop-groups#:~:text=group%20is%20applied.-,A%20nexthop%20group%20is%20a%20data%20structure%20that%20defines%20a,specifies%20a%20non%2Dexistent%20group.)

```
traffic-policies
  traffic-policy samplePolicy
    match v6-dscp3 ipv6
      dscp 3
      !
      actions
        redirect next-hop group MY_NHG
    !
```

* Cisco IOS XR support [ACL based forwarding including setting an IP next-hop](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/ip-addresses/b-ip-addresses-cr-8k/access-list-commands.html).  We are working with Cisco to extend this for next-hop-group and add OpenConfig policy-forwarding to a next-hop-group.
Current syntax
```
Router(config)# ipv4 access-list TEST
Router(config-ipv4-acl)# 10 permit tcp any any

/* Configure an ACE to match on the dont-fragment flag (indicates a non-fragmented packet)
 and forward the packet to the default (pre-configured) next hop  */
Router(config-ipv4-acl)# 20 permit tcp any any fragment-type dont-fragment nexthop1 ipv4 192.0.2.1 
```

 * JunOS supports  [filter based forwarding](https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/example/filter-based-forwarding-example.html) and configuring [next-hop-groups](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/next-hop-group-edit-forwarding-options.html).  We are working with Juniper to extend this for next-hop-group and add OpenConfig policy-forwarding to a next-hop-group.

 * Nokia SR Linux supports configuration of [next-hop-group](https://documentation.nokia.com/srlinux/23-10/books/config-basics/network-instances.html). We are working with Nokia to extend this for next-hop-group and add OpenConfig policy-forwarding to a next-hop-group.
 
