### PR TITLE
mark transceiver serial-no and vendor-part as deprecated

### DIFF
--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -740,7 +740,7 @@ module openconfig-platform-transceiver {
         right with ASCII spaces (20h). If part number is undefined,
         all 16 octets = 0h. This leaf is deprecated and the
         components/component/state/part-no leaf should be used
-        instead.";
+        to hold this value instead (these leaves are duplicates).";
     }
 
     leaf vendor-rev {
@@ -792,7 +792,7 @@ module openconfig-platform-transceiver {
         ASCII spaces (20h). If part serial number is undefined, all
         16 octets = 0h. This leaf is deprecated and the
         components/component/state/serial-no leaf should be used
-        instead.";
+        to hold this value instead (these leaves are duplicates).";
     }
 
     leaf date-code {

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -733,6 +733,7 @@ module openconfig-platform-transceiver {
       type string {
         length 1..16;
       }
+      status deprecated;
       description
         "Transceiver vendor's part number. 16-octet field that
         contains ASCII characters, left-aligned and padded on the
@@ -784,6 +785,7 @@ module openconfig-platform-transceiver {
       type string {
         length 1..16;
       }
+      status deprecated;
       description
         "Transceiver serial number. 16-octet field that contains
         ASCII characters, left-aligned and padded on the right with

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -741,7 +741,7 @@ module openconfig-platform-transceiver {
         all 16 octets = 0h. This deprecated leaf should continue
         to be supported by implementations but clients should stop
         using this leaf and instead use
-        '/components/component/state/part-no'.";  
+        '/components/component/state/part-no'.";
     }
 
     leaf vendor-rev {

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -731,7 +731,9 @@ module openconfig-platform-transceiver {
         "Transceiver vendor's part number. 16-octet field that
         contains ASCII characters, left-aligned and padded on the
         right with ASCII spaces (20h). If part number is undefined,
-        all 16 octets = 0h";
+        all 16 octets = 0h. This leaf is deprecated and the
+        components/component/state/part-no leaf should be used
+        instead.";
     }
 
     leaf vendor-rev {
@@ -780,7 +782,9 @@ module openconfig-platform-transceiver {
         "Transceiver serial number. 16-octet field that contains
         ASCII characters, left-aligned and padded on the right with
         ASCII spaces (20h). If part serial number is undefined, all
-        16 octets = 0h";
+        16 octets = 0h. This leaf is deprecated and the
+        components/component/state/serial-no leaf should be used
+        instead.";
     }
 
     leaf date-code {

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,7 +66,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.16.0";
+  oc-ext:openconfig-version "0.17.0";
+
+  revision "2025-07-21" {
+    description
+      "Mark transceiver serial-no and vendor-part leaves as deprecated.";
+    reference "0.17.0";
+  }
 
   revision "2024-10-09" {
     description

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -738,9 +738,10 @@ module openconfig-platform-transceiver {
         "Transceiver vendor's part number. 16-octet field that
         contains ASCII characters, left-aligned and padded on the
         right with ASCII spaces (20h). If part number is undefined,
-        all 16 octets = 0h. This leaf is deprecated and the
-        components/component/state/part-no leaf should be used
-        to hold this value instead (these leaves are duplicates).";
+        all 16 octets = 0h. This deprecated leaf should continue
+        to be supported by implementations but clients should stop
+        using this leaf and instead use
+        '/components/component/state/part-no'.";  
     }
 
     leaf vendor-rev {
@@ -790,9 +791,10 @@ module openconfig-platform-transceiver {
         "Transceiver serial number. 16-octet field that contains
         ASCII characters, left-aligned and padded on the right with
         ASCII spaces (20h). If part serial number is undefined, all
-        16 octets = 0h. This leaf is deprecated and the
-        components/component/state/serial-no leaf should be used
-        to hold this value instead (these leaves are duplicates).";
+        16 octets = 0h. This deprecated leaf should continue
+        to be supported by implementations but clients should stop
+        using this leaf and instead use
+        '/components/component/state/serial-no'.";
     }
 
     leaf date-code {


### PR DESCRIPTION
### Change Scope

This change is backwards compatible.

This change is marking the `components/component/transceiver/state/serial-no` and `components/component/transceiver/state/vendor-part` leaves as deprecated. The `components/component/state/serial-no` and `components/component/state/part-no` leaves should be used instead, respectively, going forward.

These duplicate serial and part number `components/component/transceiver/state/*` leaves are redundant and the top-level component ones (`components/component/state/*`) are preferred.

### Platform Implementations
Nvidia has hardware (GB200) that is using the `components/component/transceiver/state/serial-no` and `components/component/transceiver/state/vendor-part` instead of `components/component/state/serial-no` and `components/component/state/part-no`. Example:

```
openconfig/components/component/sw11/transceiver/state/serial-no, MT2503TDN3E6A
openconfig/components/component/sw11/transceiver/state/vendor-part, 980-9IAM2-00X001
```

Arista also has hardware (DCS-7808-CH) that uses `openconfig/components/component/transceiver/state/vendor-part` and `openconfig/components/component/transceiver/state/serial-no`. Note that this model of Arista is populating both serial-no leaves. Example:

```
openconfig/components/component/Ethernet4/1/state/serial-no, V8O25120026-B
openconfig/components/component/Ethernet4/1/transceiver/state/serial-no, V8O25120026-B
openconfig/components/component/Ethernet4/1/transceiver/state/vendor-part, LDO-080-DZ-GO1
```