### PR TITLE
Add packet trim configuration

### DIFF
--- a/release/models/acl/openconfig-packet-match.yang
+++ b/release/models/acl/openconfig-packet-match.yang
@@ -31,7 +31,13 @@ module openconfig-packet-match {
     wildcard ('any') for that field.";
 
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.3.0";
+
+  revision "2026-03-25" {
+    description
+      "Add internal switching fabric parameters";
+    reference "2.3.0";
+  }
 
   revision "2025-06-10" {
     description
@@ -739,4 +745,48 @@ module openconfig-packet-match {
     }
   }
 
+  grouping fabric-params-top {
+    description
+      "Top-level grouping for parameters related to the internal
+       switching fabric of the device.";
+
+    container fabric {
+      description
+        "Enclosing container for managing device-specific fabric
+         attributes.";
+
+      container config {
+        description
+          "Configuration parameters relating to fabric
+          parameters.";
+
+        uses fabric-params-config;
+      }
+
+      container state {
+        description
+          "Operational state parameters relating to fabric
+          parameters.";
+        config false;
+
+        uses fabric-params-config;
+      }
+    }
+  }
+
+  grouping fabric-params-config {
+    description
+      "Top-level grouping for configurable parameters related to the
+      internal switching fabric of the device.";
+    leaf fabric-priority {
+      type uint8;
+      description
+        "Specifies the priority for the forwarding group for local
+         transmission through the device (e.g., across the internal
+         switching fabric). The priority is expressed as a numerical
+         value where higher values indicate higher precedence. For
+         example, traffic with fabric priority 128 is treated with
+         higher priority than traffic with fabric priority 0.";
+    }
+  }
 }

--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -35,7 +35,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2026-03-25" {
+    description
+      "Add fabric parameters for classifier.";
+    reference "2.1.0";
+  }
 
   revision "2026-01-24" {
     description
@@ -257,6 +263,7 @@ submodule openconfig-qos-elements {
             uses oc-pkt-match:ipv6-protocol-fields-top;
             uses oc-pkt-match:transport-fields-top;
             uses oc-pkt-match:mpls-header-top;
+            uses oc-pkt-match:fabric-params-top;
         }
 
         container actions {

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2026-03-25" {
+    description
+      "Bump version to 2.1.0";
+    reference "2.1.0";
+  }
 
   revision "2026-01-24" {
     description

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -29,7 +29,7 @@ submodule openconfig-qos-interfaces {
 
   revision "2026-03-25" {
     description
-      "Bump version to 2.1.0";
+      "Add parameters for packet trimming configuration";
     reference "2.1.0";
   }
 

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -355,7 +355,7 @@ revision "2023-07-26" {
         "Flag to enable packet trimming per queue. If leaf is set
          to false, the packet should be completely discard,
          effectively silent dropping without preserving any part
-         of the data. If leaf is set to false, packet would be
+         of the data. If leaf is set to true, packet would be
          trimmed instead of fully dropped. Typically, this involves
          truncating the payload while preserving the packet header
          for notification or diagnostic purposes.";

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -353,12 +353,12 @@ revision "2023-07-26" {
 
       description
         "Flag to enable packet trimming per queue. If leaf is set
-         to false, the packet should be completely discard,
-         effectively silent dropping without preserving any part
-         of the data. If leaf is set to true, packet would be
-         trimmed instead of fully dropped. Typically, this involves
-         truncating the payload while preserving the packet header
-         for notification or diagnostic purposes.";
+         to false, the packet should be completely discarded,
+         without preserving any part of the data. If leaf is set to
+         true, the packet must be trimmed instead of discarded.
+         Typically, this involves truncating the payload while
+         preserving the packet header for notification or
+         diagnostic purposes.";
     }
   }
 

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,13 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2026-03-25" {
+    description
+      "Add packet discard action at queue level.";
+    reference "2.1.0";
+  }
 
   revision "2026-01-24" {
     description
@@ -340,6 +346,19 @@ revision "2023-07-26" {
         maximum buffer space from the shared pool that the queue is allowed to use is
         calculated as (free buffer * 2^scaling factor) ie. 10MB*2^3 = 80MB. Since the
         current usage is 79MB which is < 80MB, the packet is queued.";
+    }
+
+    leaf trim-enable {
+      type boolean;
+
+      description
+        "Flag to enable packet trimming per queue. If leaf is set
+         to false, the packet should be completely discard,
+         effectively silent dropping without preserving any part
+         of the data. If leaf is set to false, packet would be
+         trimmed instead of fully dropped. Typically, this involves
+         truncating the payload while preserving the packet header
+         for notification or diagnostic purposes.";
     }
   }
 

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,13 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "2.0.1";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2026-03-25" {
+    description
+      "Add parameters for packet trimming configuration";
+    reference "2.1.0";
+  }
 
   revision "2026-01-24" {
     description
@@ -169,6 +175,52 @@ revision "2023-07-26" {
       "Operational state data for global QoS";
   }
 
+  grouping qos-packet-trim-top {
+    description
+      "Top-level grouping for packet trimming.";
+
+    container packet-trim {
+      description
+        "Container for switch level packet trimming
+        parameters.";
+
+      container config {
+        description
+          "Configuration data for switch level packet
+          trimming parameters.";
+
+        uses packet-trim-config;
+      }
+      container state {
+        description
+          "Operational state data for switch level packet
+          trimming parameters.";
+        config false;
+
+        uses packet-trim-config;
+      }
+    }
+  }
+
+  grouping packet-trim-config {
+    description
+      "Top-level grouping for switch level packet
+      trimming parameters";
+    leaf symmetric-dscp {
+      type uint8;
+      description
+        "The DSCP value for the notification packet
+        (sometimes called a 'symmetric packet') sent back
+        to the source when a packet is trimmed.";
+    }
+    leaf fabric-priority {
+      type uint8;
+      description
+        "Traffic class used to transmit trimmed
+        packets.";
+    }
+  }
+
   grouping qos-top {
     description
       "Top-level grouping for QoS model";
@@ -185,10 +237,10 @@ revision "2023-07-26" {
       }
 
       container state {
-        config false;
         description
           "Operational state data for global QoS";
 
+        config false;
         uses qos-config;
         uses qos-state;
       }
@@ -200,6 +252,7 @@ revision "2023-07-26" {
       uses qos-scheduler-top;
       uses qos-buffer-profile-top;
       uses qos-queue-mgmt-profile-top;
+      uses qos-packet-trim-top;
     }
   }
 


### PR DESCRIPTION
### Change Scope

* Add parameters to support packet trimming.
* This change is backwards compatible.

### Platform Implementations

 * Implementation A: [Sonic HLD](https://github.com/sonic-net/SONiC/blob/master/doc/packet_trimming/packet-trimming-design.md).
 * Implementation B: [Nvidia Supports](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-514/Layer-1-and-Switch-Ports/Quality-of-Service/Packet-Trimming/).

### Tree View

```diff
 module: openconfig-qos
   +--rw qos
      +--rw classifiers
      |  +--rw classifier* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     |  +--rw type?   enumeration
      |     +--ro state
      |     |  +--ro name?   string
      |     |  +--ro type?   enumeration
      |     +--rw terms
      |        +--rw term* [id]
      |           +--rw id            -> ../config/id
      |           +--rw config
      |           |  +--rw id?   string
      |           +--ro state
      |           |  +--ro id?   string
      |           +--rw conditions
      |           |  +--rw l2
      |           |  |  +--rw config
      |           |  |  |  +--rw source-mac?             oc-yang:mac-address
      |           |  |  |  +--rw source-mac-mask?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac?        oc-yang:mac-address
      |           |  |  |  +--rw destination-mac-mask?   oc-yang:mac-address
      |           |  |  |  +--rw ethertype?              oc-pkt-match-types:ethertype-type
      |           |  |  +--ro state
      |           |  |     +--ro source-mac?             oc-yang:mac-address
      |           |  |     +--ro source-mac-mask?        oc-yang:mac-address
      |           |  |     +--ro destination-mac?        oc-yang:mac-address
      |           |  |     +--ro destination-mac-mask?   oc-yang:mac-address
      |           |  |     +--ro ethertype?              oc-pkt-match-types:ethertype-type
+     |           |  +--rw fabric
+     |           |     +--rw config
+     |           |     |  +--rw fabric-priority?   uint8
+     |           |     +--ro state
+     |           |        +--ro fabric-priority?   uint8
      |           +--rw actions
      |              +--rw config
      |              |  +--rw target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--ro state
      |              |  +--ro target-group?   -> ../../../../../../../forwarding-groups/forwarding-group/config/name
      |              +--rw remark
      |                 +--rw config
      |                 |  +--rw set-dscp?      uint8
      |                 |  +--rw set-dot1p?     uint8
      |                 |  +--rw set-mpls-tc?   uint8
      |                 +--ro state
      |                    +--ro set-dscp?      uint8
      |                    +--ro set-dot1p?     uint8
      |                    +--ro set-mpls-tc?   uint8
      +--rw buffer-allocation-profiles
      |  +--rw buffer-allocation-profile* [name]
      |     +--rw name      -> ../config/name
      |     +--rw config
      |     |  +--rw name?   string
      |     +--ro state
      |     |  +--ro name?   string
      |     +--rw queues
      |        +--rw queue* [name]
      |           +--rw name      -> ../config/name
      |           +--rw config
      |           |  +--rw name?                                  -> ../../../../../../queues/queue/config/name
      |           |  +--rw dedicated-buffer?                      uint64
      |           |  +--rw dedicated-buffer-temporal?             uint64
      |           |  +--rw use-shared-buffer?                     boolean
      |           |  +--rw shared-buffer-limit-type?              identityref
      |           |  +--rw static-shared-buffer-limit?            uint32
      |           |  +--rw static-shared-buffer-limit-temporal?   uint32
      |           |  +--rw dynamic-limit-scaling-factor?          int32
+     |           |  +--rw trim-enable?                        boolean
      |           +--ro state
      |              +--ro name?                                  -> ../../../../../../queues/queue/config/name
      |              +--ro dedicated-buffer?                      uint64
      |              +--ro dedicated-buffer-temporal?             uint64
      |              +--ro use-shared-buffer?                     boolean
      |              +--ro shared-buffer-limit-type?              identityref
      |              +--ro static-shared-buffer-limit?            uint32
      |              +--ro static-shared-buffer-limit-temporal?   uint32
      |              +--ro dynamic-limit-scaling-factor?          int32
+     |              +--ro trim-enable?                        boolean
+     +--rw packet-trim
+        |  +--rw symmetric-dscp?   uint8
+        |  +--rw fabric-priority?  uint8
+        +--rw state
+           +--rw symmetric-dscp?   uint8
+           +--rw fabric-priority?  uint8

```
