### PR TITLE
Fix yanglint schema warnings

### DIFF
--- a/release/models/acl/openconfig-acl.yang
+++ b/release/models/acl/openconfig-acl.yang
@@ -34,7 +34,12 @@ module openconfig-acl {
     packets should be handled. Entries have a type that indicates
     the type of match criteria, e.g., MAC layer, IPv4, IPv6, etc.";
 
-  oc-ext:openconfig-version "1.3.3";
+  oc-ext:openconfig-version "1.3.4";
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "1.3.4";
+  }
 
   revision "2023-02-06" {
     description
@@ -451,8 +456,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ethernet-header-top {
-          when "../../config/type='ACL_L2' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_L2' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "MAC-layer fields are valid when the ACL type is L2 or
               MIXED";
@@ -460,8 +465,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ipv4-protocol-fields-top {
-          when "../../config/type='ACL_IPV4' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV4' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "IPv4-layer fields are valid when the ACL type is
               IPv4 or MIXED";
@@ -469,8 +474,8 @@ module openconfig-acl {
         }
 
         uses oc-match:mpls-header-top {
-          when "../../config/type='ACL_MPLS' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_MPLS' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "MPLS-layer fields are valid when the ACL type is
               MPLS or MIXED";
@@ -478,8 +483,8 @@ module openconfig-acl {
         }
 
         uses oc-match:ipv6-protocol-fields-top {
-          when "../../config/type='ACL_IPV6' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV6' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "IPv6-layer fields are valid when the ACL type is
               IPv6 or MIXED";
@@ -487,9 +492,9 @@ module openconfig-acl {
         }
 
         uses oc-match:transport-fields-top {
-          when "../../config/type='ACL_IPV6' or " +
-            "../../config/type='ACL_IPV4' or " +
-            "../../config/type='ACL_MIXED'" {
+          when "../../config/type='oc-acl:ACL_IPV6' or " +
+            "../../config/type='oc-acl:ACL_IPV4' or " +
+            "../../config/type='oc-acl:ACL_MIXED'" {
             description
               "Transport-layer fields are valid when specifying
               L3 or MIXED ACL types";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.2.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "3.2.1";
+  }
 
   revision "2025-08-07" {
     description
@@ -327,7 +333,7 @@ submodule openconfig-aft-common {
             }
 
             container gre {
-              when "../state/type = 'oc-aftt:GRE'";
+              when "../state/type = 'GRE'";
               description
                 "Container of nodes for GRE encapsulation.";
 
@@ -340,7 +346,7 @@ submodule openconfig-aft-common {
             }
 
             container ipv4 {
-              when "../state/type = 'oc-aftt:IPV4'";
+              when "../state/type = 'IPV4'";
               description
                 "Container of nodes for UDP in IPv4 encapsulation.  When this
                 container is used, an IPv4 packet with no transport header
@@ -355,7 +361,7 @@ submodule openconfig-aft-common {
             }
 
             container ipv6 {
-              when "../state/type = 'oc-aftt:IPV6'";
+              when "../state/type = 'IPV6'";
               description
                 "Container of nodes for UDP in IPv6 encapsulation.  When this
                 container is used, an IPv6 packet with no transport header
@@ -370,7 +376,7 @@ submodule openconfig-aft-common {
             }
 
             container mpls {
-              when "../state/type = 'oc-aftt:MPLS'";
+              when "../state/type = 'MPLS'";
               description
                 "Container of nodes for MPLS encapsulation.";
 
@@ -383,7 +389,7 @@ submodule openconfig-aft-common {
             }
 
             container udp-v4 {
-              when "../state/type = 'oc-aftt:UDPV4'";
+              when "../state/type = 'UDPV4'";
               description
                 "Container of nodes for UDP in IPv4 encapsulation.  When this
                 container is used, an IPv4 header with a UDP header is added
@@ -399,7 +405,7 @@ submodule openconfig-aft-common {
             }
 
             container udp-v6 {
-              when "../state/type = 'oc-aftt:UDPV6'";
+              when "../state/type = 'UDPV6'";
               description
                 "Container of nodes for UDP in IPv6 encapsulation.  When this
                 container is used, an IPv6 header with a UDP header is added
@@ -415,7 +421,7 @@ submodule openconfig-aft-common {
             }
 
             container vxlan {
-              when "../state/type = 'oc-aftt:VXLAN'";
+              when "../state/type = 'VXLAN'";
               description
                 "Container of nodes for VXLAN encapsulation.";
 

--- a/release/models/gnsi/openconfig-gnsi-acctz.yang
+++ b/release/models/gnsi/openconfig-gnsi-acctz.yang
@@ -27,7 +27,13 @@ module openconfig-gnsi-acctz {
     "This module provides counters of gNSI accountZ requests and responses and
     the quantity of data transferred.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+  
+  revision 2026-02-10 {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.4.1";
+  }
 
   revision 2024-12-24 {
     description
@@ -263,7 +269,8 @@ module openconfig-gnsi-acctz {
 
   // Augments section.
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
-    when "config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    when "oc-sys-grpc:config[contains(oc-sys-grpc:services, " +
+         "'oc-gnsi:GNSI')]/oc-sys-grpc:enable = 'true'";
     description
       "Counters collected by the gNSI.acctz module regarding grpc servers.";
 

--- a/release/models/gnsi/openconfig-gnsi-authz.yang
+++ b/release/models/gnsi/openconfig-gnsi-authz.yang
@@ -30,7 +30,13 @@ module openconfig-gnsi-authz {
     "This module provides a data model for the metadata of the gRPC
     authorization policies installed on a networking device.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.4.1";
+  
+  revision 2026-02-10 {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.4.1";
+  }
 
   revision 2024-02-13 {
     description
@@ -202,7 +208,8 @@ module openconfig-gnsi-authz {
   }
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
-    when "config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    when "oc-sys-grpc:config[contains(oc-sys-grpc:services, " +
+         "'oc-gnsi:GNSI')]/oc-sys-grpc:enable = 'true'";
     description
       "Counters collected while evaluating access to a gRPC server using
       the gNSI.authz authorization policy.";

--- a/release/models/gnsi/openconfig-gnsi-certz.yang
+++ b/release/models/gnsi/openconfig-gnsi-certz.yang
@@ -30,7 +30,13 @@ module openconfig-gnsi-certz {
     "This module provides a data model for the metadata of gRPC credentials
     installed on a networking device.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "0.7.1";
+  
+  revision 2026-02-10 {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.7.1";
+  }
 
   revision 2025-09-26 {
     description
@@ -221,7 +227,8 @@ module openconfig-gnsi-certz {
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
           "oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    when "../oc-sys-grpc:config[contains(oc-sys-grpc:services, " +
+         "'oc-gnsi:GNSI')]/oc-sys-grpc:enable = 'true'";
     description
       "A gRPC server credentials freshness information.";
 
@@ -230,7 +237,8 @@ module openconfig-gnsi-certz {
 
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
           "oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    when "../oc-sys-grpc:config[contains(oc-sys-grpc:services, " +
+    	 "'oc-gnsi:GNSI')]/oc-sys-grpc:enable = 'true'";
     uses grpc-server-certz-counters;
     description
       "gNSI certz server access counters.";

--- a/release/models/gnsi/openconfig-gnsi-pathz.yang
+++ b/release/models/gnsi/openconfig-gnsi-pathz.yang
@@ -32,7 +32,13 @@ module openconfig-gnsi-pathz {
     OpenConfig-path-based authorization policies installed on a networking
     device.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.3.1";
+  
+  revision 2026-02-10 {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.3.1";
+  }
 
   revision 2024-02-13 {
     description
@@ -312,7 +318,8 @@ module openconfig-gnsi-pathz {
   }
   augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" +
           "/oc-sys-grpc:state" {
-    when "../config[contains(services, 'oc-gnsi:GNSI')]/enable = 'true'";
+    when "../oc-sys-grpc:config[contains(oc-sys-grpc:services, 'oc-gnsi:GNSI')]" +
+         "/oc-sys-grpc:enable = 'true'";
     description
       "A gNMI server OpenConfig-path-based authorization policy freshness
       information.";

--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -26,7 +26,13 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.16.0";
+  oc-ext:openconfig-version "2.16.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "2.16.1";
+  }
 
   revision "2025-11-20" {
     description
@@ -439,7 +445,7 @@ module openconfig-if-ethernet {
 
     leaf fec-uncorrectable-blocks {
       type oc-yang:counter64;
-      when "../../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../../config/fec-mode != 'oc-eth:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }
@@ -452,7 +458,7 @@ module openconfig-if-ethernet {
 
     leaf fec-corrected-blocks {
       type oc-yang:counter64;
-      when "../../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../../config/fec-mode != 'oc-eth:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -9,7 +9,6 @@ module openconfig-network-instance-static {
 
   import openconfig-extensions { prefix "oc-ext"; }
   import openconfig-aft { prefix "oc-aft"; }
-  import openconfig-aft-types { prefix "oc-aftt"; }
   import openconfig-local-routing { prefix "oc-loc-rt"; }
 
   // meta
@@ -22,7 +21,13 @@ module openconfig-network-instance-static {
   description
     "Static configurations associated with a network instance";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.2.2";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.2.2";
+  }
 
   revision "2025-08-05" {
     description
@@ -273,7 +278,7 @@ module openconfig-network-instance-static {
         }
 
         container udp-v4 {
-          when "../config/type = 'oc-aftt:UDPV4'";
+          when "../config/type = 'UDPV4'";
           description
             "Container of nodes for UDP in IPv4 encapsulation.  When this
             container is used, an IPv4 header with a UDP header is added
@@ -296,7 +301,7 @@ module openconfig-network-instance-static {
         }
 
         container gre {
-          when "../config/type = 'oc-aftt:GRE'";
+          when "../config/type = 'GRE'";
           description
             "Container of nodes for GRE encapsulation.  When this
             container is used, a GRE header is added to the encapsulation
@@ -318,7 +323,7 @@ module openconfig-network-instance-static {
         }
 
         container mpls {
-          when "../config/type = 'oc-aftt:MPLS'";
+          when "../config/type = 'MPLS'";
           description
             "Container of nodes for MPLS encapsulation.  When this
             container is used, a MPLS header is added to the encapsulation

--- a/release/models/optical-transport/openconfig-terminal-device.yang
+++ b/release/models/optical-transport/openconfig-terminal-device.yang
@@ -76,13 +76,19 @@ module openconfig-terminal-device {
     ports per linecard, separate linecards for client and line ports,
     etc.).";
 
-  oc-ext:openconfig-version "1.12.0";
+  oc-ext:openconfig-version "1.12.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "1.12.1";
+  }
 
   revision "2026-01-14" {
     description
       "Removal of references to unused/removed LLDP groupings";
     reference "1.12.0";
-  }
+
 
   revision "2025-12-11" {
     description
@@ -1476,14 +1482,14 @@ module openconfig-terminal-device {
         }
 
         uses terminal-otn-protocol-top {
-          when "./config/logical-channel-type = 'PROT_OTN'" {
+          when "./config/logical-channel-type = 'oc-opt-types:PROT_OTN'" {
             description
               "Include the OTN protocol data only when the
               channel is using OTN framing.";
           }
         }
         uses terminal-ethernet-protocol-top {
-          when "./config/logical-channel-type = 'PROT_ETHERNET'" {
+          when "./config/logical-channel-type = 'oc-opt-types:PROT_ETHERNET'" {
             description
               "Include the Ethernet protocol statistics only when the
               protocol used by the link is Ethernet.";

--- a/release/models/optical-transport/openconfig-wavelength-router.yang
+++ b/release/models/optical-transport/openconfig-wavelength-router.yang
@@ -41,7 +41,13 @@ module openconfig-wavelength-router {
          target spectrum power profile over the full spectrum instead
          of individual media channels.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.2.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "1.2.1";
+  }
 
   revision "2024-04-08" {
     description
@@ -622,7 +628,7 @@ module openconfig-wavelength-router {
       type decimal64 {
         fraction-digits 2;
       }
-      when "../attenuation-control-range = 'CONTROL_RANGE_LIMITED'";
+      when "../attenuation-control-range = 'oc-wave-router:CONTROL_RANGE_LIMITED'";
       units dB;
       description
         "Defines the maximum allowable WSS attenuation adjustment
@@ -636,7 +642,7 @@ module openconfig-wavelength-router {
       type decimal64 {
         fraction-digits 2;
       }
-      when "../attenuation-control-range = 'CONTROL_RANGE_LIMITED'";
+      when "../attenuation-control-range = 'oc-wave-router:CONTROL_RANGE_LIMITED'";
       units dB;
       description
         "Defines the maximum allowable WSS attenuation adjustment

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,7 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.5.3";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.5.3";
+  }
 
   revision "2024-06-17" {
     description
@@ -1448,7 +1454,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf link-type {
-      when "../type = 'TE_LINK_TYPE'" {
+      when "../type = 'oc-ospf-types:TE_LINK_TYPE'" {
         description
           "Include the link-type field only when the sub-TLV type was a TE
           link type";
@@ -1477,7 +1483,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf link-id {
-      when "../type = 'TE_LINK_ID'" {
+      when "../type = 'oc-ospf-types:TE_LINK_ID'" {
         description
           "Include the link ID field only when the sub-TLV type was a TE
           Link identifier";
@@ -1546,7 +1552,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf maximum-reservable-bandwidth {
-      when "../type = 'oc-ospf-types:TE_LINK_MAXIUMUM_RESERVABLE_BANDWIDTH'" {
+      when "../type = 'oc-ospf-types:TE_LINK_MAXIMUM_RESERVABLE_BANDWIDTH'" {
         description
           "Include the maximum reservable bandwidth field only when the
           sub-TLV type is the maximum reservable bandwidth";
@@ -1645,7 +1651,7 @@ submodule openconfig-ospfv2-lsdb {
     }
 
     leaf-list local-ipv6-addresses {
-      when "../type = 'oc-ospf-types:NODE_LOCAL_IPV6_ADDRESS'" {
+      when "../type = 'oc-ospf-types:NODE_IPV6_LOCAL_ADDRESS'" {
         description
           "Include the local IPv6 addresses when the type of the sub-TLV
           indicfates that this is the contained data";

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,7 +66,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.18.0";
+  oc-ext:openconfig-version "0.18.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.18.1";
+  }
 
   revision "2025-12-11" {
     description
@@ -828,7 +834,7 @@ module openconfig-platform-transceiver {
 
     leaf fec-uncorrectable-blocks {
       type oc-yang:counter64;
-      when "../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../config/fec-mode != 'oc-platform-types:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }
@@ -841,7 +847,7 @@ module openconfig-platform-transceiver {
 
     leaf fec-corrected-blocks {
       type oc-yang:counter64;
-      when "../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../config/fec-mode != 'oc-platform-types:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }
@@ -854,7 +860,7 @@ module openconfig-platform-transceiver {
 
     leaf fec-uncorrectable-words {
       type yang:counter64;
-      when "../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../config/fec-mode != 'oc-platform-types:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }
@@ -864,7 +870,7 @@ module openconfig-platform-transceiver {
 
     leaf fec-corrected-bytes {
       type yang:counter64;
-      when "../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../config/fec-mode != 'oc-platform-types:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }
@@ -874,7 +880,7 @@ module openconfig-platform-transceiver {
 
     leaf fec-corrected-bits {
       type yang:counter64;
-      when "../../config/fec-mode != 'FEC_DISABLED'" {
+      when "../../config/fec-mode != 'oc-platform-types:FEC_DISABLED'" {
         description
           "Applicable if FEC is enabled.";
       }

--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -24,7 +24,13 @@ submodule openconfig-rib-bgp-attributes {
     attributes for use in BGP RIB tables.";
 
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.9.1";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.9.1";
+  }
 
   revision "2022-12-20" {
     description
@@ -917,7 +923,7 @@ submodule openconfig-rib-bgp-attributes {
     }
 
     leaf remote-ipv4-address {
-      when "../type = 'IPV4_NODE_ADDRESS' or ../type='../IPV4_ADDRESS_INDEX'" +
+      when "../type = 'IPV4_NODE_ADDRESS'" +
            "or ../type='IPV4_LOCAL_INTF_ID' or " +
            "../type='IPV4_LOCAL_REMOTE_ADDR'" {
         description
@@ -946,7 +952,7 @@ submodule openconfig-rib-bgp-attributes {
     }
 
     leaf remote-ipv6-address {
-      when "../type = 'IPV6_NODE_ADDRESS' or ../type='IPV6_ADDRESS_INDEX'" +
+      when "../type = 'IPV6_NODE_ADDRESS'" +
            "or ../type='IPV6_LOCAL_INTF_ID' or " +
            "../type='IPV6_LOCAL_REMOTE_ADDR'" {
         description

--- a/release/models/sampling/openconfig-sampling-sflow.yang
+++ b/release/models/sampling/openconfig-sampling-sflow.yang
@@ -165,6 +165,19 @@ module openconfig-sampling-sflow {
         "RFC 3176 - InMon Corporation's sFlow: sFlowRcvrMaximumDatagramSize.";
     }
 
+    leaf dont-fragment {
+      type boolean;
+      description
+        "When this leaf is set to true, it sets the 'Don't fragment'
+         (DF) bit in the IPv4 header for all sFLOW packets.  When set to
+         false the DF bit is not set.  If this leaf is not configured,
+         then the device may decide whether to set the DF bit for SFLOW
+         packets by default.
+
+         This leaf has no meaning for sFlow datagrams sent over IPv6
+         networks and should be ignored.";
+    }
+
     leaf network-instance {
       type oc-netinst:network-instance-ref;
       description

--- a/release/models/sampling/openconfig-sampling-sflow.yang
+++ b/release/models/sampling/openconfig-sampling-sflow.yang
@@ -165,19 +165,6 @@ module openconfig-sampling-sflow {
         "RFC 3176 - InMon Corporation's sFlow: sFlowRcvrMaximumDatagramSize.";
     }
 
-    leaf dont-fragment {
-      type boolean;
-      description
-        "When this leaf is set to true, it sets the 'Don't fragment'
-         (DF) bit in the IPv4 header for all sFLOW packets.  When set to
-         false the DF bit is not set.  If this leaf is not configured,
-         then the device may decide whether to set the DF bit for SFLOW
-         packets by default.
-
-         This leaf has no meaning for sFlow datagrams sent over IPv6
-         networks and should be ignored.";
-    }
-
     leaf network-instance {
       type oc-netinst:network-instance-ref;
       description

--- a/release/models/segment-routing/openconfig-segment-routing.yang
+++ b/release/models/segment-routing/openconfig-segment-routing.yang
@@ -36,7 +36,13 @@ module openconfig-segment-routing {
       - SR SID advertisements - instantiated within the relevant IGP.
       - SR-specific counters - instantied within the relevant dataplane.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "0.4.2";
+  
+  revision "2026-02-10" {
+    description
+      "Fix yanglint schema warnings";
+    reference "0.4.2";
+  }
 
   revision "2023-08-09" {
     description
@@ -130,7 +136,7 @@ module openconfig-segment-routing {
     }
 
     leaf-list mpls-label-blocks {
-      when "../dataplane-type = 'oc-srt:MPLS'" {
+      when "../dataplane-type = 'MPLS'" {
         description
           "Allow the MPLS label block to be specified only for SRGBs that are
           using the MPLS dataplane.";
@@ -147,7 +153,7 @@ module openconfig-segment-routing {
     }
 
     leaf-list ipv6-prefixes {
-      when "../dataplane-type = 'oc-srt:IPV6'" {
+      when "../dataplane-type = 'IPV6'" {
         description
           "Allow IPv6 prefixes to be specified only when the dataplane
           realisation of the SRGB is IPv6.";
@@ -198,7 +204,7 @@ module openconfig-segment-routing {
     }
 
     leaf mpls-label-block {
-      when "../dataplane-type = 'oc-srt:MPLS'" {
+      when "../dataplane-type = 'MPLS'" {
         description
           "Allow the MPLS label block to be specified only for SRLBs that are
           using the MPLS dataplane.";
@@ -213,7 +219,7 @@ module openconfig-segment-routing {
     }
 
     leaf ipv6-prefix {
-      when "../dataplane-type = 'oc-srt:IPV6'" {
+      when "../dataplane-type = 'IPV6'" {
         description
           "Allow IPv6 prefixes to be specified only when the dataplane
           realisation of the SRGB is IPv6.";


### PR DESCRIPTION
### Change Scope

* Fixing yanglint warnings (there were no warnings after this run).
* I've marked all of these as bugfixes.  In theory the changes are not backwards compatible, but generally the YANG would have been broken previously, so ...

### Platform Implementations

 * N/A.  No new nodes added or removed.

### Tree View

* N/A.  No changes to the tree have occurred.

The change involve:
- Adding the module prefix for when identities are referenced in when statements (YANG 1.1 requires this, but I suspect that these may be broken when evaluating when expressions for YANG 1).
- Removing module prefixes for enum values used in when expressions (these are just broken).
- Correcting some typos (e.g., TE_LINK_MAXIUMUM_RESERVABLE_BANDWIDTH => TE_LINK_MAXIMUM_RESERVABLE_BANDWIDTH)
- Deleting references to IPV4_ADDRESS_INDEX and IPV6_ADDRESS_INDEX which are not defined as identities.
- I've also fixed up some references in authz, pathz, certz, credz where the paths don't appear to be correct.  I've not convinced that the paths are necessarily correct after my changes (but they were more correct that before and I'm not an xpath expert).