### PR TITLE
allow-config-mismatch extension

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -9,9 +9,9 @@ module openconfig-interfaces {
 
   // import some basic types
   import ietf-interfaces { prefix ietf-if; }
-  import openconfig-yang-types { prefix oc-yang; }
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
   import openconfig-transport-types { prefix oc-opt-types; }
 
   // meta
@@ -1292,7 +1292,7 @@ module openconfig-interfaces {
           description
             "Configurable items at the subinterface level";
           oc-ext:telemetry-on-change;
-
+          oc-ext:allow-config-mismatch;
           uses subinterfaces-config;
         }
 
@@ -1346,6 +1346,7 @@ module openconfig-interfaces {
             "Configurable items at the global, physical interface
             level";
           oc-ext:telemetry-on-change;
+          oc-ext:allow-config-mismatch;
 
           uses interface-phys-config;
         }

--- a/release/models/openconfig-extensions.yang
+++ b/release/models/openconfig-extensions.yang
@@ -18,7 +18,13 @@ module openconfig-extensions {
     "This module provides extensions to the YANG language to allow
     OpenConfig specific functionality and meta-data to be defined.";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2026-02-04" {
+    description
+    "Add allow-config-mismatch extension.";
+    reference "1.0.0";
+  }
 
   revision "2025-01-02" {
     description
@@ -68,6 +74,15 @@ module openconfig-extensions {
     reference "0.1.0";
   }
 
+  extension allow-config-mismatch {
+    description
+      "This extension is applied to configuration leaves that may
+      contain values which mismatch or are invalid for currently
+      installed hardware.  The target must accepted these invalid
+      values and should generate a warning message.  In this case
+      the related hardware component is expected to be in an operational
+      down or error state.";
+  }
 
   // extension statements
   extension openconfig-version {

--- a/release/models/openconfig-extensions.yang
+++ b/release/models/openconfig-extensions.yang
@@ -76,8 +76,8 @@ module openconfig-extensions {
 
   extension allow-config-mismatch {
     description
-      "This extension is applied to configuration leaves that may
-      contain values which mismatch or are invalid for currently
+      "This extension is applied to configuration leaves or containers that
+      may contain values which mismatch or are invalid for currently
       installed hardware.  The target must accepted these invalid
       values and should generate a warning message.  In this case
       the related hardware component is expected to be in an operational


### PR DESCRIPTION
It is common for hardware to be installed in a device which does not 100% match the applied or newly set configuration.  In this scenario it is desirable to still accept the configuration and return a warning.  

For example, as a network operator I want to allow a device to have unexpected interface transceivers installed and still be able to push configuration changes to a device.  Without this behavior, a single unexcepted transceiver installed in a device would block all configuration changes.  Blocking these configuration changes can be much more operationally impacting than having a single interface be unavailable.  

One way to address this might be with a yang extension to annotate containers or leaves which should allow a configuration mismatch with the underlying hardware.

### Change Scope
* Introduce a new OpenConfig yang extension called `allow-config-mismatch`
* Annotate interfaces and subinterfaces containers to include `allow-config-mismatch`

