### PR TITLE
Add support for duplicates in NH AFT state MPLS label stack

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -29,7 +29,7 @@ submodule openconfig-aft-common {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }
@@ -599,63 +599,8 @@ submodule openconfig-aft-common {
         A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
 
-        This node must be supported in addition to the
-        encap-headers/encap-header tree.  A future release of OpenConfig
-        will deprecate this node in favor of the
-        encap-headers/encap-header subtree.";
-    }
-
-    list encap-mpls-label-stack {
-      ordered-by user;
-      description
-        "The MPLS label stack imposed when forwarding packets to the
-        next-hop
-        - the stack is encoded as a leaf list whereby the order of the
-          entries is such that the first entry in the list is the
-          label at the bottom of the stack to be pushed. This supports
-          duplicate labels.
-
-        To this end, a packet which is to forwarded to a device using
-        a service label of 42, and a transport label of 8072 will be
-        represented with a label stack list of [42, 8072].
-
-        The MPLS label stack list is ordered by the user, such that no
-        system re-ordering of leaves is permitted by the system.
-
-        A swap operation is reflected by entries in the
-        decap-mpls-label-stack and encap-mpls-label-stack nodes.
-
-        This node must be supported in addition to the
-        encap-headers/encap-header tree.  A future release of OpenConfig
-        will deprecate this node in favor of the
-        encap-headers/encap-header subtree.";
-
-      key "index";
-
-      leaf index {
-          type leafref {
-            path "../state/index";
-          }
-          description
-            "Reference to list key";
-      }
-
-      container state {
-        description
-          "State parameters relating to nexthop encap";
-
-        leaf index {
-          type uint8;
-          description
-            "Index for a label in the list.";
-        }
-
-        leaf label {
-          type oc-mplst:mpls-label;
-          description
-            "MPLS label value.";
-        }
-      }
+        This node is deprecated in favor of the encap-headers/encap-header
+        subtree.";
     }
 
     leaf encapsulate-header {
@@ -684,6 +629,54 @@ submodule openconfig-aft-common {
     }
 
     uses aft-common-install-protocol;
+  }
+
+  grouping aft-common-entry-nexthop-mpls-label-state {
+    description
+      "Parameters relating to a next-hop mpls state.";
+
+    list encap-mpls-label-stack {
+      ordered-by user;
+      description
+        "A stack of MPLS label values.  The first entry in the list is the
+        label at the bottom of the stack.  The bottom of the stack is adjacent
+        to the MPLS payload. This supports duplicate labels.
+
+        For example, a packet with a label stack of two labels, the bottom
+        label being 42 and the top label being 8072 will be represented with
+        a leaf-list of [42, 8072].  The resulting packet, starting with the
+        beginning of the packet will be '[8072][42][Payload]'.
+
+        Note: a swap operation is reflected by entries in the
+        decap-mpls-label-stack and the encap-mpls-label-stack";
+
+      key "index";
+
+      leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to list key";
+      }
+
+      container state {
+        description
+          "State parameters relating to nexthop encap";
+
+        leaf index {
+          type uint8;
+          description
+            "Index for a label in the list.";
+        }
+
+        leaf label {
+          type oc-mplst:mpls-label;
+          description
+            "MPLS label value.";
+        }
+      }
+    }
   }
 
   grouping aft-common-entry-nexthop-ip-state {
@@ -748,6 +741,8 @@ submodule openconfig-aft-common {
         label at the bottom of the stack.  The bottom of the stack is adjacent
         to the MPLS payload. This does not support duplicate labels.
 
+        This node is deprecated in favor of the list encap-mpls-label-stack.
+
         For example, a packet with a label stack of two labels, the bottom
         label being 42 and the top label being 8072 will be represented with
         a leaf-list of [42, 8072].  The resulting packet, starting with the
@@ -757,48 +752,7 @@ submodule openconfig-aft-common {
         popped-mpls-label-stack and the pushed-mpls-label-stack";
     }
 
-    list encap-mpls-label-stack {
-      ordered-by user;
-      description
-        "A stack of MPLS label values.  The first entry in the list is the
-        label at the bottom of the stack.  The bottom of the stack is adjacent
-        to the MPLS payload. This supports duplicate labels.
-
-        For example, a packet with a label stack of two labels, the bottom
-        label being 42 and the top label being 8072 will be represented with
-        a leaf-list of [42, 8072].  The resulting packet, starting with the
-        beginning of the packet will be '[8072][42][Payload]'.
-
-        Note: a swap operation is reflected by entries in the
-        decap-mpls-label-stack and the encap-mpls-label-stack";
-
-      key "index";
-
-      leaf index {
-          type leafref {
-            path "../state/index";
-          }
-          description
-            "Reference to list key";
-      }
-
-      container state {
-        description
-          "State parameters relating to nexthop encap";
-
-        leaf index {
-          type uint8;
-          description
-            "Index for a label in the list.";
-        }
-
-        leaf label {
-          type oc-mplst:mpls-label;
-          description
-            "MPLS label value.";
-        }
-      }
-    }
+    uses aft-common-entry-nexthop-mpls-label-state;
   }
 
   grouping aft-common-entry-nexthop-encap-mpls-config {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -650,11 +650,11 @@ submodule openconfig-aft-common {
         Note: a swap operation is reflected by entries in the
         decap-mpls-label-stack and the encap-mpls-label-stack";
 
-      key "index";
+      key "id";
 
-      leaf index {
+      leaf id {
           type leafref {
-            path "../state/index";
+            path "../state/id";
           }
           description
             "Reference to list key";
@@ -664,7 +664,7 @@ submodule openconfig-aft-common {
         description
           "State parameters relating to nexthop encap";
 
-        leaf index {
+        leaf id {
           type uint8;
           description
             "Index for a label in the list.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -606,7 +606,6 @@ submodule openconfig-aft-common {
     }
 
     list encap-mpls-label-stack {
-      type oc-mplst:mpls-label;
       ordered-by user;
       description
         "The MPLS label stack imposed when forwarding packets to the
@@ -630,6 +629,33 @@ submodule openconfig-aft-common {
         encap-headers/encap-header tree.  A future release of OpenConfig
         will deprecate this node in favor of the
         encap-headers/encap-header subtree.";
+
+      key "index";
+
+      leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to list key";
+      }
+
+      container state {
+        description
+          "State parameters relating to nexthop encap";
+
+        leaf index {
+          type uint8;
+          description
+            "Index for a label in the list.";
+        }
+
+        leaf label {
+          type oc-mplst:mpls-label;
+          description
+            "MPLS label value.";
+        }
+      }
     }
 
     leaf encapsulate-header {
@@ -732,7 +758,6 @@ submodule openconfig-aft-common {
     }
 
     list encap-mpls-label-stack {
-      type oc-mplst:mpls-label;
       ordered-by user;
       description
         "A stack of MPLS label values.  The first entry in the list is the
@@ -746,6 +771,33 @@ submodule openconfig-aft-common {
 
         Note: a swap operation is reflected by entries in the
         decap-mpls-label-stack and the encap-mpls-label-stack";
+
+      key "index";
+
+      leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to list key";
+      }
+
+      container state {
+        description
+          "State parameters relating to nexthop encap";
+
+        leaf index {
+          type uint8;
+          description
+            "Index for a label in the list.";
+        }
+
+        leaf label {
+          type oc-mplst:mpls-label;
+          description
+            "MPLS label value.";
+        }
+      }
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,16 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description
@@ -571,12 +580,14 @@ submodule openconfig-aft-common {
     leaf-list pushed-mpls-label-stack {
       type oc-mplst:mpls-label;
       ordered-by user;
+      status deprecated;
       description
         "The MPLS label stack imposed when forwarding packets to the
         next-hop
         - the stack is encoded as a leaf list whereby the order of the
           entries is such that the first entry in the list is the
-          label at the bottom of the stack to be pushed.
+          label at the bottom of the stack to be pushed. This does not
+          support duplicate labels.
 
         To this end, a packet which is to forwarded to a device using
         a service label of 42, and a transport label of 8072 will be
@@ -587,6 +598,33 @@ submodule openconfig-aft-common {
 
         A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.
+
+        This node must be supported in addition to the
+        encap-headers/encap-header tree.  A future release of OpenConfig
+        will deprecate this node in favor of the
+        encap-headers/encap-header subtree.";
+    }
+
+    list encap-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      ordered-by user;
+      description
+        "The MPLS label stack imposed when forwarding packets to the
+        next-hop
+        - the stack is encoded as a leaf list whereby the order of the
+          entries is such that the first entry in the list is the
+          label at the bottom of the stack to be pushed. This supports
+          duplicate labels.
+
+        To this end, a packet which is to forwarded to a device using
+        a service label of 42, and a transport label of 8072 will be
+        represented with a label stack list of [42, 8072].
+
+        The MPLS label stack list is ordered by the user, such that no
+        system re-ordering of leaves is permitted by the system.
+
+        A swap operation is reflected by entries in the
+        decap-mpls-label-stack and encap-mpls-label-stack nodes.
 
         This node must be supported in addition to the
         encap-headers/encap-header tree.  A future release of OpenConfig
@@ -678,10 +716,11 @@ submodule openconfig-aft-common {
     leaf-list mpls-label-stack {
       type oc-mplst:mpls-label;
       ordered-by user;
+      status deprecated;
       description
         "A stack of MPLS label values.  The first entry in the list is the
         label at the bottom of the stack.  The bottom of the stack is adjacent
-        to the MPLS payload.
+        to the MPLS payload. This does not support duplicate labels.
 
         For example, a packet with a label stack of two labels, the bottom
         label being 42 and the top label being 8072 will be represented with
@@ -690,6 +729,23 @@ submodule openconfig-aft-common {
 
         Note: a swap operation is reflected by entries in the
         popped-mpls-label-stack and the pushed-mpls-label-stack";
+    }
+
+    list encap-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      ordered-by user;
+      description
+        "A stack of MPLS label values.  The first entry in the list is the
+        label at the bottom of the stack.  The bottom of the stack is adjacent
+        to the MPLS payload. This supports duplicate labels.
+
+        For example, a packet with a label stack of two labels, the bottom
+        label being 42 and the top label being 8072 will be represented with
+        a leaf-list of [42, 8072].  The resulting packet, starting with the
+        beginning of the packet will be '[8072][42][Payload]'.
+
+        Note: a swap operation is reflected by entries in the
+        decap-mpls-label-stack and the encap-mpls-label-stack";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -665,6 +665,7 @@ submodule openconfig-aft-common {
         }
 
         container state {
+          config false;
           description
             "State parameters relating to nexthop encap";
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -635,45 +635,50 @@ submodule openconfig-aft-common {
     description
       "Parameters relating to a next-hop mpls state.";
 
-    list encap-mpls-label-stack {
-      ordered-by user;
+    container encap-mpls-label-stacks {
       description
-        "A stack of MPLS label values.  The first entry in the list is the
-        label at the bottom of the stack.  The bottom of the stack is adjacent
-        to the MPLS payload. This supports duplicate labels.
+        "Surrounding container for groups of encap-mpls-label-stack.";
 
-        For example, a packet with a label stack of two labels, the bottom
-        label being 42 and the top label being 8072 will be represented with
-        a leaf-list of [42, 8072].  The resulting packet, starting with the
-        beginning of the packet will be '[8072][42][Payload]'.
+      list encap-mpls-label-stack {
+        ordered-by user;
+        description
+          "A stack of MPLS label values.  The first entry in the list is the
+          label at the bottom of the stack.  The bottom of the stack is adjacent
+          to the MPLS payload. This supports duplicate labels.
 
-        Note: a swap operation is reflected by entries in the
-        decap-mpls-label-stack and the encap-mpls-label-stack";
+          For example, a packet with a label stack of two labels, the bottom
+          label being 42 and the top label being 8072 will be represented with
+          a leaf-list of [42, 8072].  The resulting packet, starting with the
+          beginning of the packet will be '[8072][42][Payload]'.
 
-      key "id";
+          Note: a swap operation is reflected by entries in the
+          decap-mpls-label-stack and the encap-mpls-label-stack";
 
-      leaf id {
+        key "id";
+
+        leaf id {
           type leafref {
             path "../state/id";
           }
           description
             "Reference to list key";
-      }
-
-      container state {
-        description
-          "State parameters relating to nexthop encap";
-
-        leaf id {
-          type uint8;
-          description
-            "Index for a label in the list.";
         }
 
-        leaf label {
-          type oc-mplst:mpls-label;
+        container state {
           description
-            "MPLS label value.";
+            "State parameters relating to nexthop encap";
+
+          leaf id {
+            type uint8;
+            description
+              "Index for a label in the list.";
+          }
+
+          leaf label {
+            type oc-mplst:mpls-label;
+            description
+              "MPLS label value.";
+          }
         }
       }
     }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -389,6 +389,7 @@ submodule openconfig-aft-common {
 
                 uses aft-common-entry-nexthop-mpls-state;
               }
+              uses aft-common-entry-nexthop-mpls-label-state;
             }
 
             container udp-v4 {
@@ -665,6 +666,7 @@ submodule openconfig-aft-common {
         }
 
         container state {
+          config false;
           description
             "State parameters relating to nexthop encap";
 
@@ -756,8 +758,6 @@ submodule openconfig-aft-common {
         Note: a swap operation is reflected by entries in the
         popped-mpls-label-stack and the pushed-mpls-label-stack";
     }
-
-    uses aft-common-entry-nexthop-mpls-label-state;
   }
 
   grouping aft-common-entry-nexthop-encap-mpls-config {

--- a/release/models/aft/openconfig-aft-counters.yang
+++ b/release/models/aft/openconfig-aft-counters.yang
@@ -18,7 +18,16 @@ module openconfig-aft-counters {
   description
     "Submodule providing a unified subtree for AFT entry counters.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-07-04" {
     description

--- a/release/models/aft/openconfig-aft-counters.yang
+++ b/release/models/aft/openconfig-aft-counters.yang
@@ -24,7 +24,7 @@ module openconfig-aft-counters {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,16 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -26,7 +26,7 @@ submodule openconfig-aft-ethernet {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,16 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -26,7 +26,7 @@ submodule openconfig-aft-ipv4 {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,16 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -26,7 +26,7 @@ submodule openconfig-aft-ipv6 {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -271,11 +271,11 @@ submodule openconfig-aft-mpls {
         A swap operation is reflected by entries in the
         decap-mpls-label-stack and encap-mpls-label-stack nodes.";
 
-      key "index";
+      key "id";
 
-      leaf index {
+      leaf id {
           type leafref {
-            path "../state/index";
+            path "../state/id";
           }
           description
             "Reference to list key";
@@ -285,7 +285,7 @@ submodule openconfig-aft-mpls {
         description
           "State parameters relating to nexthop encap";
 
-        leaf index {
+        leaf id {
           type uint8;
           description
             "Index for a label in the list.";

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,16 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description
@@ -226,11 +235,13 @@ submodule openconfig-aft-mpls {
 
     leaf-list popped-mpls-label-stack {
       type oc-mplst:mpls-label;
+      status deprecated;
       description
         "The MPLS label stack to be popped from the packet when
         switched by the system. The stack is encoded as a leaf-list
         such that the first entry is the label that is outer-most (i.e.,
-        furthest from the bottom of the stack).
+        furthest from the bottom of the stack). This does not support
+        duplicate labels.
 
         If the local system pops the outer-most label 400, then the
         value of this list is [400,]. If the local system removes two
@@ -239,6 +250,24 @@ submodule openconfig-aft-mpls {
 
         A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+    }
+
+    list decap-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      description
+        "The MPLS label stack to be popped from the packet when
+        switched by the system. The stack is encoded as a list
+        such that the first entry is the label that is outer-most (i.e.,
+        furthest from the bottom of the stack). This supports duplicate
+        labels.
+
+        If the local system pops the outer-most label 400, then the
+        value of this list is [400,]. If the local system removes two
+        labels, the outer-most being 500, and the second of which is
+        400, then the value of the list is [500, 400].
+
+        A swap operation is reflected by entries in the
+        decap-mpls-label-stack and encap-mpls-label-stack nodes.";
     }
   }
 }

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -253,7 +253,7 @@ submodule openconfig-aft-mpls {
     }
 
     list decap-mpls-label-stack {
-      type oc-mplst:mpls-label;
+      ordered-by user;
       description
         "The MPLS label stack to be popped from the packet when
         switched by the system. The stack is encoded as a list
@@ -268,6 +268,33 @@ submodule openconfig-aft-mpls {
 
         A swap operation is reflected by entries in the
         decap-mpls-label-stack and encap-mpls-label-stack nodes.";
+
+      key "index";
+
+      leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to list key";
+      }
+
+      container state {
+        description
+          "State parameters relating to nexthop encap";
+
+        leaf index {
+          type uint8;
+          description
+            "Index for a label in the list.";
+        }
+
+        leaf label {
+          type oc-mplst:mpls-label;
+          description
+            "MPLS label value.";
+        }
+      }
     }
   }
 }

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-mpls {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }
@@ -242,6 +242,8 @@ submodule openconfig-aft-mpls {
         such that the first entry is the label that is outer-most (i.e.,
         furthest from the bottom of the stack). This does not support
         duplicate labels.
+
+        This node is deprecated in favor of the list decap-mpls-label-stack.
 
         If the local system pops the outer-most label 400, then the
         value of this list is [400,]. If the local system removes two

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -257,6 +257,9 @@ submodule openconfig-aft-mpls {
   }
 
   grouping aft-mpls-entry-label-state {
+    description
+      "Parameters relating to mpls label state.";
+
     container decap-mpls-label-stacks {
       description
         "Surrounding container for groups of decap-mpls-label-stack.";

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -217,6 +217,7 @@ submodule openconfig-aft-mpls {
           entry.";
         uses aft-mpls-entry-state;
       }
+      uses aft-mpls-entry-label-state;
     }
   }
 
@@ -253,7 +254,9 @@ submodule openconfig-aft-mpls {
         A swap operation is reflected by entries in the
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
     }
+  }
 
+  grouping aft-mpls-entry-label-state {
     container decap-mpls-label-stacks {
       description
         "Surrounding container for groups of decap-mpls-label-stack.";
@@ -286,6 +289,7 @@ submodule openconfig-aft-mpls {
         }
 
         container state {
+          config false;
           description
             "State parameters relating to nexthop encap";
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -286,6 +286,7 @@ submodule openconfig-aft-mpls {
         }
 
         container state {
+          config false;
           description
             "State parameters relating to nexthop encap";
 

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -254,47 +254,52 @@ submodule openconfig-aft-mpls {
         popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
     }
 
-    list decap-mpls-label-stack {
-      ordered-by user;
+    container decap-mpls-label-stacks {
       description
-        "The MPLS label stack to be popped from the packet when
-        switched by the system. The stack is encoded as a list
-        such that the first entry is the label that is outer-most (i.e.,
-        furthest from the bottom of the stack). This supports duplicate
-        labels.
+        "Surrounding container for groups of decap-mpls-label-stack.";
 
-        If the local system pops the outer-most label 400, then the
-        value of this list is [400,]. If the local system removes two
-        labels, the outer-most being 500, and the second of which is
-        400, then the value of the list is [500, 400].
+      list decap-mpls-label-stack {
+        ordered-by user;
+        description
+          "The MPLS label stack to be popped from the packet when
+          switched by the system. The stack is encoded as a list
+          such that the first entry is the label that is outer-most (i.e.,
+          furthest from the bottom of the stack). This supports duplicate
+          labels.
 
-        A swap operation is reflected by entries in the
-        decap-mpls-label-stack and encap-mpls-label-stack nodes.";
+          If the local system pops the outer-most label 400, then the
+          value of this list is [400,]. If the local system removes two
+          labels, the outer-most being 500, and the second of which is
+          400, then the value of the list is [500, 400].
 
-      key "id";
+          A swap operation is reflected by entries in the
+          decap-mpls-label-stack and encap-mpls-label-stack nodes.";
 
-      leaf id {
+        key "id";
+
+        leaf id {
           type leafref {
             path "../state/id";
           }
           description
             "Reference to list key";
-      }
-
-      container state {
-        description
-          "State parameters relating to nexthop encap";
-
-        leaf id {
-          type uint8;
-          description
-            "Index for a label in the list.";
         }
 
-        leaf label {
-          type oc-mplst:mpls-label;
+        container state {
           description
-            "MPLS label value.";
+            "State parameters relating to nexthop encap";
+
+          leaf id {
+            type uint8;
+            description
+              "Index for a label in the list.";
+          }
+
+          leaf label {
+            type oc-mplst:mpls-label;
+            description
+              "MPLS label value.";
+          }
         }
       }
     }

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -34,7 +34,7 @@ submodule openconfig-aft-pf {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,16 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -22,7 +22,7 @@ submodule openconfig-aft-state-synced {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,16 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -48,7 +48,7 @@ module openconfig-aft {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
        and mpls-label-stack leafs as they do not support duplicates.
-       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       Add decap-mpls-label-stack and AFT NH encap-mpls-label-stack
        and encap-mpls-label-stack leafs that support duplicates.";
     reference "3.3.0";
   }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,16 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-02-09" {
+    description
+      "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack
+       and mpls-label-stack leafs as they do not support duplicates.
+       Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack
+       and encap-mpls-label-stack leafs that support duplicates.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/segment-routing/openconfig-srte-policy.yang
+++ b/release/models/segment-routing/openconfig-srte-policy.yang
@@ -38,7 +38,14 @@ module openconfig-srte-policy {
   reference
     "draft-ietf-spring-segment-routing-policy";
 
-  oc-ext:openconfig-version "0.2.3";
+  oc-ext:openconfig-version "0.2.4";
+
+  revision "2026-02-09" {
+    description
+      "Update segment-lists nexthop state container to use
+      aft-common-entry-nexthop-mpls-label-state.";
+    reference "0.2.4";
+  }
 
   revision "2021-07-28" {
     description
@@ -442,6 +449,7 @@ module openconfig-srte-policy {
                   description "State parameters for the nexthop.";
 
                   uses oc-aft:aft-common-entry-nexthop-state;
+                  uses oc-aft:aft-common-entry-nexthop-mpls-label-state;
 
                   container counters {
                     description

--- a/release/models/segment-routing/openconfig-srte-policy.yang
+++ b/release/models/segment-routing/openconfig-srte-policy.yang
@@ -449,7 +449,6 @@ module openconfig-srte-policy {
                   description "State parameters for the nexthop.";
 
                   uses oc-aft:aft-common-entry-nexthop-state;
-                  uses oc-aft:aft-common-entry-nexthop-mpls-label-state;
 
                   container counters {
                     description
@@ -459,6 +458,7 @@ module openconfig-srte-policy {
                   }
                 }
 
+                uses oc-aft:aft-common-entry-nexthop-mpls-label-state;
                 uses oc-if:interface-ref-state;
               }
             }


### PR DESCRIPTION
**Change Scope**
- Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack and mpls-label-stack leafs as they do not support duplicates.
- Add decap-mpls-label-stack and AFT NH encah-mpls-label-stack and encap-mpls-label-stack leafs that support duplicates.
- This change is backwards compatible

**Context:** 
[NH AFT state MPLS label stack doesn't support duplicates](https://github.com/openconfig/public/issues/1396)

**Tree View**
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
           +--rw segment-routing
           |  +--ro te-policies
           |     +--ro te-policy* [color endpoint]
           |        +--ro candidate-paths
           |           +--ro candidate-path* [protocol-origin originator-asn originator-addr discriminator]
           |              +--ro segment-lists
           |                 +--ro segment-list* [id]
           |                    +--ro next-hops
           |                       +--ro next-hop* [index]
           |                          +--ro index            -> ../state/index
           |                          +--ro state
           |                          |  +--ro index?                     uint64
           |                          |  +--ro programmed-index?          uint64
           |                          |  +--ro ip-address?                oc-inet:ip-address
           |                          |  +--ro mac-address?               oc-yang:mac-address
           |                          |  +--ro pop-top-label?             boolean
  -        |                          |  +--ro pushed-mpls-label-stack*   oc-mplst:mpls-label
  +        |                          |  x--ro pushed-mpls-label-stack*   oc-mplst:mpls-label
  +        |                          +--ro encap-mpls-label-stacks
  +        |                          |  +--ro encap-mpls-label-stack* [id]
  +        |                          |     +--ro id       -> ../state/id
  +        |                          |     +--ro state
  +        |                          |        +--ro id?      uint8
  +        |                          |        +--ro label?   oc-mplst:mpls-label
           |                          |  +--ro encapsulate-header?        oc-aftt:encapsulation-header-type
           |                          |  +--ro decapsulate-header?        oc-aftt:encapsulation-header-type
           |                          |  +--ro origin-protocol?           identityref
```

```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
           +--ro afts
           |  +--ro mpls
           |  |  +--ro label-entry* [label]
           |  |     +--ro label    -> ../state/label
           |  |     +--ro state
           |  |        +--ro label?                                      oc-mplst:mpls-label
           |  |        +--ro counters
           |  |        |  x--ro packets-forwarded?   oc-yang:counter64
           |  |        |  x--ro octets-forwarded?    oc-yang:counter64
           |  |        +--ro entry-metadata?                             binary
  -        |  |        +--ro popped-mpls-label-stack*                    oc-mplst:mpls-label
  +        |  |        x--ro popped-mpls-label-stack*                    oc-mplst:mpls-label
  +        |  |     +--ro decap-mpls-label-stacks
  +        |  |     |  +--ro decap-mpls-label-stack* [id]
  +        |  |     |     +--ro id       -> ../state/id
  +        |  |     |     +--ro state
  +        |  |     |        +--ro id?      uint8
  +        |  |     |        +--ro label?   oc-mplst:mpls-label
           |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
           |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
           |  |
           |  |
           |  +--ro next-hops
           |  |  +--ro next-hop* [index]
           |  |     +--ro index            -> ../state/index
           |  |     +--ro state
           |  |     |  +--ro index?                       uint64
           |  |     |  +--ro programmed-index?            uint64
           |  |     |  +--ro ip-address?                  oc-inet:ip-address
           |  |     |  +--ro mac-address?                 oc-yang:mac-address
           |  |     |  +--ro pop-top-label?               boolean
  -        |  |     |  +--ro pushed-mpls-label-stack*     oc-mplst:mpls-label
  +        |  |     |  x--ro pushed-mpls-label-stack*     oc-mplst:mpls-label
           |  |     |  +--ro encapsulate-header?          oc-aftt:encapsulation-header-type
           |  |     |  +--ro decapsulate-header?          oc-aftt:encapsulation-header-type
           |  |     |  +--ro origin-protocol?             identityref
           |  |     |  +--ro lsp-name?                    string
           |  |     | 
           |  |     | 
           |  |     +--ro encap-headers
           |  |     |  +--ro encap-header* [index]
           |  |     |     +--ro index     -> ../state/index
           |  |     |     +--ro state
           |  |     |     |  +--ro index?   uint8
           |  |     |     |  +--ro type?    oc-aftt:encapsulation-header-type
           |  |     |     +--ro mpls
           |  |     |     |  +--ro state
           |  |     |     |     +--ro traffic-class?      oc-mplst:mpls-tc
  -        |  |     |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
  +        |  |     |     |     x--ro mpls-label-stack*         oc-mplst:mpls-label
  +        |  |     |     |  +--ro encap-mpls-label-stacks
  +        |  |     |     |     +--ro encap-mpls-label-stack* [id]
  +        |  |     |     |        +--ro id       -> ../state/id
  +        |  |     |     |        +--ro state
  +        |  |     |     |           +--ro id?      uint8
  +        |  |     |     |           +--ro label?   oc-mplst:mpls-label
           |  |     |     +--ro udp-v4
           |  |     |     |  +--ro state
           |  |     |     |     +--ro src-ip?         oc-inet:ipv4-address
```