### PR TITLE
Update .spec.yml to include GNSI documentation

### DIFF
--- a/release/models/gnsi/.spec.yml
+++ b/release/models/gnsi/.spec.yml
@@ -1,4 +1,11 @@
 - name: openconfig-system-gnsi
+  docs:
+    - yang/gnsi/openconfig-gnsi.yang
+    - yang/gnsi/openconfig-gnsi-acctz.yang
+    - yang/gnsi/openconfig-gnsi-authz.yang
+    - yang/gnsi/openconfig-gnsi-certz.yang
+    - yang/gnsi/openconfig-gnsi-credentialz.yang
+    - yang/gnsi/openconfig-gnsi-pathz.yang
   build:
     - yang/system/openconfig-system.yang
     - yang/gnsi/openconfig-gnsi.yang


### PR DESCRIPTION
This will cause auto documentation generation to appear at https://openconfig.net/projects/models/