### PR TITLE
Add MACSec interface status and MKA security-policy leaf

### DIFF
--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -240,6 +240,8 @@ revision "2023-06-08" {
     description
       "MKA interface state grouping";
 
+    uses macsec-session-status;
+
     container counters {
       description
         "MKA interface counters";
@@ -299,6 +301,11 @@ revision "2023-06-08" {
         that are accepted. A value of 0 means that frames are accepted only in
         the correct order.";
     }
+  }
+
+  grouping macsec-session-status {
+    description
+      "Media Access Control Security (MACsec) status grouping";
 
     leaf status {
       type enumeration {
@@ -587,6 +594,7 @@ revision "2023-06-08" {
             "Operational state data ";
 
           uses macsec-interface-config;
+          uses macsec-session-status;
 
           container counters {
             description

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -27,7 +27,7 @@ module openconfig-macsec {
     description
       "Add interface status and security-policy leaf with should-secure and
       must-secure enum.";
-    reference "1.3.0"
+    reference "1.3.0";
   }
 
   revision "2025-01-02" {
@@ -691,7 +691,7 @@ revision "2023-06-08" {
             Unencrypted frames will be dropped.";
           }
         }
-      description 
+      description
       "List of options for how to handle unencrypted frames on an interface configured
       to use MACSec.";
     }

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -18,10 +18,17 @@ module openconfig-macsec {
     "This module defines configuration and state data for
      MACsec IEEE Std 802.1AE-2018.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.3.0";
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  revision "2026-01-26" {
+    description
+      "Add interface status and security-policy leaf with should-secure and
+      must-secure enum.";
+    reference "1.3.0"
+  }
 
   revision "2025-01-02" {
     description
@@ -291,6 +298,22 @@ revision "2023-06-08" {
         "MACsec window size, as defined by the number of out-of-order frames
         that are accepted. A value of 0 means that frames are accepted only in
         the correct order.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum ACTIVE {
+          description  "MACSec is operational and encrypting/decrypting frames
+          on the interface.";
+        }
+        enum INACTIVE {
+          description  "MACSec is disabled on the interface.";
+        }
+        enum PENDING {
+          description  "MACSec is enabled, but the secure channel and
+          association are not yet established.";
+        }
+      }
     }
   }
 
@@ -655,6 +678,22 @@ revision "2023-06-08" {
       default "false";
       description
         "Rekey on peer loss";
+    }
+
+    leaf security-policy {
+        type enumeration {
+          enum SHOULD_SECURE {
+            description  "Encrypted and un-encrypted frames will be
+            processed.";
+          }
+          enum MUST_SECURE {
+            description  "Only encrypted frames will be processed.
+            Unencrypted frames will be dropped.";
+          }
+        }
+      description 
+      "List of options for how to handle unencrypted frames on an interface configured
+      to use MACSec.";
     }
 
     leaf use-updated-eth-header {

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -308,6 +308,9 @@ revision "2023-06-08" {
       "Media Access Control Security (MACsec) status grouping";
 
     leaf status {
+      description
+        "Status of MACsec on an interface.";
+
       type enumeration {
         enum ACTIVE {
           description  "MACSec is operational and encrypting/decrypting frames


### PR DESCRIPTION
## Change Scope
* Add a MACSec interface `status` leaf
* Add a MACSec interface MKA session `status` leaf
* Add a MACSec MKA policy `security-policy` leaf with `SHOULD_SECURE` and `MUST_SECURE` options.
* As this change only adds leaves, it is backwards compatible. 

## Platform Implementations

### MACSec MKA `security-policy` `SHOULD_SECURE` and `MUST_SECURE` options.

[Cisco IOSXR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/macsec/b-macsec-encryption-config-cisco8000/fundamentals-of-macsec-encryption.html#configure-macsec)

! Define the Key Chain
key chain MACSEC_KEYS
 key 01
  key-string password123
  cryptographic-algorithm aes-128-cmac
! Create the MACsec Policy
macsec-policy MUST_ENCRYPT_POLICY
 confidentiality-offset 0
 security-policy must-secure (or should-secure)
! Apply to the Interface
interface TenGigE0/0/0/1
 macsec
  service-policy MUST_ENCRYPT_POLICY keychain MACSEC_KEYS
!

[Arista EOS](https://www.arista.com/en/um-eos/eos-data-plane-security#xx1211894)

Arista EOS is “must-secure” by default. Traffic unprotected allow  enables the "should-secure" behavior.
```
mac security
   profile FALLBACK_PROFILE
      key 0abcd... 0 password123
      traffic unprotected allow
!
interface Ethernet1
   mac security profile FALLBACK_PROFILE
```

[Juniper JunOS](https://www.juniper.net/documentation/us/en/software/junos/security-services/topics/task/macsec-configuring-advanced.html)

```
set security macsec connectivity-association CA_NAME mka should-secure
# To enforce "must-secure", simply omit or delete that line: (Junos is “must-secure” by default)
delete security macsec connectivity-association CA_NAME mka should-secure
```


|Policy Type | Cisco IOS-XR | Arista EOS | Juniper Junos |
| -- | -- | -- | --
| must-secure (drop unencrypted) | security-policy must-secure | (Default behavior) | (Default behavior)
| should-secure (allow unencrypted) | security-policy should-secure | traffic unprotected allow | should-secure
| Default State | Must be explicitly defined | Strict (Fail-closed) | Strict (Fail-closed)


### MACSec interface status and interface MKA session status

* Cisco (IOS-XE)
```
show macsec interface <interface-id>
sh mka sessions
```

### Arista (EOS)
```
show mac security interface <interface-id>
show mac security mka sessions interface <interface-id>

```

### Juniper (Junos)
```
show security macsec connections [interface <name>]
show security macsec mka sessions [interface <name>]
```


### Tree View

```diff
 module: openconfig-macsec
   +--rw macsec
      +--rw mka
      |  +--rw policies
      |  |  +--rw policy* [name]
      |  |     +--rw name      -> ../config/name
      |  |     +--rw config
      |  |     |  +--rw name?                          string
      |  |     |  +--rw key-server-priority?           uint8
      |  |     |  +--rw macsec-cipher-suite*           macsec-types:macsec-cipher-suite
      |  |     |  +--rw confidentiality-offset?        macsec-types:confidentiality-offset
      |  |     |  +--rw delay-protection?              boolean
      |  |     |  +--rw include-icv-indicator?         boolean
      |  |     |  +--rw include-sci?                   boolean
      |  |     |  +--rw sak-rekey-interval?            uint32
      |  |     |  +--rw sak-rekey-on-live-peer-loss?   boolean
+     |  |     |  +--rw security-policy?               enumeration
      |  |     |  +--rw use-updated-eth-header?        boolean
      |  |     +--ro state
      |  |        +--ro name?                          string
      |  |        +--ro key-server-priority?           uint8
      |  |        +--ro macsec-cipher-suite*           macsec-types:macsec-cipher-suite
      |  |        +--ro confidentiality-offset?        macsec-types:confidentiality-offset
      |  |        +--ro delay-protection?              boolean
      |  |        +--ro include-icv-indicator?         boolean
      |  |        +--ro include-sci?                   boolean
      |  |        +--ro sak-rekey-interval?            uint32
      |  |        +--ro sak-rekey-on-live-peer-loss?   boolean
+     |  |        +--ro security-policy?               enumeration
      |  |        +--ro use-updated-eth-header?        boolean
      |  +--ro state
      |     +--ro counters
      |        +--ro out-mkpdu-errors?                   oc-yang:counter64
      |        +--ro in-mkpdu-icv-verification-errors?   oc-yang:counter64
      |        +--ro in-mkpdu-validation-errors?         oc-yang:counter64
      |        +--ro in-mkpdu-bad-peer-errors?           oc-yang:counter64
      |        +--ro in-mkpdu-peer-list-errors?          oc-yang:counter64
      |        +--ro sak-generation-errors?              oc-yang:counter64
      |        +--ro sak-hash-errors?                    oc-yang:counter64
      |        +--ro sak-encryption-errors?              oc-yang:counter64
      |        +--ro sak-decryption-errors?              oc-yang:counter64
      |        +--ro sak-cipher-mismatch-errors?         oc-yang:counter64
      +--rw interfaces
         +--rw interface* [name]
            +--rw name       -> ../config/name
            +--rw config
            |  +--rw name?                oc-if:base-interface-ref
            |  +--rw enable?              boolean
            |  +--rw replay-protection?   uint16
            +--ro state
            |  +--ro name?                oc-if:base-interface-ref
            |  +--ro enable?              boolean
            |  +--ro replay-protection?   uint16
+           |  +--ro status?              enumeration
            |  +--ro counters
            |     +--ro tx-untagged-pkts?     oc-yang:counter64
            |     +--ro rx-untagged-pkts?     oc-yang:counter64
            |     +--ro rx-badtag-pkts?       oc-yang:counter64
            |     +--ro rx-unknownsci-pkts?   oc-yang:counter64
            |     +--ro rx-nosci-pkts?        oc-yang:counter64
            |     +--ro rx-late-pkts?         oc-yang:counter64
            +--ro scsa-tx
            |  +--ro scsa-tx* [sci-tx]
            |     +--ro sci-tx    -> ../state/sci-tx
            |     +--ro state
            |        +--ro sci-tx?     oc-yang:hex-string
            |        +--ro counters
            |           +--ro sc-auth-only?   oc-yang:counter64
            |           +--ro sc-encrypted?   oc-yang:counter64
            |           +--ro sa-auth-only?   oc-yang:counter64
            |           +--ro sa-encrypted?   oc-yang:counter64
            +--ro scsa-rx
            |  +--ro scsa-rx* [sci-rx]
            |     +--ro sci-rx    -> ../state/sci-rx
            |     +--ro state
            |        +--ro sci-rx?     oc-yang:hex-string
            |        +--ro counters
            |           +--ro sc-invalid?   oc-yang:counter64
            |           +--ro sc-valid?     oc-yang:counter64
            |           +--ro sa-invalid?   oc-yang:counter64
            |           +--ro sa-valid?     oc-yang:counter64
            +--rw mka
               +--rw config
               |  +--rw mka-policy?   -> /macsec/mka/policies/policy/name
               |  +--rw key-chain?    -> /oc-keychain:keychains/keychain/name
               +--ro state
                  +--ro mka-policy?   -> /macsec/mka/policies/policy/name
                  +--ro key-chain?    -> /oc-keychain:keychains/keychain/name
+                 +--ro status?       enumeration
                  +--ro counters
                     +--ro in-mkpdu?        oc-yang:counter64
                     +--ro in-sak-mkpdu?    oc-yang:counter64
                     +--ro in-cak-mkpdu?    oc-yang:counter64
                     +--ro out-mkpdu?       oc-yang:counter64
                     +--ro out-sak-mkpdu?   oc-yang:counter64
                     +--ro out-cak-mkpdu?   oc-yang:counter64
```
