### PR TITLE
Fix typo in openconfig-relay-agent.yang

### DIFF
--- a/release/models/relay-agent/openconfig-relay-agent.yang
+++ b/release/models/relay-agent/openconfig-relay-agent.yang
@@ -594,10 +594,10 @@ module openconfig-relay-agent {
         by the relay agent";
     }
 
-    leaf dhcpv6-adverstise-sent {
+    leaf dhcpv6-advertise-sent {
       type yang:counter64;
       description
-        "Number of DHCPv6 adverstise messages sent to clients by
+        "Number of DHCPv6 advertise messages sent to clients by
         the relay agent";
     }
 


### PR DESCRIPTION
### Change Scope

* DHCPv6 advertise message is spelled incorrectly; correct it.
* The change won't be backward compatible, i.e., the incorrectly
    spelled leaf won't be available further.
