### PR TITLE
Add rtt to openconfig-wifi-mac.yang

### DIFF
--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,7 +26,7 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.4.3";
+  oc-ext:openconfig-version "1.5.0";
 
   revision "2026-03-23" {
     description "Add RTT-enable to SSID config.";

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -612,7 +612,7 @@ module openconfig-wifi-mac {
     description
       "802.11mc RTT (Round Trip Time) configuration, per SSID.";
 
-    leaf rtt {
+    leaf enabled {
       type boolean;
       description
         "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -144,15 +144,15 @@ module openconfig-wifi-mac {
         "Whether this SSID IE is hidden within Beacons.";
     }
     leaf enable-rtt {
-          type boolean;
-          default false;
-          description
-            "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),
-             also known as Round Trip Time (RTT), is enabled for clients
-             associated with this SSID. When set to 'true', the Access Point
-             will respond to FTM requests from clients, allowing them to
-             perform accurate distance measurements. When 'false', FTM
-             responses are disabled for this SSID.";
+      type boolean;
+      default "false";
+      description
+        "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM), 
+        also known as Round Trip Time (RTT), is enabled for clients 
+        associated with this SSID. When set to 'true', the Access Point 
+        will respond to FTM requests from clients, allowing them to 
+        perform accurate distance measurements. When 'false', FTM 
+        responses are disabled for this SSID.";
     }
 
     leaf default-vlan {

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -32,7 +32,7 @@ module openconfig-wifi-mac {
     description "Add RTT-enable to SSID config.";
     reference "1.4.3";
   }
-  
+
   revision "2026-01-06" {
     description "Add tx-beacons counter to BSSID state.";
     reference "1.4.2";

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -26,8 +26,13 @@ module openconfig-wifi-mac {
   description
     "Model for managing MAC layer configuration of Radio interfaces.";
 
-  oc-ext:openconfig-version "1.4.2";
+  oc-ext:openconfig-version "1.4.3";
 
+  revision "2026-03-23" {
+    description "Add RTT-enable to SSID config.";
+    reference "1.4.3";
+  }
+  
   revision "2026-01-06" {
     description "Add tx-beacons counter to BSSID state.";
     reference "1.4.2";

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -147,11 +147,11 @@ module openconfig-wifi-mac {
       type boolean;
       default "false";
       description
-        "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM), 
-        also known as Round Trip Time (RTT), is enabled for clients 
-        associated with this SSID. When set to 'true', the Access Point 
-        will respond to FTM requests from clients, allowing them to 
-        perform accurate distance measurements. When 'false', FTM 
+        "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),
+        also known as Round Trip Time (RTT), is enabled for clients
+        associated with this SSID. When set to 'true', the Access Point
+        will respond to FTM requests from clients, allowing them to
+        perform accurate distance measurements. When 'false', FTM
         responses are disabled for this SSID.";
     }
 

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -143,6 +143,17 @@ module openconfig-wifi-mac {
       description
         "Whether this SSID IE is hidden within Beacons.";
     }
+    leaf enable-rtt {
+          type boolean;
+          default false;
+          description
+            "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),
+             also known as Round Trip Time (RTT), is enabled for clients
+             associated with this SSID. When set to 'true', the Access Point
+             will respond to FTM requests from clients, allowing them to
+             perform accurate distance measurements. When 'false', FTM
+             responses are disabled for this SSID.";
+    }
 
     leaf default-vlan {
       type oc-vlan-types:vlan-id;

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -28,8 +28,8 @@ module openconfig-wifi-mac {
 
   oc-ext:openconfig-version "1.5.0";
 
-  revision "2026-03-23" {
-    description "Add RTT-enable to SSID config.";
+  revision "2026-03-24" {
+    description "Add 802.11mc RTT configuration and state containers.";
     reference "1.5.0";
   }
 
@@ -147,17 +147,6 @@ module openconfig-wifi-mac {
       default "false";
       description
         "Whether this SSID IE is hidden within Beacons.";
-    }
-    leaf enable-rtt {
-      type boolean;
-      default "false";
-      description
-        "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),
-        also known as Round Trip Time (RTT), is enabled for clients
-        associated with this SSID. When set to 'true', the Access Point
-        will respond to FTM requests from clients, allowing them to
-        perform accurate distance measurements. When 'false', FTM
-        responses are disabled for this SSID.";
     }
 
     leaf default-vlan {
@@ -616,6 +605,22 @@ module openconfig-wifi-mac {
       type boolean;
       description
         "Enable Multi-Link Operation";
+    }
+  }
+
+  grouping rtt-config {
+    description
+      "802.11mc RTT (Round Trip Time) configuration, per SSID.";
+
+    leaf rtt {
+      type boolean;
+      description
+        "Configures whether IEEE 802.11mc Fine Timing Measurement (FTM),
+        also known as Round Trip Time (RTT), is enabled for clients
+        associated with this SSID. When set to 'true', the Access Point
+        will respond to FTM requests from clients, allowing them to
+        perform accurate distance measurements. When 'false', FTM
+        responses are disabled for this SSID.";
     }
   }
 
@@ -1811,6 +1816,31 @@ module openconfig-wifi-mac {
     }
   }
 
+  grouping rtt-top {
+    description
+      "Top-level grouping for RTT configuration and operational
+      state data.";
+
+    container rtt {
+      description
+        "Top-level container for RTT configuration and
+        state container.";
+
+      container config {
+        description
+          "Container for RTT configuration elements.";
+        uses rtt-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Container for RTT state elements.";
+        uses rtt-config;
+      }
+    }
+  }
+
   grouping ssid-top {
     description
       "Top-level grouping for SSID configuration and operational state
@@ -1856,6 +1886,7 @@ module openconfig-wifi-mac {
         uses dot1x-timers-top;
         uses band-steering-top;
         uses mlo-top;
+        uses rtt-top;
       }
     }
   }

--- a/release/models/wifi/openconfig-wifi-mac.yang
+++ b/release/models/wifi/openconfig-wifi-mac.yang
@@ -30,7 +30,7 @@ module openconfig-wifi-mac {
 
   revision "2026-03-23" {
     description "Add RTT-enable to SSID config.";
-    reference "1.4.3";
+    reference "1.5.0";
   }
 
   revision "2026-01-06" {


### PR DESCRIPTION
**Scope Update:**
- Initially, this PR introduced 802.11mc Fine Timing Measurement (RTT) as a standalone configuration leaf. 
- To better align with OpenConfig style guidelines and to future-proof the schema for additional RTT-related attributes (e.g., burst duration, timers, or thresholds), the model has been refactored. 
- RTT configuration and state are now encapsulated in a dedicated `rtt` container under the `ssid` list, featuring explicit `config` and `state` subcontainers. 
- The `openconfig-wifi-mac.yang` version has been bumped to `1.5.0` to reflect these additions.

### Related Issue
Closes #1450

### Platform Implementations
- Implementation A: Arista currently supports this via the CLI and through an OpenConfig vendor augment. The goal is to integrate this into the OpenConfig model for long-term support.
- Implementation B: Aruba currently supports this via the CLI. The goal is to integrate this into the OpenConfig model for long-term support.
### New Tree View

```diff
module: openconfig-wifi-mac
  +--rw ssids
     +--rw ssid* [name]
        +--rw name                 -> ../config/name
        +--rw config
        |  +--rw name?                      string
        |  +--rw enabled?                   boolean
        |  ...
        +--ro state
        |  ...
        +--ro bssids
        |  ...
        +--rw wmm
        |  ...
+        +--rw rtt
+           +--rw config
+           |  +--rw enabled   boolean
+           +--ro state
+              +--ro enabled   boolean