### PR TITLE
Revert datatypes for QoS percentage leafs

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,14 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2026-01-16" {
+    description
+      "Revert percentage types to uint64 with appropriate
+      scoping/units";
+    reference "2.0.0";
+  }
 
   revision "2025-12-16" {
     description

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,14 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2026-01-16" {
+    description
+      "Revert percentage types to uint64 with appropriate
+      scoping/units";
+    reference "2.0.0";
+  }
 
   revision "2025-12-16" {
     description

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,14 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2026-01-16" {
+    description
+      "Revert percentage types to uint64 with appropriate
+      scoping/units";
+    reference "2.0.0";
+  }
 
   revision "2025-12-16" {
     description
@@ -366,7 +373,10 @@ revision "2023-07-26" {
     }
 
     leaf min-threshold-percent {
-      type oc-types:percentage;
+      type uint64 {
+        range "0..100";
+      }
+      units percentage;
       description
         "The mininum threshold parameter for a RED-managed queue in percent.
         When the average queue length is less than minth, all packets are
@@ -375,7 +385,10 @@ revision "2023-07-26" {
     }
 
     leaf max-threshold-percent {
-      type oc-types:percentage;
+      type uint64 {
+        range "0..100";
+      }
+      units percentage;
       description
         "The maximum threshold parameter for a RED-managed queue in percent.
         When the average queue length exceeds the maxth value, all packets

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,14 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2026-01-16" {
+    description
+      "Revert percentage types to uint64 with appropriate
+      scoping/units";
+    reference "2.0.0";
+  }
 
   revision "2025-12-16" {
     description


### PR DESCRIPTION
### Change Scope

* Implement changes described at #1414.  That PR has some conflicts which I've resolved here in this PR.  

Reverting prior commit https://github.com/openconfig/public/pull/1382 as this
brought in a change from uint64 to uint8 which as been flagged as an
undesirable mostly athstetic breaking change (especially when it comes to an
encoding such as JSON_IETF)

While the type is being changed back to a uint64, we are still proposing
scoping and proper units declaration here.

This was to address issue https://github.com/openconfig/public/issues/1381### Platform Implementations

### Tree View

```diff
 module: openconfig-qos
   +--rw qos
      +--rw config
      +--ro state
      +--rw interfaces
      |  +--rw interface* [interface-id]
      |     +--rw interface-id     -> ../config/interface-id
      |     +--rw config
      |     |  +--rw interface-id?   string
      |     +--ro state
      |     |  +--ro interface-id?   string
      |     +--rw interface-ref
      |     |  +--rw config
      |     |  |  +--rw interface?      -> /oc-if:interfaces/interface/name
      |     |  |  +--rw subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
      |     |  +--ro state
      |     |     +--ro interface?      -> /oc-if:interfaces/interface/name
      |     |     +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
      |     +--rw input
      |     |  +--rw config
      |     |  |  +--rw buffer-allocation-profile?             -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  |  +--rw multicast-buffer-allocation-profile?   -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  |  +--rw unicast-buffer-allocation-profile?     -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  +--ro state
      |     |  |  +--ro buffer-allocation-profile?             -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  |  +--ro multicast-buffer-allocation-profile?   -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  |  +--ro unicast-buffer-allocation-profile?     -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |     |  +--rw classifiers
      |     |  |  +--rw classifier* [type]
      |     |  |     +--rw type      -> ../config/type
      |     |  |     +--rw config
      |     |  |     |  +--rw name?   -> ../../../../../../../classifiers/classifier/config/name
      |     |  |     |  +--rw type?   enumeration
      |     |  |     +--ro state
      |     |  |     |  +--ro name?   -> ../../../../../../../classifiers/classifier/config/name
      |     |  |     |  +--ro type?   enumeration
      |     |  |     +--rw terms
      |     |  |        +--ro term* [id]
      |     |  |           +--ro id       -> ../state/id
      |     |  |           +--ro state
      |     |  |              +--ro id?                -> ../../../../../../../../../classifiers/classifier[name=current()/../../../../config/name]/terms/term/config/id
      |     |  |              +--ro matched-packets?   oc-yang:counter64
      |     |  |              +--ro matched-octets?    oc-yang:counter64
      |     |  +--rw queues
      |     |  |  +--rw queue* [name]
      |     |  |     +--rw name      -> ../config/name
      |     |  |     +--rw config
      |     |  |     |  +--rw name?                       string
      |     |  |     |  +--rw queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |     |  |     +--ro state
      |     |  |        +--ro name?                       string
      |     |  |        +--ro queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |     |  |        +--ro max-queue-len?              oc-yang:counter64
      |     |  |        +--ro avg-queue-len?              oc-yang:counter64
      |     |  |        +--ro transmit-pkts?              oc-yang:counter64
      |     |  |        +--ro transmit-octets?            oc-yang:counter64
      |     |  |        +--ro dropped-pkts?               oc-yang:counter64
      |     |  |        +--ro dropped-octets?             oc-yang:counter64
      |     |  |        +--ro ecn-marked-pkts?            oc-yang:counter64
      |     |  |        +--ro ecn-marked-octets?          oc-yang:counter64
      |     |  |        +--ro ecn-selected-pkts?          oc-yang:counter64
      |     |  |        +--ro ecn-selected-octets?        oc-yang:counter64
      |     |  +--rw scheduler-policy
      |     |  |  +--rw config
      |     |  |  |  +--rw name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |     |  |  +--ro state
      |     |  |  |  +--ro name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |     |  |  +--ro schedulers
      |     |  |     +--ro scheduler* [sequence]
      |     |  |        +--ro sequence    -> ../state/sequence
      |     |  |        +--ro state
      |     |  |           +--ro sequence?            -> ../../../../../../../../scheduler-policies/scheduler-policy[name=current()/../../../../config/name]/schedulers/scheduler/config/sequence
      |     |  |           +--ro conforming-pkts?     oc-yang:counter64
      |     |  |           +--ro conforming-octets?   oc-yang:counter64
      |     |  |           +--ro exceeding-pkts?      oc-yang:counter64
      |     |  |           +--ro exceeding-octets?    oc-yang:counter64
      |     |  |           +--ro violating-pkts?      oc-yang:counter64
      |     |  |           +--ro violating-octets?    oc-yang:counter64
      |     |  +--rw virtual-output-queues
      |     |     +--rw voq-interface* [name]
      |     |        +--rw name      -> ../config/name
      |     |        +--rw config
      |     |        |  +--rw name?   string
      |     |        +--ro state
      |     |        |  +--ro name?   string
      |     |        +--rw queues
      |     |           +--rw queue* [name]
      |     |              +--rw name      -> ../config/name
      |     |              +--rw config
      |     |              |  +--rw name?   string
      |     |              +--ro state
      |     |                 +--ro name?                  string
      |     |                 +--ro max-queue-len?         oc-yang:counter64
      |     |                 +--ro avg-queue-len?         oc-yang:counter64
      |     |                 +--ro transmit-pkts?         oc-yang:counter64
      |     |                 +--ro transmit-octets?       oc-yang:counter64
      |     |                 +--ro dropped-pkts?          oc-yang:counter64
      |     |                 +--ro dropped-octets?        oc-yang:counter64
      |     |                 +--ro ecn-marked-pkts?       oc-yang:counter64
      |     |                 +--ro ecn-marked-octets?     oc-yang:counter64
      |     |                 +--ro ecn-selected-pkts?     oc-yang:counter64
      |     |                 +--ro ecn-selected-octets?   oc-yang:counter64
      |     +--rw output
      |        +--rw config
      |        |  +--rw buffer-allocation-profile?             -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        |  +--rw multicast-buffer-allocation-profile?   -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        |  +--rw unicast-buffer-allocation-profile?     -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        +--ro state
      |        |  +--ro buffer-allocation-profile?             -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        |  +--ro multicast-buffer-allocation-profile?   -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        |  +--ro unicast-buffer-allocation-profile?     -> ../../../../../buffer-allocation-profiles/buffer-allocation-profile/config/name
      |        +--rw classifiers
      |        |  +--rw classifier* [type]
      |        |     +--rw type      -> ../config/type
      |        |     +--rw config
      |        |     |  +--rw name?   -> ../../../../../../../classifiers/classifier/config/name
      |        |     |  +--rw type?   enumeration
      |        |     +--ro state
      |        |     |  +--ro name?   -> ../../../../../../../classifiers/classifier/config/name
      |        |     |  +--ro type?   enumeration
      |        |     +--rw terms
      |        |        +--ro term* [id]
      |        |           +--ro id       -> ../state/id
      |        |           +--ro state
      |        |              +--ro id?                -> ../../../../../../../../../classifiers/classifier[name=current()/../../../../config/name]/terms/term/config/id
      |        |              +--ro matched-packets?   oc-yang:counter64
      |        |              +--ro matched-octets?    oc-yang:counter64
      |        +--rw queues
      |        |  +--rw queue* [name]
      |        |     +--rw name      -> ../config/name
      |        |     +--rw config
      |        |     |  +--rw name?                       string
      |        |     |  +--rw queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |        |     +--ro state
      |        |        +--ro name?                       string
      |        |        +--ro queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |        |        +--ro max-queue-len?              oc-yang:counter64
      |        |        +--ro avg-queue-len?              oc-yang:counter64
      |        |        +--ro transmit-pkts?              oc-yang:counter64
      |        |        +--ro transmit-octets?            oc-yang:counter64
      |        |        +--ro dropped-pkts?               oc-yang:counter64
      |        |        +--ro dropped-octets?             oc-yang:counter64
      |        |        +--ro ecn-marked-pkts?            oc-yang:counter64
      |        |        +--ro ecn-marked-octets?          oc-yang:counter64
      |        |        +--ro ecn-selected-pkts?          oc-yang:counter64
      |        |        +--ro ecn-selected-octets?        oc-yang:counter64
      |        +--rw scheduler-policy
      |           +--rw config
      |           |  +--rw name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |           +--ro state
      |           |  +--ro name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |           +--ro schedulers
      |              +--ro scheduler* [sequence]
      |                 +--ro sequence    -> ../state/sequence
      |                 +--ro state
      |                    +--ro sequence?            -> ../../../../../../../../scheduler-policies/scheduler-policy[name=current()/../../../../config/name]/schedulers/scheduler/config/sequence
      |                    +--ro conforming-pkts?     oc-yang:counter64
      |                    +--ro conforming-octets?   oc-yang:counter64
      |                    +--ro exceeding-pkts?      oc-yang:counter64
      |                    +--ro exceeding-octets?    oc-yang:counter64
      |                    +--ro violating-pkts?      oc-yang:counter64
      |                    +--ro violating-octets?    oc-yang:counter64
      +--rw classifiers
      |  +--rw classifier* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     |  +--rw type?   enumeration
      |     +--ro state
      |     |  +--ro name?   string
      |     |  +--ro type?   enumeration
      |     +--rw terms
      |        +--rw term* [id]
      |           +--rw id            -> ../config/id
      |           +--rw config
      |           |  +--rw id?   string
      |           +--ro state
      |           |  +--ro id?   string
      |           +--rw conditions
      |           |  +--rw l2
      |           |  |  +--rw config
      |           |  |  |  +--rw source-mac?             oc-yang:mac-address
      |           |  |  |  +--rw source-mac-mask?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac-mask?   oc-yang:mac-address
      |           |  |  |  +--rw ethertype?              oc-pkt-match-types:ethertype-type
      |           |  |  +--ro state
      |           |  |     +--ro source-mac?             oc-yang:mac-address
      |           |  |     +--ro source-mac-mask?        oc-yang:mac-address
      |           |  |     +--ro destination-mac?        oc-yang:mac-address
      |           |  |     +--ro destination-mac-mask?   oc-yang:mac-address
      |           |  |     +--ro ethertype?              oc-pkt-match-types:ethertype-type
      |           |  +--rw ipv4
      |           |  |  +--rw config
      |           |  |  |  +--rw source-address?                   oc-inet:ipv4-prefix
      |           |  |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--rw destination-address?              oc-inet:ipv4-prefix
      |           |  |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--rw fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
      |           |  |  |  +--rw dscp?                             oc-inet:dscp
      |           |  |  |  +--rw dscp-set*                         oc-inet:dscp
      |           |  |  |  +--rw length?                           uint16
      |           |  |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--rw hop-limit?                        uint8
      |           |  |  +--ro state
      |           |  |  |  +--ro source-address?                   oc-inet:ipv4-prefix
      |           |  |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--ro destination-address?              oc-inet:ipv4-prefix
      |           |  |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--ro fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
      |           |  |  |  +--ro dscp?                             oc-inet:dscp
      |           |  |  |  +--ro dscp-set*                         oc-inet:dscp
      |           |  |  |  +--ro length?                           uint16
      |           |  |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--ro hop-limit?                        uint8
      |           |  |  +--rw icmpv4
      |           |  |     +--rw config
      |           |  |     |  +--rw type?   identityref
      |           |  |     |  +--rw code?   identityref
      |           |  |     +--ro state
      |           |  |        +--ro type?   identityref
      |           |  |        +--ro code?   identityref
      |           |  +--rw ipv6
      |           |  |  +--rw config
      |           |  |  |  +--rw source-address?                   oc-inet:ipv6-prefix
      |           |  |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
      |           |  |  |  +--rw source-flow-label?                oc-inet:ipv6-flow-label
      |           |  |  |  +--rw destination-address?              oc-inet:ipv6-prefix
      |           |  |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
      |           |  |  |  +--rw destination-flow-label?           oc-inet:ipv6-flow-label
      |           |  |  |  +--rw dscp?                             oc-inet:dscp
      |           |  |  |  +--rw dscp-set*                         oc-inet:dscp
      |           |  |  |  +--rw length?                           uint16
      |           |  |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--rw hop-limit?                        uint8
      |           |  |  +--ro state
      |           |  |  |  +--ro source-address?                   oc-inet:ipv6-prefix
      |           |  |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
      |           |  |  |  +--ro source-flow-label?                oc-inet:ipv6-flow-label
      |           |  |  |  +--ro destination-address?              oc-inet:ipv6-prefix
      |           |  |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
      |           |  |  |  +--ro destination-flow-label?           oc-inet:ipv6-flow-label
      |           |  |  |  +--ro dscp?                             oc-inet:dscp
      |           |  |  |  +--ro dscp-set*                         oc-inet:dscp
      |           |  |  |  +--ro length?                           uint16
      |           |  |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--ro hop-limit?                        uint8
      |           |  |  +--rw icmpv6
      |           |  |     +--rw config
      |           |  |     |  +--rw type?   identityref
      |           |  |     |  +--rw code?   identityref
      |           |  |     +--ro state
      |           |  |        +--ro type?   identityref
      |           |  |        +--ro code?   identityref
      |           |  +--rw transport
      |           |  |  +--rw config
      |           |  |  |  +--rw source-port?                  oc-pkt-match-types:port-num-range
      |           |  |  |  +--rw source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |  |  +--rw destination-port?             oc-pkt-match-types:port-num-range
      |           |  |  |  +--rw destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |  |  +--rw detail-mode?                  enumeration
      |           |  |  |  +--rw explicit-detail-match-mode?   enumeration
      |           |  |  |  +--rw explicit-tcp-flags*           identityref
      |           |  |  |  +--rw builtin-detail?               enumeration
      |           |  |  +--ro state
      |           |  |     +--ro source-port?                  oc-pkt-match-types:port-num-range
      |           |  |     +--ro source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |     +--ro destination-port?             oc-pkt-match-types:port-num-range
      |           |  |     +--ro destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |     +--ro detail-mode?                  enumeration
      |           |  |     +--ro explicit-detail-match-mode?   enumeration
      |           |  |     +--ro explicit-tcp-flags*           identityref
      |           |  |     +--ro builtin-detail?               enumeration
      |           |  +--rw mpls
      |           |     +--rw config
      |           |     |  +--rw traffic-class?       oc-mpls:mpls-tc
      |           |     |  +--rw start-label-value?   oc-mpls:mpls-label
      |           |     |  +--rw end-label-value?     oc-mpls:mpls-label
      |           |     |  +--rw ttl-value?           uint8
      |           |     +--ro state
      |           |        +--ro traffic-class?       oc-mpls:mpls-tc
      |           |        +--ro start-label-value?   oc-mpls:mpls-label
      |           |        +--ro end-label-value?     oc-mpls:mpls-label
      |           |        +--ro ttl-value?           uint8
      |           +--rw actions
      |              +--rw config
      |              |  +--rw target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--ro state
      |              |  +--ro target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--rw remark
      |                 +--rw config
      |                 |  +--rw set-dscp?      uint8
      |                 |  +--rw set-dot1p?     uint8
      |                 |  +--rw set-mpls-tc?   uint8
      |                 +--ro state
      |                    +--ro set-dscp?      uint8
      |                    +--ro set-dot1p?     uint8
      |                    +--ro set-mpls-tc?   uint8
      +--rw forwarding-groups
      |  +--rw forwarding-group* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?                     string
      |     |  +--rw fabric-priority?          uint8
      |     |  +--rw output-queue?             -> ../../../../queues/queue/config/name
      |     |  +--rw unicast-output-queue?     -> ../../../../queues/queue/config/name
      |     |  +--rw multicast-output-queue?   -> ../../../../queues/queue/config/name
      |     +--ro state
      |        +--ro name?                     string
      |        +--ro fabric-priority?          uint8
      |        +--ro output-queue?             -> ../../../../queues/queue/config/name
      |        +--ro unicast-output-queue?     -> ../../../../queues/queue/config/name
      |        +--ro multicast-output-queue?   -> ../../../../queues/queue/config/name
      +--rw queues
      |  +--rw queue* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?       string
      |     |  +--rw queue-id?   uint8
      |     +--ro state
      |        +--ro name?       string
      |        +--ro queue-id?   uint8
      +--rw scheduler-policies
      |  +--rw scheduler-policy* [name]
      |     +--rw name          -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     +--ro state
      |     |  +--ro name?   string
      |     +--rw schedulers
      |        +--rw scheduler* [sequence]
      |           +--rw sequence                -> ../config/sequence
      |           +--rw config
      |           |  +--rw sequence?   uint32
      |           |  +--rw type?       identityref
      |           |  +--rw priority?   enumeration
      |           +--ro state
      |           |  +--ro sequence?   uint32
      |           |  +--ro type?       identityref
      |           |  +--ro priority?   enumeration
      |           +--rw inputs
      |           |  +--rw input* [id]
      |           |     +--rw id        -> ../config/id
      |           |     +--rw config
      |           |     |  +--rw id?           string
      |           |     |  +--rw input-type?   enumeration
      |           |     |  +--rw queue?        -> ../../../../../../../../queues/queue/name
      |           |     |  +--rw weight?       uint64
      |           |     +--ro state
      |           |        +--ro id?           string
      |           |        +--ro input-type?   enumeration
      |           |        +--ro queue?        -> ../../../../../../../../queues/queue/name
      |           |        +--ro weight?       uint64
      |           +--rw output
      |           |  +--rw config
      |           |  |  +--rw output-type?        enumeration
      |           |  |  +--rw child-scheduler?    -> ../../../../../../../scheduler-policies/scheduler-policy/config/name
      |           |  |  +--rw output-fwd-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |           |  +--ro state
      |           |     +--ro output-type?        enumeration
      |           |     +--ro child-scheduler?    -> ../../../../../../../scheduler-policies/scheduler-policy/config/name
      |           |     +--ro output-fwd-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |           +--rw one-rate-two-color
      |           |  +--rw config
      |           |  |  +--rw cir?                       uint64
      |           |  |  +--rw cir-pct?                   oc-types:percentage
      |           |  |  +--rw cir-pct-remaining?         oc-types:percentage
      |           |  |  +--rw bc?                        uint32
      |           |  |  +--rw queuing-behavior?          oc-qos-types:queue-behavior
      |           |  |  +--rw max-queue-depth-bytes?     uint32
      |           |  |  +--rw max-queue-depth-packets?   uint32
      |           |  |  +--rw max-queue-depth-percent?   oc-types:percentage
      |           |  +--ro state
      |           |  |  +--ro cir?                       uint64
      |           |  |  +--ro cir-pct?                   oc-types:percentage
      |           |  |  +--ro cir-pct-remaining?         oc-types:percentage
      |           |  |  +--ro bc?                        uint32
      |           |  |  +--ro queuing-behavior?          oc-qos-types:queue-behavior
      |           |  |  +--ro max-queue-depth-bytes?     uint32
      |           |  |  +--ro max-queue-depth-packets?   uint32
      |           |  |  +--ro max-queue-depth-percent?   oc-types:percentage
      |           |  +--rw conform-action
      |           |  |  +--rw config
      |           |  |  |  +--rw set-dscp?      uint8
      |           |  |  |  +--rw set-dot1p?     uint8
      |           |  |  |  +--rw set-mpls-tc?   uint8
      |           |  |  +--ro state
      |           |  |     +--ro set-dscp?      uint8
      |           |  |     +--ro set-dot1p?     uint8
      |           |  |     +--ro set-mpls-tc?   uint8
      |           |  +--rw exceed-action
      |           |     +--rw config
      |           |     |  +--rw set-dscp?      uint8
      |           |     |  +--rw set-dot1p?     uint8
      |           |     |  +--rw set-mpls-tc?   uint8
      |           |     |  +--rw drop?          boolean
      |           |     +--ro state
      |           |        +--ro set-dscp?      uint8
      |           |        +--ro set-dot1p?     uint8
      |           |        +--ro set-mpls-tc?   uint8
      |           |        +--ro drop?          boolean
      |           +--rw two-rate-three-color
      |              +--rw config
      |              |  +--rw cir?                 uint64
      |              |  +--rw cir-pct?             oc-types:percentage
      |              |  +--rw cir-pct-remaining?   oc-types:percentage
      |              |  +--rw pir?                 uint64
      |              |  +--rw pir-pct?             oc-types:percentage
      |              |  +--rw pir-pct-remaining?   oc-types:percentage
      |              |  +--rw bc?                  uint32
      |              |  +--rw be?                  uint32
      |              +--ro state
      |              |  +--ro cir?                 uint64
      |              |  +--ro cir-pct?             oc-types:percentage
      |              |  +--ro cir-pct-remaining?   oc-types:percentage
      |              |  +--ro pir?                 uint64
      |              |  +--ro pir-pct?             oc-types:percentage
      |              |  +--ro pir-pct-remaining?   oc-types:percentage
      |              |  +--ro bc?                  uint32
      |              |  +--ro be?                  uint32
      |              +--rw conform-action
      |              |  +--rw config
      |              |  |  +--rw set-dscp?      uint8
      |              |  |  +--rw set-dot1p?     uint8
      |              |  |  +--rw set-mpls-tc?   uint8
      |              |  +--ro state
      |              |     +--ro set-dscp?      uint8
      |              |     +--ro set-dot1p?     uint8
      |              |     +--ro set-mpls-tc?   uint8
      |              +--rw exceed-action
      |              |  +--rw config
      |              |  |  +--rw set-dscp?      uint8
      |              |  |  +--rw set-dot1p?     uint8
      |              |  |  +--rw set-mpls-tc?   uint8
      |              |  |  +--rw drop?          boolean
      |              |  +--ro state
      |              |     +--ro set-dscp?      uint8
      |              |     +--ro set-dot1p?     uint8
      |              |     +--ro set-mpls-tc?   uint8
      |              |     +--ro drop?          boolean
      |              +--rw violate-action
      |                 +--rw config
      |                 |  +--rw set-dscp?      uint8
      |                 |  +--rw set-dot1p?     uint8
      |                 |  +--rw set-mpls-tc?   uint8
      |                 |  +--rw drop?          boolean
      |                 +--ro state
      |                    +--ro set-dscp?      uint8
      |                    +--ro set-dot1p?     uint8
      |                    +--ro set-mpls-tc?   uint8
      |                    +--ro drop?          boolean
      +--rw buffer-allocation-profiles
      |  +--rw buffer-allocation-profile* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     +--ro state
      |     |  +--ro name?   string
      |     +--rw queues
      |        +--rw queue* [name]
      |           +--rw name      -> ../config/name
      |           +--rw config
      |           |  +--rw name?                                  -> ../../../../../../queues/queue/config/name
      |           |  +--rw dedicated-buffer?                      uint64
      |           |  +--rw dedicated-buffer-temporal?             uint64
      |           |  +--rw use-shared-buffer?                     boolean
      |           |  +--rw shared-buffer-limit-type?              identityref
      |           |  +--rw static-shared-buffer-limit?            uint32
      |           |  +--rw static-shared-buffer-limit-temporal?   uint32
      |           |  +--rw dynamic-limit-scaling-factor?          int32
      |           +--ro state
      |              +--ro name?                                  -> ../../../../../../queues/queue/config/name
      |              +--ro dedicated-buffer?                      uint64
      |              +--ro dedicated-buffer-temporal?             uint64
      |              +--ro use-shared-buffer?                     boolean
      |              +--ro shared-buffer-limit-type?              identityref
      |              +--ro static-shared-buffer-limit?            uint32
      |              +--ro static-shared-buffer-limit-temporal?   uint32
      |              +--ro dynamic-limit-scaling-factor?          int32
      +--rw queue-management-profiles
         +--rw queue-management-profile* [name]
            +--rw name      -> ../config/name
            +--rw config
            |  +--rw name?   string
            +--ro state
            |  +--ro name?   string
            +--rw wred
            |  +--rw uniform
            |     +--rw config
            |     |  +--rw min-threshold?                  uint64
            |     |  +--rw max-threshold?                  uint64
-           |     |  +--rw min-threshold-percent?          oc-types:percentage
-           |     |  +--rw max-threshold-percent?          oc-types:percentage
+           |     |  +--rw min-threshold-percent?          uint64
+           |     |  +--rw max-threshold-percent?          uint64
            |     |  +--rw enable-ecn?                     boolean
            |     |  +--rw drop?                           boolean
            |     |  +--rw weight?                         uint32
            |     |  +--rw max-drop-probability-percent?   oc-types:percentage
            |     +--ro state
            |        +--ro min-threshold?                  uint64
            |        +--ro max-threshold?                  uint64
-           |        +--ro min-threshold-percent?          oc-types:percentage
-           |        +--ro max-threshold-percent?          oc-types:percentage
+           |        +--ro min-threshold-percent?          uint64
+           |        +--ro max-threshold-percent?          uint64
            |        +--ro enable-ecn?                     boolean
            |        +--ro drop?                           boolean
            |        +--ro weight?                         uint32
            |        +--ro max-drop-probability-percent?   oc-types:percentage
            +--rw red
               +--rw uniform
                  +--rw config
                  |  +--rw min-threshold?           uint64
                  |  +--rw max-threshold?           uint64
-                 |  +--rw min-threshold-percent?   oc-types:percentage
-                 |  +--rw max-threshold-percent?   oc-types:percentage
+                 |  +--rw min-threshold-percent?   uint64
+                 |  +--rw max-threshold-percent?   uint64
                  |  +--rw enable-ecn?              boolean
                  |  +--rw drop?                    boolean
                  +--ro state
                     +--ro min-threshold?           uint64
                     +--ro max-threshold?           uint64
-                    +--ro min-threshold-percent?   oc-types:percentage
-                    +--ro max-threshold-percent?   oc-types:percentage
+                    +--ro min-threshold-percent?   uint64
+                    +--ro max-threshold-percent?   uint64
                     +--ro enable-ecn?              boolean
                     +--ro drop?                    boolean
```
