### PR TITLE
Add rib-has-route condition to openconfig-routing-policy

### DIFF
--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -665,6 +665,55 @@ module openconfig-routing-policy {
     }
   }
 
+  grouping rib-has-route-condition-config {
+    description
+      "Configuration data for rib-has-route conditions";
+
+    leaf prefix-set {
+        type leafref {
+          path "../../../../../../../../defined-sets/" +
+            "prefix-sets/prefix-set/config/name";
+        }
+        description "References a defined prefix set";
+      }
+      uses match-set-options-restricted-group;
+  }
+
+
+  grouping rib-has-route-condition-state {
+    description
+      "Operational state data for rib-has-route conditions";
+  }
+
+  grouping rib-has-route-condition-top {
+    description
+      "Top-level grouping for rib-has-route conditions";
+
+    container match-rib-has-route {
+      description
+        "Match a referenced prefix-set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for a rib-has-route condition";
+
+        uses rib-has-route-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for a rib-has-route condition";
+
+        uses rib-has-route-condition-config;
+        uses rib-has-route-condition-state;
+      }
+    }
+  }
+
   grouping neighbor-set-condition-config {
     description
       "Configuration data for neighbor-set conditions";
@@ -774,6 +823,7 @@ module openconfig-routing-policy {
 
     uses match-interface-condition-top;
     uses prefix-set-condition-top;
+    uses rib-has-route-condition-top;
     uses neighbor-set-condition-top;
     uses tag-set-condition-top;
 

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -768,6 +768,55 @@ module openconfig-routing-policy {
     }
   }
 
+  grouping rib-has-route-condition-config {
+    description
+      "Configuration data for rib-has-route conditions";
+
+    leaf prefix-set {
+        type leafref {
+          path "../../../../../../../../defined-sets/" +
+            "prefix-sets/prefix-set/config/name";
+        }
+        description "References a defined prefix set";
+      }
+      uses match-set-options-restricted-group;
+  }
+
+
+  grouping rib-has-route-condition-state {
+    description
+      "Operational state data for rib-has-route conditions";
+  }
+
+  grouping rib-has-route-condition-top {
+    description
+      "Top-level grouping for rib-has-route conditions";
+
+    container match-rib-has-route {
+      description
+        "Match a referenced prefix-set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for a rib-has-route condition";
+
+        uses rib-has-route-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for a rib-has-route condition";
+
+        uses rib-has-route-condition-config;
+        uses rib-has-route-condition-state;
+      }
+    }
+  }
+
   grouping generic-conditions {
     description "Condition statement definitions for checking
     membership in a generic defined set";
@@ -776,7 +825,7 @@ module openconfig-routing-policy {
     uses prefix-set-condition-top;
     uses neighbor-set-condition-top;
     uses tag-set-condition-top;
-
+    uses rib-has-route-condition-top;
   }
 
   grouping generic-actions {

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -768,55 +768,6 @@ module openconfig-routing-policy {
     }
   }
 
-  grouping rib-has-route-condition-config {
-    description
-      "Configuration data for rib-has-route conditions";
-
-    leaf prefix-set {
-        type leafref {
-          path "../../../../../../../../defined-sets/" +
-            "prefix-sets/prefix-set/config/name";
-        }
-        description "References a defined prefix set";
-      }
-      uses match-set-options-restricted-group;
-  }
-
-
-  grouping rib-has-route-condition-state {
-    description
-      "Operational state data for rib-has-route conditions";
-  }
-
-  grouping rib-has-route-condition-top {
-    description
-      "Top-level grouping for rib-has-route conditions";
-
-    container match-rib-has-route {
-      description
-        "Match a referenced prefix-set according to the logic
-        defined in the match-set-options leaf";
-
-      container config {
-        description
-          "Configuration data for a rib-has-route condition";
-
-        uses rib-has-route-condition-config;
-      }
-
-      container state {
-
-        config false;
-
-        description
-          "Operational state data for a rib-has-route condition";
-
-        uses rib-has-route-condition-config;
-        uses rib-has-route-condition-state;
-      }
-    }
-  }
-
   grouping generic-conditions {
     description "Condition statement definitions for checking
     membership in a generic defined set";
@@ -825,7 +776,7 @@ module openconfig-routing-policy {
     uses prefix-set-condition-top;
     uses neighbor-set-condition-top;
     uses tag-set-condition-top;
-    uses rib-has-route-condition-top;
+
   }
 
   grouping generic-actions {


### PR DESCRIPTION
## Add rib-has-route condition to openconfig-routing-policy

### Change Scope

* Add support for the "rib-has-route" route-policy condition which will check if a route exists in the routing-table. Multiple vendors support this capability which is used for conditional route-advertisements, i.e. the route-policy condition checks if a certain prefix A exists in the routing table, and if so then advertises another prefix B or a default-route.


### Platform Implementations


 * Cisco IOS-XR - rib-has-route

 https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/cumulative/command/reference/b-routing-cr-cisco8000/m-rpl-commands-1.html#wp4036312080
```
prefix-set PREFIX-TO-TRACK                                                                                                    
  10.10.10.0/24                                                                                                               
end-set                                                                                                                       
! 
route-policy CONDITIONAL-ADVERTISEMENT
  if rib-has-route in PREFIX-TO-TRACK then
    done
  endif
  drop
end-policy
```
 * Arista EOS - dynamic prefix-lists
https://www.arista.com/en/support/toi/eos-4-21-0f/14072-bgp-conditional-route-inject-routing-protocol-mode-rib
```
dynamic prefix-list DPL
  match-map PREFIX-TO-CHECK
  prefix-list ipv4 ADV-THIS-PREFIX
!
route-map PREFIX-TO-CHECK permit 10
  match ip address prefix-list PREFIX-TO-TRACK
!
ip prefix-list PREFIX-TO-TRACK seq 10 permit 10.10.10.0/24

ip prefix-list ADV-THIS-PREFIX seq 10 permit 10.20.20.0/24
!
route-map OUTBOUND-POLICY permit 10
  match ip address dynamic prefix-list DPL
```
 * Juniper JUNOS - if-route-exists
https://www.juniper.net/documentation/us/en/software/junos/routing-policy/bgp/topics/example/conditional-prefix-installing-configuring.html
```
policy-options {
    prefix-list ADV-THIS-PREFIX {
        10.20.20.0/24;
    }
    policy-statement OUTBOUND-POLICY {
        term CONDITIONAL-ADVERTISE {
            from {
                prefix-list ADV-THIS-PREFIX;
                condition CHECK-TRACK-ROUTE;
            }                           
            then accept;
        }
    }
    condition CHECK-TRACK-ROUTE {
        if-route-exists {
            10.10.10.0/24;
            table inet.0;
        }
    }
}
```

### Tree View

```diff
 module: openconfig-routing-policy
               +--rw statement* [name]
                  +--rw name          -> ../config/name
                  +--rw config
                  |  +--rw name?   string
                  +--ro state
                  |  +--ro name?   string
                  +--rw conditions
                  |  +--rw config
                  |  |  +--rw call-policy?           -> ../../../../../../../policy-definitions/policy-definition/name
                  |  |  +--rw install-protocol-eq?   identityref
                  |  +--ro state
                  |  |  +--ro call-policy?           -> ../../../../../../../policy-definitions/policy-definition/name
                  |  |  +--ro install-protocol-eq?   identityref
                  |  +--rw match-interface
                  |  |  +--rw config
                  |  |  +--ro state
                  |  +--rw match-prefix-set
                  |  |  +--rw config
                  |  |  |  +--rw prefix-set?          -> ../../../../../../../../defined-sets/prefix-sets/prefix-set/config/name
                  |  |  |  +--rw match-set-options?   oc-pol-types:match-set-options-restricted-type
                  |  |  +--ro state
                  |  |     +--ro prefix-set?          -> ../../../../../../../../defined-sets/prefix-sets/prefix-set/config/name
                  |  |     +--ro match-set-options?   oc-pol-types:match-set-options-restricted-type
+                 |  +--rw match-rib-has-route
+                 |  |  +--rw config
+                 |  |  |  +--rw prefix-set?          -> ../../../../../../../../defined-sets/prefix-sets/prefix-set/config/name
+                 |  |  |  +--rw match-set-options?   oc-pol-types:match-set-options-restricted-type
+                 |  |  +--ro state
+                 |  |     +--ro prefix-set?          -> ../../../../../../../../defined-sets/prefix-sets/prefix-set/config/name
+                 |  |     +--ro match-set-options?   oc-pol-types:match-set-options-restricted-type
                  |  +--rw match-neighbor-set
                  |  |  +--rw config
                  |  |  |  +--rw neighbor-set?        -> ../../../../../../../../defined-sets/neighbor-sets/neighbor-set/name
                  |  |  |  +--rw match-set-options?   oc-pol-types:match-set-options-restricted-type
                  |  |  +--ro state
                  |  |     +--ro neighbor-set?        -> ../../../../../../../../defined-sets/neighbor-sets/neighbor-set/name
                  |  |     +--ro match-set-options?   oc-pol-types:match-set-options-restricted-type
                  |  +--rw match-tag-set
                  |     +--rw config
                  |     |  +--rw tag-set?             -> ../../../../../../../../defined-sets/tag-sets/tag-set/name
                  |     |  +--rw match-set-options?   oc-pol-types:match-set-options-restricted-type
                  |     +--ro state
                  |        +--ro tag-set?             -> ../../../../../../../../defined-sets/tag-sets/tag-set/name
                  |        +--ro match-set-options?   oc-pol-types:match-set-options-restricted-type
                  +--rw actions
                     +--rw config
                     |  +--rw policy-result?   policy-result-type
                     +--ro state
                     |  +--ro policy-result?   policy-result-type
                     +--rw set-tag
                        +--rw config
```
