### PR TITLE
Mark /system/alarms list entries as atomic

### DIFF
--- a/release/models/system/openconfig-alarms.yang
+++ b/release/models/system/openconfig-alarms.yang
@@ -42,7 +42,13 @@ module openconfig-alarms {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.3.2";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2025-11-18" {
+    description
+      "Mark alarm list entries as telemetry-atomic";
+    reference "0.4.0";
+  }
 
   revision "2019-07-09" {
     description
@@ -176,6 +182,7 @@ module openconfig-alarms {
       config false;
 
       list alarm {
+        oc-ext:telemetry-atomic;
         key "id";
         description
           "List of alarms, keyed by a unique id";


### PR DESCRIPTION
  * (M) release/models/system/openconfig-alarms.yang
    - Add telemetry-atomic to alarm list
    - Increment version to 0.4.0

### Change Scope

For reference, the current `/system/alarms` subtree:

```
module: openconfig-system
  +--rw system
     +--ro alarms
        +--ro alarm* [id]
           +--ro id        -> ../state/id
           +--ro config
           +--ro state
              +--ro id?             string
              +--ro resource?       string
              +--ro text?           string
              +--ro time-created?   oc-types:timeticks64
              +--ro severity?       identityref
              +--ro type-id?        union
```

This PR does not propose any structural or type changes but rather introduces
the `oc-ext:telemetry-atomic` annotation to the `alarm` list structure to align
w/ current expectations and implementations.

### Platform Implementations

* Juniper JUNOS/EVO: Current behavior
