### PR TITLE
Adding platform model for USB port

### DIFF
--- a/release/models/platform/.spec.yml
+++ b/release/models/platform/.spec.yml
@@ -17,6 +17,7 @@
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
     - yang/platform/openconfig-platform-healthz.yang
+    - yang/platform/openconfig-platform-usb-port.yang
     - yang/p4rt/openconfig-p4rt.yang
     - yang/system/openconfig-alarms.yang
     - yang/optical-transport/openconfig-terminal-device.yang
@@ -38,6 +39,7 @@
     - yang/platform/openconfig-platform-integrated-circuit.yang
     - yang/platform/openconfig-platform-controller-card.yang
     - yang/platform/openconfig-platform-healthz.yang
+    - yang/platform/openconfig-platform-usb-port.yang
     - yang/p4rt/openconfig-p4rt.yang
     - yang/system/openconfig-alarms.yang
     - yang/optical-transport/openconfig-terminal-device.yang

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -393,7 +393,7 @@ module openconfig-platform-types {
   identity USB_PORT {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
-      "USB port, typically USB-A.";
+      "Non-serial USB ports of any type.";
   }
 
   identity TRANSCEIVER {

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,8 +22,14 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.9.0";
+  oc-ext:openconfig-version "1.10.0";
 
+
+  revision "2025-07-18" {
+    description
+      "Add USB_PORT";
+    reference "1.10.0";
+  }
 
   revision "2024-11-04" {
     description
@@ -382,6 +388,12 @@ module openconfig-platform-types {
     description
       "Physical port, e.g., for attaching pluggables and networking
       cables";
+  }
+
+  identity USB_PORT {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "USB port, typically USB-A.";
   }
 
   identity TRANSCEIVER {

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -24,7 +24,7 @@ module openconfig-platform-usb-port {
 
   oc-ext:openconfig-version "0.1.0";
 
-  revision "2025-07-12" {
+  revision "2025-08-18" {
     description
       "Initial revision";
     reference "0.1.0";
@@ -37,49 +37,34 @@ module openconfig-platform-usb-port {
 
   // grouping statements
 
-  grouping platform-usb-port-config {
+  grouping usb-port-config {
     description
-      "Configuration data for USB port";
+      "Configuration data for USB ports";
 
-    leaf enabled {
-      type boolean;
-      description
-        "The configured state (enabled/disabled) of this USB port.";
-    }
+    uses oc-platform:component-power-management;
   }
 
-  grouping platform-usb-port-state {
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:usb-port/oc-platform:config" {
     description
-      "Operational state data for USB port";
+      "Configuration data for USB ports.
+      A USB port can be configured for persistent powered-off
+      mode using the config/power-admin-state leaf.";
+
+    uses usb-port-config;
   }
 
-  grouping usb-port-top {
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:usb-port/oc-platform:state" {
     description
-      "Top-level grouping for USB port data";
+      "Adding USB port data to physical inventory. This subtree
+      is only valid when the type of the component is USB_PORT.";
 
-    container usb-port {
-      description
-        "Top-level container for USB port";
-
-      container config {
-        description
-          "Configuration data for USB port";
-
-        uses platform-usb-port-config;
-      }
-
-      container state {
-
-        config false;
-
-        description
-          "Operational state data for USB port";
-
-        uses platform-usb-port-config;
-        uses platform-usb-port-state;
-      }
-    }
+    uses usb-port-config;
   }
-  uses usb-port-top;
 
 }

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -37,9 +37,9 @@ module openconfig-platform-usb-port {
 
   // grouping statements
 
-  grouping usb-port-config {
+  grouping platform-usb-port-config {
     description
-      "Configuration data for usb port components";
+      "Configuration data for USB port";
 
     leaf enabled {
       type boolean;
@@ -47,7 +47,40 @@ module openconfig-platform-usb-port {
       description
         "The configured state (enabled/disabled) of this USB port.";
     }
-
   }
+
+  grouping platform-usb-port-state {
+    description
+      "Operational state data for USB port";
+  }
+
+  grouping usb-port-top {
+    description
+      "Top-level grouping for USB port data";
+
+    container usb-port {
+      description
+        "Top-level container for USB port";
+
+      container config {
+        description
+          "Configuration data for USB port";
+
+        uses platform-usb-port-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for USB port";
+
+        uses platform-usb-port-config;
+        uses platform-usb-port-state;
+      }
+    }
+  }
+  uses usb-port-top;
 
 }

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -24,7 +24,7 @@ module openconfig-platform-usb-port {
 
   oc-ext:openconfig-version "0.1.0";
 
-  revision "2025-07-10" {
+  revision "2025-07-18" {
     description
       "Initial revision";
     reference "0.1.0";

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -24,7 +24,7 @@ module openconfig-platform-usb-port {
 
   oc-ext:openconfig-version "0.1.0";
 
-  revision "2025-07-18" {
+  revision "2025-07-12" {
     description
       "Initial revision";
     reference "0.1.0";
@@ -43,7 +43,6 @@ module openconfig-platform-usb-port {
 
     leaf enabled {
       type boolean;
-      default "false";
       description
         "The configured state (enabled/disabled) of this USB port.";
     }

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -1,0 +1,74 @@
+module openconfig-platform-usb-port {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/usb-port";
+
+  prefix "oc-usb-port";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to USB port components in the
+    OpenConfig platform model.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2025-07-10" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping usb-port-config {
+    description
+      "Configuration data for usb port components";
+
+    uses oc-platform:component-power-management;
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:usb-port/oc-platform:config" {
+    description
+      "Configuration data for usb port components.
+      A USB port can be configured for persistent powered-off
+      mode using the config/power-admin-state leaf.";
+
+    uses usb-port-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:usb/oc-platform:state" {
+    description
+      "Adding USB port data to component model.";
+
+    uses usb-port-config;
+  }
+
+}

--- a/release/models/platform/openconfig-platform-usb-port.yang
+++ b/release/models/platform/openconfig-platform-usb-port.yang
@@ -35,40 +35,19 @@ module openconfig-platform-usb-port {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  // identity statements
-
-  // typedef statements
-
   // grouping statements
 
   grouping usb-port-config {
     description
       "Configuration data for usb port components";
 
-    uses oc-platform:component-power-management;
-  }
+    leaf enabled {
+      type boolean;
+      default "false";
+      description
+        "The configured state (enabled/disabled) of this USB port.";
+    }
 
-
-  // data definition statements
-
-  // augment statements
-
-  augment "/oc-platform:components/oc-platform:component/" +
-    "oc-platform:usb-port/oc-platform:config" {
-    description
-      "Configuration data for usb port components.
-      A USB port can be configured for persistent powered-off
-      mode using the config/power-admin-state leaf.";
-
-    uses usb-port-config;
-  }
-
-  augment "/oc-platform:components/oc-platform:component/" +
-    "oc-platform:usb/oc-platform:state" {
-    description
-      "Adding USB port data to component model.";
-
-    uses usb-port-config;
   }
 
 }


### PR DESCRIPTION
### Change Scope

Adding new platform model for USB ports, enable/disable functionality.
This change is backwards compatible

### Platform Implementations

- Mobility Controller-based Aruba Access Points: https://arubanetworking.hpe.com/techdocs/CLI-Bank/Content/aos8/ap-system-pro.htm (`ap-usb-power-mode [enable|disable]`)

- Cisco Catalyst switches: https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/17-17/command_reference/b_1717_9400_cr/interface_and_hardware_commands.html?dtid=osscdc000283&linkclickid=srch#wp3775305635  (`[no] platform usb disable`)