### PR TITLE
openconfig macsec sak-rekey-on-live-peer-loss description update

### DIFF
--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -18,7 +18,7 @@ module openconfig-macsec {
     "This module defines configuration and state data for
      MACsec IEEE Std 802.1AE-2018.";
 
-  oc-ext:openconfig-version "1.2.0";
+  oc-ext:openconfig-version "1.2.1";
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
@@ -662,7 +662,7 @@ module openconfig-macsec {
       description
         "When set to true, the loss of a peer triggers sak rekey only if the MKA
          session still has other live peers. If no live peers remain, the rekey
-         behaviour is determined by the configured traffic policy. Depending on
+         behavior is determined by the configured traffic policy. Depending on
          the policy, the implementation may continue using the currently active
          SAK to allow ongoing traffic or remove the SAK.";
     }

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -23,6 +23,12 @@ module openconfig-macsec {
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
+  revision "2026-03-24" {
+    description
+      "Updating description of openconfig/macsec leaf sak-rekey-on-live-peer-loss.";
+    reference "1.2.1";
+  }
+
   revision "2025-01-02" {
     description
       "Add include-sci to allow enable/disable of secure channel
@@ -36,7 +42,7 @@ module openconfig-macsec {
     reference "1.1.1";
   }
 
-revision "2023-06-08" {
+  revision "2023-06-08" {
     description
       "Support rx-late-pkts leaf.";
     reference "1.1.0";

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -654,7 +654,11 @@ revision "2023-06-08" {
       type boolean;
       default "false";
       description
-        "Rekey on peer loss";
+        "When set to true, the loss of a peer triggers sak rekey only if the MKA
+         session still has other live peers. If no live peers remain, the rekey
+         behaviour is determined by the configured traffic policy. Depending on
+         the policy, the implementation may continue using the currently active
+         SAK to allow ongoing traffic or remove the SAK.";
     }
 
     leaf use-updated-eth-header {

--- a/release/models/macsec/openconfig-macsec.yang
+++ b/release/models/macsec/openconfig-macsec.yang
@@ -660,11 +660,14 @@ module openconfig-macsec {
       type boolean;
       default "false";
       description
-        "When set to true, the loss of a peer triggers sak rekey only if the MKA
-         session still has other live peers. If no live peers remain, the rekey
-         behavior is determined by the configured traffic policy. Depending on
-         the policy, the implementation may continue using the currently active
-         SAK to allow ongoing traffic or remove the SAK.";
+		  "When set to true, the loss of a peer triggers a SAK rekey only if the
+			MKA session still has other live peers. If the peer loss results in no
+			live peers remaining in the MKA session, an automatic rekey is not
+			triggered. Instead, the security-policy leaf configuration determines
+			the subsequent behavior. Based on the security-policy leaf configuration,
+			the system may retain the currently active SAK to allow encrypted traffic
+			exchange, or it may immediately remove the SAK to halt or allow unencrypted
+			transmission.";
     }
 
     leaf use-updated-eth-header {


### PR DESCRIPTION
### Change Scope

* The current description of this leaf is "Rekey on peer loss." . This description should be updated to clearly state that when this leaf is set to "True", a peer loss will trigger a rekey only if the MKA key-server peer still has live peers available. If there are no live peers, the rekey behaviour will depend on the traffic policy ( https://github.com/openconfig/public/pull/1430 ).
* Updating the description of openconfig/public/macsec leaf sak-rekey-on-live-peer-loss to take [security-policy](https://github.com/openconfig/public/pull/1430 ) into account while defining the expected behaviour.
* This change is backward compatible.

### Related Issues

Fixes #1446 

### Platform Implementations

Implementation A: AristaNetworks
When the traffic policy is "traffic unprotected allow active-sak" (Arista), the MACsec KaY will not perform a rekey on live peer loss. Instead, preserves the current SAK, and allows traffic exchange to continue using that SAK when there are no live peers.
```
mac security
   profile FALLBACK_PROFILE
      key 0abcd... 0 password123
      traffic unprotected allow active-sak
!
interface Ethernet1
   mac security profile FALLBACK_PROFILE

```
If the policy is `traffic unprotected allow` or `traffic unprotected drop` then the traffic will be handled accordingly, when the session fails. No sak rekey required.

### Tree View
No changes to tree view
