### PR TITLE
Add initial prefix filter

### DIFF
--- a/release/models/aft/.spec.yml
+++ b/release/models/aft/.spec.yml
@@ -4,9 +4,11 @@
     - yang/aft/openconfig-aft-counters.yang
     - yang/aft/openconfig-aft-types.yang
     - yang/aft/openconfig-aft-summary.yang
+    - yang/aft/openconfig-aft-global-filter.yang
   build:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/aft/openconfig-aft-network-instance.yang
     - yang/aft/openconfig-aft-counters.yang
     - yang/aft/openconfig-aft-summary.yang
+    - yang/aft/openconfig-aft-global-filter.yang
   run-ci: true

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description
@@ -194,6 +200,7 @@ submodule openconfig-aft-common {
       "Structural grouping describing a next-hop entry.";
 
     container next-hops {
+      config false;
       description
         "The list of next-hops that are to be used for entry within
         the AFT table. The structure of each next-hop is address
@@ -868,6 +875,7 @@ submodule openconfig-aft-common {
       "Logical grouping for groups of next-hops.";
 
     container next-hop-groups {
+      config false;
       description
         "Surrounding container for groups of next-hops.";
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -30,7 +30,7 @@ submodule openconfig-aft-common {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-ethernet {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -1,0 +1,72 @@
+submodule openconfig-aft-global-filter {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the global
+    filter configuration applicable to abstract forwarding tables.";
+
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance
+      AFT prefix filtering.";
+    reference "3.3.0";
+  }
+
+  grouping aft-global-filter-config {
+    description
+      "Configuration parameters for the AFT global filter.";
+
+    leaf policy-name {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions" +
+             "/oc-rpol:policy-definition/oc-rpol:config/oc-rpol:name";
+      }
+      description
+        "Reference to a routing policy that is used to filter the
+        prefixes that are installed into the AFT. Only prefixes that
+        are accepted by the referenced policy are installed.";
+    }
+  }
+
+  grouping aft-global-filter-structural {
+    description
+      "Structural grouping defining the schema for the global filter
+      applied to the abstract forwarding tables.";
+
+    container global-filter {
+      description
+        "Configuration and state for a global filter applied to the
+        AFT. The filter is used to restrict which prefixes are
+        installed into the AFT for the network instance.";
+
+      container config {
+        description
+          "Configuration parameters for the AFT global filter.";
+
+        uses aft-global-filter-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the AFT global filter.";
+
+        uses aft-global-filter-config;
+      }
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -21,8 +21,8 @@ submodule openconfig-aft-global-filter {
 
   revision "2026-03-10" {
     description
-      "Add global-filter container to support per-network-instance
-      AFT prefix filtering.";
+      "Add global-filter container to support per-network-instance and per
+      AFT filtering, with routing policy split by address family.";
     reference "3.3.0";
   }
 
@@ -30,15 +30,26 @@ submodule openconfig-aft-global-filter {
     description
       "Configuration parameters for the AFT global filter.";
 
-    leaf policy-name {
+    leaf ipv4-policy {
       type leafref {
         path "/oc-rpol:routing-policy/oc-rpol:policy-definitions" +
              "/oc-rpol:policy-definition/oc-rpol:config/oc-rpol:name";
       }
       description
         "Reference to a routing policy that is used to filter the
-        prefixes that are installed into the AFT. Only prefixes that
-        are accepted by the referenced policy are installed.";
+        IPv4 prefixes that are installed into the AFT. Only prefixes
+        that are accepted by the referenced policy are installed.";
+    }
+
+    leaf ipv6-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions" +
+             "/oc-rpol:policy-definition/oc-rpol:config/oc-rpol:name";
+      }
+      description
+        "Reference to a routing policy that is used to filter the
+        IPv6 prefixes that are installed into the AFT. Only prefixes
+        that are accepted by the referenced policy are installed.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -15,14 +15,14 @@ submodule openconfig-aft-global-filter {
 
   description
     "Submodule containing definitions of groupings for the global
-    filter configuration applicable to abstract forwarding tables.";
+     filter configuration applicable to abstract forwarding tables.";
 
   oc-ext:openconfig-version "3.3.0";
 
   revision "2026-03-10" {
     description
       "Add global-filter container to support per-network-instance and per
-      AFT filtering, with routing policy split by address family.";
+       AFT filtering, with routing policy split by address family.";
     reference "3.3.0";
   }
 
@@ -36,11 +36,11 @@ submodule openconfig-aft-global-filter {
       }
       description
         "Reference to a routing policy that is used to filter the
-        IPv6 prefixes that are installed into the AFT. Only prefixes
-        that are accepted by the referenced policy are installed.
-        The policy may, for example, use an explicit prefix set to
-        match prefixes, or match prefixes that are more specific than
-        a given prefix.";
+         IPv6 prefixes that are present in the FIB. Only prefixes
+         that are accepted by the referenced policy are streamed.
+         The policy may, for example, use an explicit prefix set to
+         match prefixes, or match prefixes that are more specific than
+         a given prefix.";
     }
 
     leaf ipv4-policy {
@@ -50,11 +50,11 @@ submodule openconfig-aft-global-filter {
       }
       description
         "Reference to a routing policy that is used to filter the
-        IPv4 prefixes that are installed into the AFT. Only prefixes
-        that are accepted by the referenced policy are installed.
-        The policy may, for example, use an explicit prefix set to
-        match prefixes, or match prefixes that are more specific than
-        a given prefix.";
+         IPv4 prefixes that are in the FIB. Only prefixes
+         that are accepted by the referenced policy are streamed.
+         The policy may, for example, use an explicit prefix set to
+         match prefixes, or match prefixes that are more specific than
+         a given prefix.";
     }
   }
 
@@ -62,13 +62,13 @@ submodule openconfig-aft-global-filter {
   grouping aft-global-filter-structural {
     description
       "Structural grouping defining the schema for the global filter
-      applied to the abstract forwarding tables.";
+       applied to the abstract forwarding tables.";
 
     container global-filter {
       description
         "Configuration and state for a global filter applied to the
-        AFT. The filter is used to restrict which prefixes are
-        installed into the AFT for the network instance.";
+         AFT. The filter is used to restrict which prefixes are
+         installed into the AFT for the network instance.";
 
       container config {
         description

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -29,6 +29,19 @@ submodule openconfig-aft-global-filter {
   grouping aft-global-filter-config {
     description
       "Configuration parameters for the AFT global filter.";
+    leaf ipv6-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions" +
+             "/oc-rpol:policy-definition/oc-rpol:config/oc-rpol:name";
+      }
+      description
+        "Reference to a routing policy that is used to filter the
+        IPv6 prefixes that are installed into the AFT. Only prefixes
+        that are accepted by the referenced policy are installed.
+        The policy may, for example, use an explicit prefix set to
+        match prefixes, or match prefixes that are more specific than
+        a given prefix.";
+    }
 
     leaf ipv4-policy {
       type leafref {
@@ -43,21 +56,8 @@ submodule openconfig-aft-global-filter {
         match prefixes, or match prefixes that are more specific than
         a given prefix.";
     }
-
-    leaf ipv6-policy {
-      type leafref {
-        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions" +
-             "/oc-rpol:policy-definition/oc-rpol:config/oc-rpol:name";
-      }
-      description
-        "Reference to a routing policy that is used to filter the
-        IPv6 prefixes that are installed into the AFT. Only prefixes
-        that are accepted by the referenced policy are installed.
-        The policy may, for example, use an explicit prefix set to
-        match prefixes, or match prefixes that are more specific than
-        a given prefix.";
-    }
   }
+
 
   grouping aft-global-filter-structural {
     description

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -38,7 +38,10 @@ submodule openconfig-aft-global-filter {
       description
         "Reference to a routing policy that is used to filter the
         IPv4 prefixes that are installed into the AFT. Only prefixes
-        that are accepted by the referenced policy are installed.";
+        that are accepted by the referenced policy are installed.
+        The policy may, for example, use an explicit prefix set to
+        match prefixes, or match prefixes that are more specific than
+        a given prefix.";
     }
 
     leaf ipv6-policy {
@@ -49,7 +52,10 @@ submodule openconfig-aft-global-filter {
       description
         "Reference to a routing policy that is used to filter the
         IPv6 prefixes that are installed into the AFT. Only prefixes
-        that are accepted by the referenced policy are installed.";
+        that are accepted by the referenced policy are installed.
+        The policy may, for example, use an explicit prefix set to
+        match prefixes, or match prefixes that are more specific than
+        a given prefix.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -6,7 +6,6 @@ module openconfig-aft-global-filter {
   import openconfig-network-instance { prefix "oc-ni"; }
   import openconfig-routing-policy { prefix "oc-rpol"; }
 
-
   organization
     "OpenConfig working group";
 

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -36,9 +36,9 @@ module openconfig-aft-global-filter {
       }
       description
         "Reference to a routing policy that is used to filter the
-         IPv6 prefixes that are streamed from the FIB.  This does
-         not affect which prefixes are installed in the FIB.
-         The policy may, for example, use an explicit prefix set to
+         IPv6 prefixes that are streamed from the FIB. This does
+         not affect which prefixes are installed in the FIB. The
+         policy may, for example, use an explicit prefix set to
          match prefixes, or match prefixes that are more specific than
          a given prefix.";
     }
@@ -50,9 +50,9 @@ module openconfig-aft-global-filter {
       }
       description
         "Reference to a routing policy that is used to filter the
-         IPv4 prefixes that are in the FIB. Only prefixes
-         that are accepted by the referenced policy are streamed.
-         The policy may, for example, use an explicit prefix set to
+         IPv4 prefixes that are streamed from the FIB. This does
+         not affect which prefixes are installed in the FIB. The
+         policy may, for example, use an explicit prefix set to
          match prefixes, or match prefixes that are more specific than
          a given prefix.";
     }

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -19,7 +19,6 @@ module openconfig-aft-global-filter {
 
   oc-ext:openconfig-version "3.3.0";
 
-
   revision "2026-03-10" {
     description
       "Add global-filter container to support per-network-instance and per

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -67,8 +67,15 @@ module openconfig-aft-global-filter {
     container global-filter {
       description
         "Configuration and state for a global filter applied to the
-         AFT. The filter is used to restrict which prefixes are
-         installed into the AFT for the network instance.";
+         AFT. The filter is used to restrict which prefixes from the
+         network instance's AFT are streamed via gNMI; it does not
+         affect which prefixes are installed in the forwarding plane
+         (hardware FIB). All gNMI clients subscribing to the IPv4 or
+         IPv6 AFT for this network instance will only receive data
+         corresponding to prefixes accepted by the configured
+         filter policy. Prefixes rejected by the policy are omitted
+         from the streamed AFT state for every subscriber, regardless
+         of the client.";
 
       container config {
         description

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -19,6 +19,7 @@ module openconfig-aft-global-filter {
 
   oc-ext:openconfig-version "3.3.0";
 
+
   revision "2026-03-10" {
     description
       "Add global-filter container to support per-network-instance and per

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -36,8 +36,8 @@ module openconfig-aft-global-filter {
       }
       description
         "Reference to a routing policy that is used to filter the
-         IPv6 prefixes that are present in the FIB. Only prefixes
-         that are accepted by the referenced policy are streamed.
+         IPv6 prefixes that are streamed from the FIB.  This does
+         not affect which prefixes are installed in the FIB.
          The policy may, for example, use an explicit prefix set to
          match prefixes, or match prefixes that are more specific than
          a given prefix.";

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -6,6 +6,7 @@ module openconfig-aft-global-filter {
   import openconfig-network-instance { prefix "oc-ni"; }
   import openconfig-routing-policy { prefix "oc-rpol"; }
 
+
   organization
     "OpenConfig working group";
 

--- a/release/models/aft/openconfig-aft-global-filter.yang
+++ b/release/models/aft/openconfig-aft-global-filter.yang
@@ -1,9 +1,9 @@
-submodule openconfig-aft-global-filter {
-  belongs-to "openconfig-aft" {
-    prefix "oc-aft";
-  }
+module openconfig-aft-global-filter {
+  namespace "http://openconfig.net/yang/aft/global-filter";
+  prefix "oc-aft-gf";
 
   import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
   import openconfig-routing-policy { prefix "oc-rpol"; }
 
   organization
@@ -14,7 +14,7 @@ submodule openconfig-aft-global-filter {
     www.openconfig.net";
 
   description
-    "Submodule containing definitions of groupings for the global
+    "Module containing definitions of groupings for the global
      filter configuration applicable to abstract forwarding tables.";
 
   oc-ext:openconfig-version "3.3.0";
@@ -85,5 +85,12 @@ submodule openconfig-aft-global-filter {
         uses aft-global-filter-config;
       }
     }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts" {
+    description
+      "Add global filter to AFT tree.";
+
+    uses aft-global-filter-structural;
   }
 }

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-ipv4 {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-ipv6 {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -28,7 +28,7 @@ submodule openconfig-aft-mpls {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -35,7 +35,7 @@ submodule openconfig-aft-pf {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -23,7 +23,7 @@ submodule openconfig-aft-state-synced {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/aft/openconfig-aft-summary.yang
+++ b/release/models/aft/openconfig-aft-summary.yang
@@ -39,6 +39,7 @@ module openconfig-aft-summary {
       "Grouping for protocol type state.";
 
     leaf origin-protocol {
+      config false;
       description
         "Protocol type that keys the protocol list.";
 
@@ -48,10 +49,12 @@ module openconfig-aft-summary {
     }
 
     container counters {
+      config false;
       description
       "Enclosing container for aft entry counters";
 
       leaf aft-entries {
+        config false;
         description
           "Total number of entries in the aft.";
         type uint64;

--- a/release/models/aft/openconfig-aft-summary.yang
+++ b/release/models/aft/openconfig-aft-summary.yang
@@ -20,7 +20,13 @@ module openconfig-aft-summary {
     "This module provides summary of aft entry counts per protocol type for each network
     instance.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2026-03-11" {
+    description
+      "Add config false to protocols and state containers.";
+    reference "0.2.1";
+  }
 
   revision "2024-01-12" {
     description
@@ -39,7 +45,6 @@ module openconfig-aft-summary {
       "Grouping for protocol type state.";
 
     leaf origin-protocol {
-      config false;
       description
         "Protocol type that keys the protocol list.";
 
@@ -49,12 +54,10 @@ module openconfig-aft-summary {
     }
 
     container counters {
-      config false;
       description
-      "Enclosing container for aft entry counters";
+        "Enclosing container for aft entry counters";
 
       leaf aft-entries {
-        config false;
         description
           "Total number of entries in the aft.";
         type uint64;
@@ -67,6 +70,7 @@ module openconfig-aft-summary {
       "A summary of aft entries by protocol type.";
 
     container protocols {
+      config false;
       description
         "Enclosing container for a list of protocols";
       list protocol {
@@ -84,6 +88,7 @@ module openconfig-aft-summary {
         }
 
         container state {
+          config false;
           description
             "State parameters for the aft entry list.";
           uses protocols-state;

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -22,6 +22,8 @@ module openconfig-aft {
   include openconfig-aft-common;
   // Include the state synced submodule.
   include openconfig-aft-state-synced;
+  // Include the global filter submodule.
+  include openconfig-aft-global-filter;
 
   organization
     "OpenConfig working group";
@@ -42,7 +44,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-03-10" {
+    description
+      "Add global-filter container to support per-network-instance AFT prefix filtering.";
+    reference "3.3.0";
+  }
 
   revision "2025-08-07" {
     description
@@ -222,7 +230,6 @@ module openconfig-aft {
       AFT.";
 
     container afts {
-      config false;
       description
         "The abstract forwarding tables (AFTs) that are associated
         with the network instance. An AFT is instantiated per-protocol
@@ -234,6 +241,7 @@ module openconfig-aft {
         forwarding entry.";
 
       container ipv4-unicast {
+        config false;
         description
           "The abstract forwarding table for IPv4 unicast. Entries
           within this table are uniquely keyed on the IPv4 unicast
@@ -248,6 +256,7 @@ module openconfig-aft {
       }
 
       container ipv6-unicast {
+        config false;
         description
           "The abstract forwarding table for IPv6 unicast. Entries
           within this table are uniquely keyed on the IPv6 unicast
@@ -262,6 +271,7 @@ module openconfig-aft {
       }
 
       container policy-forwarding {
+        config false;
         description
           "The abstract forwarding table for policy-based forwarding
           entries. Since multiple match criteria can be utilised
@@ -279,6 +289,7 @@ module openconfig-aft {
       }
 
       container mpls {
+        config false;
         description
           "The abstract forwarding table for MPLS label based
           forwarding entries. Entries within the table are keyed based
@@ -289,6 +300,7 @@ module openconfig-aft {
       }
 
       container ethernet {
+        config false;
         description
           "The abstract forwarding table for Ethernet based forwarding
           entries. Entries within the table are keyed based on the
@@ -298,6 +310,7 @@ module openconfig-aft {
       }
 
       container state-synced {
+        config false;
         description
           "In some cases AFT streaming (e.g., over gNMI) is an eventually consistent system.
           When the device updates an entry it is usually expected to
@@ -320,6 +333,7 @@ module openconfig-aft {
 
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
+      uses aft-global-filter-structural;
     }
   }
 }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -22,8 +22,6 @@ module openconfig-aft {
   include openconfig-aft-common;
   // Include the state synced submodule.
   include openconfig-aft-state-synced;
-  // Include the global filter submodule.
-  include openconfig-aft-global-filter;
 
   organization
     "OpenConfig working group";
@@ -333,7 +331,6 @@ module openconfig-aft {
 
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
-      uses aft-global-filter-structural;
     }
   }
 }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -49,7 +49,7 @@ module openconfig-aft {
       "Add global-filter container to support per-network-instance AFT prefix filtering.";
     reference "3.4.0";
   }
-  
+
   revision "2026-02-09" {
     description
       "Deprecate popped-mpls-label-stack and AFT NH pushed-mpls-label-stack

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -127,7 +127,7 @@ module openconfig-local-routing-network-instance {
     leaf name {
       description
         "A user defined name to reference a static next-hop-group.";
-      // we are at /network-instances/network-instance/protocols/protocol/static-routes/static/next-hop-group/config/name
+      // we are at /network-instances/network-instance/protocols/protocol/static-routes/static/next-hop-group/config/name	
       type leafref {
         path "../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }

--- a/release/models/local-routing/openconfig-local-routing-network-instance.yang
+++ b/release/models/local-routing/openconfig-local-routing-network-instance.yang
@@ -127,7 +127,7 @@ module openconfig-local-routing-network-instance {
     leaf name {
       description
         "A user defined name to reference a static next-hop-group.";
-      // we are at /network-instances/network-instance/protocols/protocol/static-routes/static/next-hop-group/config/name	
+      // we are at /network-instances/network-instance/protocols/protocol/static-routes/static/next-hop-group/config/name
       type leafref {
         path "../../../../../../../oc-ni:static/oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:config/oc-ni:name";
       }


### PR DESCRIPTION
### Change Scope

* We add a new container to filter the `afts` tree based on a named routing policy.
* The change is backwards compatible, though it marks `afts` as a `rw` container rather than a `ro` container since we're adding a configuration leaf.

### Platform Implementations

This request is being made without any existing implementations that I know of. We will be requesting this from the vendors. (and so we will need at least 2 approvals from different vendors)

### Tree View

```diff
-        +--ro afts
+        +--rw afts
         |  +--ro ipv4-unicast
         |  |  +--ro ipv4-entry* [prefix]
         |  |     +--ro prefix    -> ../state/prefix
         |  |     +--ro state
         |  |        +--ro prefix?               oc-inet:ipv4-prefix
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?          oc-yang:counter64
         |  |        |  x--ro octets-forwarded?           oc-yang:counter64
         |  |        |  x--ro packets-forwarded-backup?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded-backup?    oc-yang:counter64
         |  |        +--ro entry-metadata?       binary
         |  |        +--ro origin-protocol?      identityref
         |  |        +--ro decapsulate-header?   oc-aftt:encapsulation-header-type
         |  +--ro ipv6-unicast
         |  |  +--ro ipv6-entry* [prefix]
         |  |     +--ro prefix    -> ../state/prefix
         |  |     +--ro state
         |  |        +--ro prefix?               oc-inet:ipv6-prefix
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?          oc-yang:counter64
         |  |        |  x--ro octets-forwarded?           oc-yang:counter64
         |  |        |  x--ro packets-forwarded-backup?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded-backup?    oc-yang:counter64
         |  |        +--ro entry-metadata?       binary
         |  |        +--ro origin-protocol?      identityref
         |  |        +--ro decapsulate-header?   oc-aftt:encapsulation-header-type
         |  +--ro policy-forwarding
         |  |  +--ro policy-forwarding-entry* [index]
         |  |     +--ro index    -> ../state/index
         |  |     +--ro state
         |  |        +--ro index?            uint64
         |  |        +--ro ip-prefix?        oc-inet:ip-prefix
         |  |        +--ro mac-address?      oc-yang:mac-address
         |  |        +--ro mpls-label?       oc-mplst:mpls-label
         |  |        +--ro mpls-tc?          oc-mplst:mpls-tc
         |  |        +--ro ip-dscp?          oc-inet:dscp
         |  |        +--ro ip-protocol?      oc-pkt-match-types:ip-protocol-type
         |  |        +--ro l4-src-port?      oc-inet:port-number
         |  |        +--ro l4-dst-port?      oc-inet:port-number
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded?    oc-yang:counter64
         |  |        +--ro entry-metadata?   binary
         |  +--ro mpls
         |  |  +--ro label-entry* [label]
         |  |     +--ro label    -> ../state/label
         |  |     +--ro state
         |  |        +--ro label?                     oc-mplst:mpls-label
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded?    oc-yang:counter64
         |  |        +--ro entry-metadata?            binary
         |  |        +--ro popped-mpls-label-stack*   oc-mplst:mpls-label
         |  +--ro ethernet
         |  |  +--ro mac-entry* [mac-address]
         |  |     +--ro mac-address    -> ../state/mac-address
         |  |     +--ro state
         |  |        +--ro mac-address?      oc-yang:mac-address
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded?    oc-yang:counter64
         |  |        +--ro entry-metadata?   binary
         |  +--ro state-synced
         |  |  +--ro state
         |  |     +--ro ipv4-unicast?   boolean
         |  |     +--ro ipv6-unicast?   boolean
         |  +--ro next-hop-groups
         |  |  +--ro next-hop-group* [id]
         |  |     +--ro id             -> ../state/id
         |  |     +--ro state
         |  |     |  +--ro id?                      uint64
         |  |     |  +--ro next-hop-group-name?     string
         |  |     |  +--ro programmed-id?           uint64
         |  |     |  +--ro color?                   uint64
         |  |     |  +--ro backup-next-hop-group?   -> ../../../next-hop-group/state/id
         |  |     |  +--ro backup-active?           boolean
         |  |     +--ro next-hops
         |  |     |  +--ro next-hop* [index]
         |  |     |     +--ro index    -> ../state/index
         |  |     |     +--ro state
         |  |     |        +--ro index?    -> ../../../../../../next-hops/next-hop/state/index
         |  |     |        +--ro weight?   uint64
         |  |     +--ro conditional
         |  |        +--ro condition* [id]
         |  |           +--ro id                  -> ../state/id
         |  |           +--ro state
         |  |           |  +--ro id?               uint64
         |  |           |  +--ro dscp*             oc-inet:dscp
         |  |           |  +--ro next-hop-group?   -> ../../../../../next-hop-group/state/id
         |  |           +--ro input-interfaces
         |  |              +--ro input-interface* [id]
         |  |                 +--ro id       -> ../state/id
         |  |                 +--ro state
         |  |                    +--ro id?             string
         |  |                    +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |                    +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
         |  +--ro next-hops
-        |     +--ro next-hop* [index]
-        |        +--ro index            -> ../state/index
-        |        +--ro state
-        |        |  +--ro index?                     uint64
-        |        |  +--ro programmed-index?          uint64
-        |        |  +--ro ip-address?                oc-inet:ip-address
-        |        |  +--ro mac-address?               oc-yang:mac-address
-        |        |  +--ro pop-top-label?             boolean
-        |        |  +--ro pushed-mpls-label-stack*   oc-mplst:mpls-label
-        |        |  +--ro encapsulate-header?        oc-aftt:encapsulation-header-type
-        |        |  +--ro decapsulate-header?        oc-aftt:encapsulation-header-type
-        |        |  +--ro origin-protocol?           identityref
-        |        |  +--ro lsp-name?                  string
-        |        |  +--ro counters
-        |        |  |  x--ro packets-forwarded?   oc-yang:counter64
-        |        |  |  x--ro octets-forwarded?    oc-yang:counter64
-        |        |  +--ro vni-label?                 oc-evpn-types:evi-id
-        |        |  +--ro tunnel-src-ip-address?     oc-inet:ip-address
-        |        +--ro ip-in-ip
-        |        |  +--ro state
-        |        |     +--ro src-ip?   oc-inet:ip-address
-        |        |     +--ro dst-ip?   oc-inet:ip-address
-        |        +--ro gre
-        |        |  +--ro state
-        |        |     +--ro src-ip?   oc-inet:ip-address
-        |        |     +--ro dst-ip?   oc-inet:ip-address
-        |        |     +--ro ttl?      uint8
-        |        +--ro encap-headers
-        |        |  +--ro encap-header* [index]
-        |        |     +--ro index     -> ../state/index
-        |        |     +--ro state
-        |        |     |  +--ro index?   uint8
-        |        |     |  +--ro type?    oc-aftt:encapsulation-header-type
-        |        |     +--ro gre
-        |        |     |  +--ro state
-        |        |     |     +--ro src-ip?   oc-inet:ip-address
-        |        |     |     +--ro dst-ip?   oc-inet:ip-address
-        |        |     |     +--ro ttl?      uint8
-        |        |     +--ro ipv4
-        |        |     |  +--ro state
-        |        |     |     +--ro src-ip?   oc-inet:ip-address
-        |        |     |     +--ro dst-ip?   oc-inet:ip-address
-        |        |     +--ro ipv6
-        |        |     |  +--ro state
-        |        |     |     +--ro src-ip?   oc-inet:ip-address
-        |        |     |     +--ro dst-ip?   oc-inet:ip-address
-        |        |     +--ro mpls
-        |        |     |  +--ro state
-        |        |     |     +--ro traffic-class?      oc-mplst:mpls-tc
-        |        |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
-        |        |     +--ro udp-v4
-        |        |     |  +--ro state
-        |        |     |     +--ro src-ip?         oc-inet:ipv4-address
-        |        |     |     +--ro dst-ip?         oc-inet:ipv4-address
-        |        |     |     +--ro dscp?           oc-inet:dscp
-        |        |     |     +--ro src-udp-port?   oc-inet:port-number
-        |        |     |     +--ro dst-udp-port?   oc-inet:port-number
-        |        |     |     +--ro ip-ttl?         uint8
-        |        |     +--ro udp-v6
-        |        |     |  +--ro state
-        |        |     |     +--ro src-ip?         oc-inet:ipv6-address
-        |        |     |     +--ro dst-ip?         oc-inet:ipv6-address
-        |        |     |     +--ro dscp?           oc-inet:dscp
-        |        |     |     +--ro src-udp-port?   oc-inet:port-number
-        |        |     |     +--ro dst-udp-port?   oc-inet:port-number
-        |        |     |     +--ro ip-ttl?         uint8
-        |        |     +--ro vxlan
-        |        |        +--ro state
-        |        |           +--ro vni-label?               oc-evpn-types:evi-id
-        |        |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
-        |        +--ro interface-ref
-        |           +--ro state
-        |              +--ro interface?      -> /oc-if:interfaces/interface/name
-        |              +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
+        |  |  +--ro next-hop* [index]
+        |  |     +--ro index            -> ../state/index
+        |  |     +--ro state
+        |  |     |  +--ro index?                     uint64
+        |  |     |  +--ro programmed-index?          uint64
+        |  |     |  +--ro ip-address?                oc-inet:ip-address
+        |  |     |  +--ro mac-address?               oc-yang:mac-address
+        |  |     |  +--ro pop-top-label?             boolean
+        |  |     |  +--ro pushed-mpls-label-stack*   oc-mplst:mpls-label
+        |  |     |  +--ro encapsulate-header?        oc-aftt:encapsulation-header-type
+        |  |     |  +--ro decapsulate-header?        oc-aftt:encapsulation-header-type
+        |  |     |  +--ro origin-protocol?           identityref
+        |  |     |  +--ro lsp-name?                  string
+        |  |     |  +--ro counters
+        |  |     |  |  x--ro packets-forwarded?   oc-yang:counter64
+        |  |     |  |  x--ro octets-forwarded?    oc-yang:counter64
+        |  |     |  +--ro vni-label?                 oc-evpn-types:evi-id
+        |  |     |  +--ro tunnel-src-ip-address?     oc-inet:ip-address
+        |  |     +--ro ip-in-ip
+        |  |     |  +--ro state
+        |  |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     +--ro gre
+        |  |     |  +--ro state
+        |  |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     +--ro ttl?      uint8
+        |  |     +--ro encap-headers
+        |  |     |  +--ro encap-header* [index]
+        |  |     |     +--ro index     -> ../state/index
+        |  |     |     +--ro state
+        |  |     |     |  +--ro index?   uint8
+        |  |     |     |  +--ro type?    oc-aftt:encapsulation-header-type
+        |  |     |     +--ro gre
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro ttl?      uint8
+        |  |     |     +--ro ipv4
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     +--ro ipv6
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?   oc-inet:ip-address
+        |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
+        |  |     |     +--ro mpls
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro traffic-class?      oc-mplst:mpls-tc
+        |  |     |     |     +--ro mpls-label-stack*   oc-mplst:mpls-label
+        |  |     |     +--ro udp-v4
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?         oc-inet:ipv4-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ipv4-address
+        |  |     |     |     +--ro dscp?           oc-inet:dscp
+        |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro ip-ttl?         uint8
+        |  |     |     +--ro udp-v6
+        |  |     |     |  +--ro state
+        |  |     |     |     +--ro src-ip?         oc-inet:ipv6-address
+        |  |     |     |     +--ro dst-ip?         oc-inet:ipv6-address
+        |  |     |     |     +--ro dscp?           oc-inet:dscp
+        |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
+        |  |     |     |     +--ro ip-ttl?         uint8
+        |  |     |     +--ro vxlan
+        |  |     |        +--ro state
+        |  |     |           +--ro vni-label?               oc-evpn-types:evi-id
+        |  |     |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
+        |  |     +--ro interface-ref
+        |  |        +--ro state
+        |  |           +--ro interface?      -> /oc-if:interfaces/interface/name
+        |  |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
+        |  +--rw global-filter
+        |     +--rw config
+        |     |  +--rw ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |     |  +--rw ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |     +--ro state
+        |        +--ro ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |        +--ro ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
```

Notably,

```
+        |  +--rw global-filter
+        |     +--rw config
+        |     |  +--rw ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |     |  +--rw ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |     +--ro state
+        |        +--ro ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
+        |        +--ro ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
```

Is the part being added (and the rest are part of the diff because there's an extra `|` at the start of the line).

## Feature Profile Testing

Some of the functionality / expected behavior can be found in [this feature profile PR](https://github.com/openconfig/featureprofiles/pull/5217).