### PR TITLE
Reset initial version of openconfig-system-bootz to 0.1.0

### DIFF
--- a/release/models/system/openconfig-system-bootz.yang
+++ b/release/models/system/openconfig-system-bootz.yang
@@ -19,14 +19,14 @@ module openconfig-system-bootz {
     service running on a network device.";
 
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "0.1.0";
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
-  revision "2023-06-16" {
+  revision "2025-09-03" {
     description
-      "Creation of bootz state paths needed for the service.";
-    reference "1.0.0";
+      "Initial version";
+    reference "0.1.0";
   }
 
   grouping bootz-service-structural {


### PR DESCRIPTION
  * (M) release/models/system/openconfig-system-bootz.yang
    - Reset initial version from 1.0.0 to 0.1.0

### Change Scope

Initial model publish of openconfig-system-bootz was published with 1.0.0 which
conflicts with standard OC publish policy.  All initial versions are to be
0.1.0 to accomodate the possible backwards-incompatible iterations < 1.0.0.

Slightly obscure case that should have been caught in initial review thus we
are not versioning backwards in revision statements but rather resetting the
initial publish version and adjusting the date.

### Platform Implementations

N/A: Version reset for implementors to handle
