### PR TITLE
platform: add fault description leaf and ACTION_FW_REPROGRAM

### DIFF
--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -149,7 +149,7 @@ module openconfig-platform-healthz-fault {
       force-reprogramming all FPGAs and reloading
       all drivers on the Chassis.
       This reprogramming would be to the currently-installed
-      version, not the factory default version."
+      version, not the factory default version.";
   }
 
   grouping platform-health-faults {

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -310,6 +310,12 @@ module openconfig-platform-healthz-fault {
               disruptive.";
           }
 
+          leaf description {
+            type string;
+            description
+              "Description for the remediating action";
+          }
+
           leaf action {
             description
               "The specific action to be performed";

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -136,9 +136,21 @@ module openconfig-platform-healthz-fault {
     base ACTION_BASE;
     description
       "Force-reprogram the firmware for the targeted component.
+      In many cases where this action is required, the targeted
+      component must be powercycled for the reprogramming
+      to take effect.
+
+      In comparison to ACTION_FACTORY_RESET action,
+      ACTION_FW_REPROGRAM does not necessarily involve resetting
+      the firmware back to its factory default. It also does not
+      involve resetting any certificates on disk or removing
+      any config files or OS images.
+
       E.g. for the Chassis component this could mean
       force-reprogramming all FPGAs and reloading
-      all drivers on the Chassis";
+      all drivers on the Chassis.
+      This reprogramming would be to the currently-installed
+      version, not the factory default version."
   }
 
   grouping platform-health-faults {

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -136,9 +136,8 @@ module openconfig-platform-healthz-fault {
     base ACTION_BASE;
     description
       "Force-reprogram the firmware for the targeted component.
-      In many cases where this action is required, the targeted
-      component must be powercycled for the reprogramming
-      to take effect.
+      The targeted component may need to be powercycled
+      for the reprogramming to take effect.
 
       In comparison to ACTION_FACTORY_RESET action,
       ACTION_FW_REPROGRAM does not necessarily involve resetting

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -135,7 +135,10 @@ module openconfig-platform-healthz-fault {
   identity ACTION_FW_REPROGRAM {
     base ACTION_BASE;
     description
-      "Force-reprogram all FPGA images and reload drivers";
+      "Force-reprogram the firmware for the targeted component.
+      E.g. for the Chassis component this could mean
+      force-reprogramming all FPGAs and reloading
+      all drivers on the Chassis";
   }
 
   grouping platform-health-faults {

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -23,7 +23,13 @@ module openconfig-platform-healthz-fault {
   description
     "This model defines device reported fault";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2026-03-23" {
+    description
+      "Add ACTION_FW_REPROGRAM";
+    reference "0.1.1";
+  }
 
   revision "2025-08-05" {
     description
@@ -124,6 +130,12 @@ module openconfig-platform-healthz-fault {
     base ACTION_BASE;
     description
       "Replace component.";
+  }
+
+  identity ACTION_FW_REPROGRAM {
+    base ACTION_BASE;
+    description
+      "Force-reprogram all FPGA images and reload drivers";
   }
 
   grouping platform-health-faults {

--- a/release/models/platform/openconfig-platform-healthz-fault.yang
+++ b/release/models/platform/openconfig-platform-healthz-fault.yang
@@ -27,7 +27,7 @@ module openconfig-platform-healthz-fault {
 
   revision "2026-03-23" {
     description
-      "Add ACTION_FW_REPROGRAM";
+      "Add remediation description and ACTION_FW_REPROGRAM";
     reference "0.1.1";
   }
 


### PR DESCRIPTION
### Change Scope

* Add an action identity `ACTION_FW_REPROGRAM ` to represent the case where the network operator should reprogram a component.
* Add a `description` leaf at `/components/component/healthz/faults/fault/remediations/remediation/state/description` to allow vendors to provide more platform specific information about a particular remediating action. 
* this change is backward compatible

### Platform Implementations

* I am unaware of any publicly available documentation mentioning existing implementations of support for fault reporting over YANG via this model.

### Tree View

This change adds the `description` leaf at:
```
  augment /oc-platform:components/oc-platform:component/oc-platform-healthz:healthz:
    +--rw faults
       +--ro fault* [symptom]
          +--ro remediations
             +--ro remediation* [index]
                +--ro state
                   +--ro description?   string
```

