### PR TITLE
Adding a host-certificate string to allow clients to authenticate the host.

### DIFF
--- a/release/models/system/openconfig-system-terminal.yang
+++ b/release/models/system/openconfig-system-terminal.yang
@@ -27,7 +27,7 @@ module openconfig-system-terminal {
   revision "2025-11-10" {
     description
       "Add a host-certificate leaf.";
-    reference "0.3.2";
+    reference "0.4.0";
   }
 
   revision "2018-11-21" {


### PR DESCRIPTION
SSH host certificates are digital documents that verify the identity of an SSH server to a client. They are signed by a trusted Certificate Authority (CA) and include information like the server's public key, its hostname, and an expiration date. This allows clients to securely connect to SSH servers without needing to rely on static host keys, streamlining authentication and enhancing security. 