### PR TITLE
Deprecate source/destination flow-label and add single flow-label leaf

### DIFF
--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -31,7 +31,14 @@ module openconfig-packet-match {
     wildcard ('any') for that field.";
 
 
-  oc-ext:openconfig-version "2.3.0";
+  oc-ext:openconfig-version "2.4.0";
+
+  revision "2026-05-11" {
+    description
+      "Deprecate source/destination flow-label definitions and replace
+      with single IPv6 flow-label leaf.";
+    reference "2.4.0";
+  }
 
   revision "2026-03-25" {
     description
@@ -416,8 +423,13 @@ module openconfig-packet-match {
 
     leaf source-flow-label {
       type oc-inet:ipv6-flow-label;
+      status deprecated;
       description
-        "Source IPv6 Flow label.";
+        "Source IPv6 Flow label.
+
+        Deprecated: use flow-label instead.  The IPv6 header contains a
+        single flow-label field; there is no distinct source or
+        destination flow-label.";
     }
 
     leaf destination-address {
@@ -438,8 +450,19 @@ module openconfig-packet-match {
 
     leaf destination-flow-label {
       type oc-inet:ipv6-flow-label;
+      status deprecated;
       description
-        "Destination IPv6 Flow label.";
+        "Destination IPv6 Flow label.
+
+        Deprecated: use flow-label instead.  The IPv6 header contains a
+        single flow-label field; there is no distinct source or
+        destination flow-label.";
+    }
+
+    leaf flow-label {
+      type oc-inet:ipv6-flow-label;
+      description
+        "IPv6 Flow label.";
     }
 
     uses ip-protocol-fields-common-config;

--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -425,9 +425,7 @@ module openconfig-packet-match {
       type oc-inet:ipv6-flow-label;
       status deprecated;
       description
-        "Source IPv6 Flow label.
-
-        Deprecated: use flow-label instead.  The IPv6 header contains a
+        "Deprecated: use flow-label instead.  The IPv6 header contains a
         single flow-label field; there is no distinct source or
         destination flow-label.";
     }
@@ -452,9 +450,7 @@ module openconfig-packet-match {
       type oc-inet:ipv6-flow-label;
       status deprecated;
       description
-        "Destination IPv6 Flow label.
-
-        Deprecated: use flow-label instead.  The IPv6 header contains a
+        "Deprecated: use flow-label instead.  The IPv6 header contains a
         single flow-label field; there is no distinct source or
         destination flow-label.";
     }


### PR DESCRIPTION
  * (M) release/models/acl/openconfig-packet-match.yang
    - Deprecate source-flow-label and destination-flow-label
    - Add flow-label leaf to ipv6-protocol-fields-config grouping
    - Bump openconfig-version to 2.3.0

### Change Scope

The IPv6 header contains a single 20-bit flow-label field; there is no distinct source or destination flow-label. Deprecate source-flow-label and destination-flow-label in ipv6-protocol-fields-config and replace with a single flow-label leaf matching the actual header structure.

This was raised 6y back via https://github.com/openconfig/public/issues/346 but was never addressed and was closed/stale.

### Platform Implementations

N/A

### Tree View

```diff

         +--rw policy-forwarding
         |  +--rw config
         |  |  +--rw global-decap-policy?   string
         |  +--ro state
         |  |  +--ro global-decap-policy?   string
         |  +--rw policies
         |  |  +--rw policy* [policy-id]
         |  |     +--rw policy-id    -> ../config/policy-id
         |  |     +--rw config
         |  |     |  +--rw policy-id?   string
         |  |     |  +--rw type?        enumeration
         |  |     +--ro state
         |  |     |  +--ro policy-id?   string
         |  |     |  +--ro type?        enumeration
         |  |     +--rw rules
         |  |        +--rw rule* [sequence-id]
         |  |           +--rw sequence-id        -> ../config/sequence-id
         |  |           +--rw config
         |  |           |  +--rw sequence-id?      uint32
         |  |           |  +--rw address-family?   identityref
         |  |           |  +--rw description?      string
         |  |           +--ro state
         |  |           |  +--ro sequence-id?      uint32
         |  |           |  +--ro address-family?   identityref
         |  |           |  +--ro description?      string
         |  |           |  +--ro matched-pkts?     oc-yang:counter64
         |  |           |  +--ro matched-octets?   oc-yang:counter64
         |  |           +--rw l2
         |  |           |  +--rw config
         |  |           |  |  +--rw source-mac?             oc-yang:mac-address
         |  |           |  |  +--rw source-mac-mask?        oc-yang:mac-address
         |  |           |  |  +--rw destination-mac?        oc-yang:mac-address
         |  |           |  |  +--rw destination-mac-mask?   oc-yang:mac-address
         |  |           |  |  +--rw ethertype?              oc-pkt-match-types:ethertype-type
         |  |           |  +--ro state
         |  |           |     +--ro source-mac?             oc-yang:mac-address
         |  |           |     +--ro source-mac-mask?        oc-yang:mac-address
         |  |           |     +--ro destination-mac?        oc-yang:mac-address
         |  |           |     +--ro destination-mac-mask?   oc-yang:mac-address
         |  |           |     +--ro ethertype?              oc-pkt-match-types:ethertype-type
         |  |           +--rw ipv4
         |  |           |  +--rw config
         |  |           |  |  +--rw source-address?                   oc-inet:ipv4-prefix
         |  |           |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
         |  |           |  |  +--rw destination-address?              oc-inet:ipv4-prefix
         |  |           |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
         |  |           |  |  +--rw fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
         |  |           |  |  +--rw dscp?                             oc-inet:dscp
         |  |           |  |  +--rw dscp-set*                         oc-inet:dscp
         |  |           |  |  +--rw length?                           uint16
         |  |           |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
         |  |           |  |  +--rw hop-limit?                        uint8
         |  |           |  +--ro state
         |  |           |  |  +--ro source-address?                   oc-inet:ipv4-prefix
         |  |           |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
         |  |           |  |  +--ro destination-address?              oc-inet:ipv4-prefix
         |  |           |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
         |  |           |  |  +--ro fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
         |  |           |  |  +--ro dscp?                             oc-inet:dscp
         |  |           |  |  +--ro dscp-set*                         oc-inet:dscp
         |  |           |  |  +--ro length?                           uint16
         |  |           |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
         |  |           |  |  +--ro hop-limit?                        uint8
         |  |           |  +--rw icmpv4
         |  |           |     +--rw config
         |  |           |     |  +--rw type?   identityref
         |  |           |     |  +--rw code?   identityref
         |  |           |     +--ro state
         |  |           |        +--ro type?   identityref
         |  |           |        +--ro code?   identityref
         |  |           +--rw ipv6
         |  |           |  +--rw config
         |  |           |  |  +--rw source-address?                   oc-inet:ipv6-prefix
         |  |           |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-        |  |           |  |  +--rw source-flow-label?                oc-inet:ipv6-flow-label
+        |  |           |  |  x--rw source-flow-label?                oc-inet:ipv6-flow-label
         |  |           |  |  +--rw destination-address?              oc-inet:ipv6-prefix
         |  |           |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-        |  |           |  |  +--rw destination-flow-label?           oc-inet:ipv6-flow-label
+        |  |           |  |  x--rw destination-flow-label?           oc-inet:ipv6-flow-label
+        |  |           |  |  +--rw flow-label?                       oc-inet:ipv6-flow-label
         |  |           |  |  +--rw dscp?                             oc-inet:dscp
         |  |           |  |  +--rw dscp-set*                         oc-inet:dscp
         |  |           |  |  +--rw length?                           uint16
         |  |           |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
         |  |           |  |  +--rw hop-limit?                        uint8
         |  |           |  +--ro state
         |  |           |  |  +--ro source-address?                   oc-inet:ipv6-prefix
         |  |           |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-        |  |           |  |  +--ro source-flow-label?                oc-inet:ipv6-flow-label
+        |  |           |  |  x--ro source-flow-label?                oc-inet:ipv6-flow-label
         |  |           |  |  +--ro destination-address?              oc-inet:ipv6-prefix
         |  |           |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-        |  |           |  |  +--ro destination-flow-label?           oc-inet:ipv6-flow-label
+        |  |           |  |  x--ro destination-flow-label?           oc-inet:ipv6-flow-label
+        |  |           |  |  +--ro flow-label?                       oc-inet:ipv6-flow-label
         |  |           |  |  +--ro dscp?                             oc-inet:dscp
         |  |           |  |  +--ro dscp-set*                         oc-inet:dscp
         |  |           |  |  +--ro length?                           uint16
         |  |           |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
         |  |           |  |  +--ro hop-limit?                        uint8
         |  |           |  +--rw icmpv6
         |  |           |     +--rw config
         |  |           |     |  +--rw type?   identityref
         |  |           |     |  +--rw code?   identityref
         |  |           |     +--ro state
         |  |           |        +--ro type?   identityref
         |  |           |        +--ro code?   identityref
         |  |           +--rw transport
         |  |           |  +--rw config
         |  |           |  |  +--rw source-port?                  oc-pkt-match-types:port-num-range
         |  |           |  |  +--rw source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
         |  |           |  |  +--rw destination-port?             oc-pkt-match-types:port-num-range
         |  |           |  |  +--rw destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
         |  |           |  |  +--rw detail-mode?                  enumeration
         |  |           |  |  +--rw explicit-detail-match-mode?   enumeration
         |  |           |  |  +--rw explicit-tcp-flags*           identityref
         |  |           |  |  +--rw builtin-detail?               enumeration
         |  |           |  +--ro state
         |  |           |     +--ro source-port?                  oc-pkt-match-types:port-num-range
         |  |           |     +--ro source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
         |  |           |     +--ro destination-port?             oc-pkt-match-types:port-num-range
         |  |           |     +--ro destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
         |  |           |     +--ro detail-mode?                  enumeration
         |  |           |     +--ro explicit-detail-match-mode?   enumeration
         |  |           |     +--ro explicit-tcp-flags*           identityref
         |  |           |     +--ro builtin-detail?               enumeration
         |  |           +--rw action
         |  |           |  +--rw config
         |  |           |  |  x--rw discard?                           boolean
         |  |           |  |  +--rw decapsulate-gre?                   boolean
         |  |           |  |  +--rw decap-network-instance?            -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw decap-fallback-network-instance?   -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw log?                               boolean
         |  |           |  |  +--rw post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw network-instance?                  -> /network-instances/network-instance/config/name
         |  |           |  |  +--rw path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |           |  |  +--rw next-hop?                          oc-inet:ip-address
         |  |           |  |  +--rw next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |           |  |  +--rw decapsulate-mpls-in-udp?           boolean
         |  |           |  |  +--rw decapsulate-gue?                   boolean
         |  |           |  |  x--rw ip-ttl?                            uint8
         |  |           |  +--ro state
         |  |           |  |  x--ro discard?                           boolean
         |  |           |  |  +--ro decapsulate-gre?                   boolean
         |  |           |  |  +--ro decap-network-instance?            -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro decap-fallback-network-instance?   -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro log?                               boolean
         |  |           |  |  +--ro post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro network-instance?                  -> /network-instances/network-instance/config/name
         |  |           |  |  +--ro path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |           |  |  +--ro next-hop?                          oc-inet:ip-address
         |  |           |  |  +--ro next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |           |  |  +--ro decapsulate-mpls-in-udp?           boolean
         |  |           |  |  +--ro decapsulate-gue?                   boolean
         |  |           |  |  x--ro ip-ttl?                            uint8
         |  |           |  +--rw encapsulate-gre
         |  |           |  |  +--rw config
         |  |           |  |  |  +--rw identifying-prefix?   oc-inet:ip-prefix
         |  |           |  |  +--ro state
         |  |           |  |  |  +--ro identifying-prefix?   oc-inet:ip-prefix
         |  |           |  |  +--rw targets
         |  |           |  |     +--rw target* [id]
         |  |           |  |        +--rw id        -> ../config/id
         |  |           |  |        +--rw config
         |  |           |  |        |  +--rw id?            string
         |  |           |  |        |  +--rw source?        oc-inet:ip-address
         |  |           |  |        |  +--rw destination?   oc-inet:ip-prefix
         |  |           |  |        |  +--rw ip-ttl?        uint8
         |  |           |  |        +--ro state
         |  |           |  |           +--ro id?            string
         |  |           |  |           +--ro source?        oc-inet:ip-address
         |  |           |  |           +--ro destination?   oc-inet:ip-prefix
         |  |           |  |           +--ro ip-ttl?        uint8
         |  |           |  +--rw ipv4
         |  |           |  |  +--rw config
         |  |           |  |  |  +--rw dscp?   oc-inet-types:dscp
         |  |           |  |  |  +--rw ttl?    uint8
         |  |           |  |  +--ro state
         |  |           |  |     +--ro dscp?   oc-inet-types:dscp
         |  |           |  |     +--ro ttl?    uint8
         |  |           |  +--rw ipv6
         |  |           |  |  +--rw config
         |  |           |  |  |  +--rw dscp?        oc-inet-types:dscp
         |  |           |  |  |  +--rw hop-limit?   uint8
         |  |           |  |  +--ro state
         |  |           |  |     +--ro dscp?        oc-inet-types:dscp
         |  |           |  |     +--ro hop-limit?   uint8
         |  |           |  +--rw mpls
         |  |           |  |  +--rw config
         |  |           |  |  |  +--rw mpls-traffic-class?   oc-mplst:mpls-tc
         |  |           |  |  +--ro state
         |  |           |  |     +--ro mpls-traffic-class?   oc-mplst:mpls-tc
         |  |           |  +--rw forwarding
         |  |           |  |  +--rw config
         |  |           |  |  |  +--rw forwarding-action?      identityref
@@ -11493,216 +11495,218 @@
      |        |              +--ro matched-octets?    oc-yang:counter64
      |        +--rw queues
      |        |  +--rw queue* [name]
      |        |     +--rw name      -> ../config/name
      |        |     +--rw config
      |        |     |  +--rw name?                       string
      |        |     |  +--rw queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |        |     +--ro state
      |        |        +--ro name?                       string
      |        |        +--ro queue-management-profile?   -> ../../../../../../../queue-management-profiles/queue-management-profile/config/name
      |        |        +--ro max-queue-len?              oc-yang:counter64
      |        |        +--ro avg-queue-len?              oc-yang:counter64
      |        |        +--ro transmit-pkts?              oc-yang:counter64
      |        |        +--ro transmit-octets?            oc-yang:counter64
      |        |        +--ro dropped-pkts?               oc-yang:counter64
      |        |        +--ro dropped-octets?             oc-yang:counter64
      |        |        +--ro ecn-marked-pkts?            oc-yang:counter64
      |        |        +--ro ecn-marked-octets?          oc-yang:counter64
      |        |        +--ro ecn-selected-pkts?          oc-yang:counter64
      |        |        +--ro ecn-selected-octets?        oc-yang:counter64
      |        +--rw scheduler-policy
      |           +--rw config
      |           |  +--rw name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |           +--ro state
      |           |  +--ro name?   -> ../../../../../../scheduler-policies/scheduler-policy/config/name
      |           +--ro schedulers
      |              +--ro scheduler* [sequence]
      |                 +--ro sequence    -> ../state/sequence
      |                 +--ro state
      |                    +--ro sequence?            -> ../../../../../../../../scheduler-policies/scheduler-policy[name=current()/../../../../config/name]/schedulers/scheduler/config/sequence
      |                    +--ro conforming-pkts?     oc-yang:counter64
      |                    +--ro conforming-octets?   oc-yang:counter64
      |                    +--ro exceeding-pkts?      oc-yang:counter64
      |                    +--ro exceeding-octets?    oc-yang:counter64
      |                    +--ro violating-pkts?      oc-yang:counter64
      |                    +--ro violating-octets?    oc-yang:counter64
      +--rw classifiers
      |  +--rw classifier* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     |  +--rw type?   enumeration
      |     +--ro state
      |     |  +--ro name?   string
      |     |  +--ro type?   enumeration
      |     +--rw terms
      |        +--rw term* [id]
      |           +--rw id            -> ../config/id
      |           +--rw config
      |           |  +--rw id?   string
      |           +--ro state
      |           |  +--ro id?   string
      |           +--rw conditions
      |           |  +--rw l2
      |           |  |  +--rw config
      |           |  |  |  +--rw source-mac?             oc-yang:mac-address
      |           |  |  |  +--rw source-mac-mask?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac-mask?   oc-yang:mac-address
      |           |  |  |  +--rw ethertype?              oc-pkt-match-types:ethertype-type
      |           |  |  +--ro state
      |           |  |     +--ro source-mac?             oc-yang:mac-address
      |           |  |     +--ro source-mac-mask?        oc-yang:mac-address
      |           |  |     +--ro destination-mac?        oc-yang:mac-address
      |           |  |     +--ro destination-mac-mask?   oc-yang:mac-address
      |           |  |     +--ro ethertype?              oc-pkt-match-types:ethertype-type
      |           |  +--rw ipv4
      |           |  |  +--rw config
      |           |  |  |  +--rw source-address?                   oc-inet:ipv4-prefix
      |           |  |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--rw destination-address?              oc-inet:ipv4-prefix
      |           |  |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--rw fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
      |           |  |  |  +--rw dscp?                             oc-inet:dscp
      |           |  |  |  +--rw dscp-set*                         oc-inet:dscp
      |           |  |  |  +--rw length?                           uint16
      |           |  |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--rw hop-limit?                        uint8
      |           |  |  +--ro state
      |           |  |  |  +--ro source-address?                   oc-inet:ipv4-prefix
      |           |  |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--ro destination-address?              oc-inet:ipv4-prefix
      |           |  |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv4-prefix-sets/ipv4-prefix-set/name
      |           |  |  |  +--ro fragment-offsets*                 oc-pkt-match-types:fragment-offset-range
      |           |  |  |  +--ro dscp?                             oc-inet:dscp
      |           |  |  |  +--ro dscp-set*                         oc-inet:dscp
      |           |  |  |  +--ro length?                           uint16
      |           |  |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--ro hop-limit?                        uint8
      |           |  |  +--rw icmpv4
      |           |  |     +--rw config
      |           |  |     |  +--rw type?   identityref
      |           |  |     |  +--rw code?   identityref
      |           |  |     +--ro state
      |           |  |        +--ro type?   identityref
      |           |  |        +--ro code?   identityref
      |           |  +--rw ipv6
      |           |  |  +--rw config
      |           |  |  |  +--rw source-address?                   oc-inet:ipv6-prefix
      |           |  |  |  +--rw source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-     |           |  |  |  +--rw source-flow-label?                oc-inet:ipv6-flow-label
+     |           |  |  |  x--rw source-flow-label?                oc-inet:ipv6-flow-label
      |           |  |  |  +--rw destination-address?              oc-inet:ipv6-prefix
      |           |  |  |  +--rw destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-     |           |  |  |  +--rw destination-flow-label?           oc-inet:ipv6-flow-label
+     |           |  |  |  x--rw destination-flow-label?           oc-inet:ipv6-flow-label
+     |           |  |  |  +--rw flow-label?                       oc-inet:ipv6-flow-label
      |           |  |  |  +--rw dscp?                             oc-inet:dscp
      |           |  |  |  +--rw dscp-set*                         oc-inet:dscp
      |           |  |  |  +--rw length?                           uint16
      |           |  |  |  +--rw protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--rw hop-limit?                        uint8
      |           |  |  +--ro state
      |           |  |  |  +--ro source-address?                   oc-inet:ipv6-prefix
      |           |  |  |  +--ro source-address-prefix-set?        -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-     |           |  |  |  +--ro source-flow-label?                oc-inet:ipv6-flow-label
+     |           |  |  |  x--ro source-flow-label?                oc-inet:ipv6-flow-label
      |           |  |  |  +--ro destination-address?              oc-inet:ipv6-prefix
      |           |  |  |  +--ro destination-address-prefix-set?   -> /oc-sets:defined-sets/ipv6-prefix-sets/ipv6-prefix-set/name
-     |           |  |  |  +--ro destination-flow-label?           oc-inet:ipv6-flow-label
+     |           |  |  |  x--ro destination-flow-label?           oc-inet:ipv6-flow-label
+     |           |  |  |  +--ro flow-label?                       oc-inet:ipv6-flow-label
      |           |  |  |  +--ro dscp?                             oc-inet:dscp
      |           |  |  |  +--ro dscp-set*                         oc-inet:dscp
      |           |  |  |  +--ro length?                           uint16
      |           |  |  |  +--ro protocol?                         oc-pkt-match-types:ip-protocol-type
      |           |  |  |  +--ro hop-limit?                        uint8
      |           |  |  +--rw icmpv6
      |           |  |     +--rw config
      |           |  |     |  +--rw type?   identityref
      |           |  |     |  +--rw code?   identityref
      |           |  |     +--ro state
      |           |  |        +--ro type?   identityref
      |           |  |        +--ro code?   identityref
      |           |  +--rw transport
      |           |  |  +--rw config
      |           |  |  |  +--rw source-port?                  oc-pkt-match-types:port-num-range
      |           |  |  |  +--rw source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |  |  +--rw destination-port?             oc-pkt-match-types:port-num-range
      |           |  |  |  +--rw destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |  |  +--rw detail-mode?                  enumeration
      |           |  |  |  +--rw explicit-detail-match-mode?   enumeration
      |           |  |  |  +--rw explicit-tcp-flags*           identityref
      |           |  |  |  +--rw builtin-detail?               enumeration
      |           |  |  +--ro state
      |           |  |     +--ro source-port?                  oc-pkt-match-types:port-num-range
      |           |  |     +--ro source-port-set?              -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |     +--ro destination-port?             oc-pkt-match-types:port-num-range
      |           |  |     +--ro destination-port-set?         -> /oc-sets:defined-sets/port-sets/port-set/name
      |           |  |     +--ro detail-mode?                  enumeration
      |           |  |     +--ro explicit-detail-match-mode?   enumeration
      |           |  |     +--ro explicit-tcp-flags*           identityref
      |           |  |     +--ro builtin-detail?               enumeration
      |           |  +--rw mpls
      |           |     +--rw config
      |           |     |  +--rw traffic-class?       oc-mpls:mpls-tc
      |           |     |  +--rw start-label-value?   oc-mpls:mpls-label
      |           |     |  +--rw end-label-value?     oc-mpls:mpls-label
      |           |     |  +--rw ttl-value?           uint8
      |           |     +--ro state
      |           |        +--ro traffic-class?       oc-mpls:mpls-tc
      |           |        +--ro start-label-value?   oc-mpls:mpls-label
      |           |        +--ro end-label-value?     oc-mpls:mpls-label
      |           |        +--ro ttl-value?           uint8
      |           +--rw actions
      |              +--rw config
      |              |  +--rw target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--ro state
      |              |  +--ro target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--rw remark
      |                 +--rw config
      |                 |  +--rw set-dscp?      uint8
      |                 |  +--rw set-dot1p?     uint8
      |                 |  +--rw set-mpls-tc?   uint8
      |                 +--ro state
      |                    +--ro set-dscp?      uint8
      |                    +--ro set-dot1p?     uint8
      |                    +--ro set-mpls-tc?   uint8
      +--rw forwarding-groups
      |  +--rw forwarding-group* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?                     string
      |     |  +--rw fabric-priority?          uint8
      |     |  +--rw output-queue?             -> ../../../../queues/queue/config/name
      |     |  +--rw unicast-output-queue?     -> ../../../../queues/queue/config/name
      |     |  +--rw multicast-output-queue?   -> ../../../../queues/queue/config/name
      |     +--ro state
      |        +--ro name?                     string
      |        +--ro fabric-priority?          uint8
      |        +--ro output-queue?             -> ../../../../queues/queue/config/name
      |        +--ro unicast-output-queue?     -> ../../../../queues/queue/config/name
      |        +--ro multicast-output-queue?   -> ../../../../queues/queue/config/name
      +--rw queues
      |  +--rw queue* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?       string
      |     |  +--rw queue-id?   uint8
      |     +--ro state
      |        +--ro name?       string
      |        +--ro queue-id?   uint8
      +--rw scheduler-policies
      |  +--rw scheduler-policy* [name]
      |     +--rw name          -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     +--ro state
      |     |  +--ro name?   string
      |     +--rw schedulers
      |        +--rw scheduler* [sequence]
      |           +--rw sequence                -> ../config/sequence
      |           +--rw config
      |           |  +--rw sequence?   uint32
      |           |  +--rw type?       identityref
      |           |  +--rw priority?   enumeration
      |           +--ro state
      |           |  +--ro sequence?   uint32
      |           |  +--ro type?       identityref
      |           |  +--ro priority?   enumeration
      |           +--rw inputs
      |           |  +--rw input* [id]
```
