### PR TITLE
Add path for optics error counters

### DIFF
--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,12 +66,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.19.0";
+  oc-ext:openconfig-version "1.0.0";
 
   revision "2026-03-25" {
     description
-      "Add optics error counters per physical channel.";
-    reference "0.19.0";
+      "Add optics error counters per physical channel. Promote
+      model to version 1.0.0.";
+    reference "1.0.0";
   }
 
   revision "2025-12-11" {

--- a/release/models/platform/openconfig-platform-transceiver.yang
+++ b/release/models/platform/openconfig-platform-transceiver.yang
@@ -66,7 +66,13 @@ module openconfig-platform-transceiver {
       specify a physical-channel within a TRANSCEIVER component
       (i.e. gray optic) that it is associated with.";
 
-  oc-ext:openconfig-version "0.18.0";
+  oc-ext:openconfig-version "0.19.0";
+
+  revision "2026-03-25" {
+    description
+      "Add optics error counters per physical channel.";
+    reference "0.19.0";
+  }
 
   revision "2025-12-11" {
     description
@@ -426,6 +432,27 @@ module openconfig-platform-transceiver {
       uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
     }
 
+    container host-snr {
+      description
+        "The Signal-to-Noise Ratio (SNR) measured on the host-side
+        (electrical) interface.";
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container media-snr {
+      description
+        "The Signal-to-Noise Ratio (SNR) measured on the media-side
+        (optical) interface.";
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    container counters {
+      description
+        "Top-level container for counters per optical physical
+        channel.";
+      uses optical-error-counts;
+    }
+
     leaf tx-failure {
       type boolean;
       description
@@ -451,6 +478,49 @@ module openconfig-platform-transceiver {
 
     uses output-optical-frequency;
     uses optical-power-state;
+  }
+
+  grouping optical-error-counts {
+    description
+      "Top-level grouping for counters per optical physical
+      channel";
+    leaf tx-fault-count {
+      type oc-yang:counter64;
+      description
+        "Total number of transmitter fault conditions detected
+        on this lane.";
+      reference "QSFP-DD CMIS 5.0 Page 11h (Lane-Specific Flags)";
+    }
+
+    leaf tx-los-count {
+      type oc-yang:counter64;
+      description
+        "Total number of transmitter Loss of Signal (LOS) events.";
+      reference "QSFP-DD CMIS 5.0 Page 11h (Lane-Specific Flags)";
+    }
+
+    leaf tx-lol-count {
+      type oc-yang:counter64;
+      description
+        "Total number of transmitter Clock and Data Recovery (CDR)
+        Loss of Lock (LOL) events.";
+      reference "QSFP-DD CMIS 5.0 Page 11h (Lane-Specific Flags)";
+    }
+
+    leaf rx-los-count {
+      type oc-yang:counter64;
+      description
+        "Total number of receiver Loss of Signal (LOS) events.";
+      reference "QSFP-DD CMIS 5.0 Page 11h (Lane-Specific Flags)";
+    }
+
+    leaf rx-lol-count {
+      type oc-yang:counter64;
+      description
+        "Total number of receiver Clock and Data Recovery (CDR)
+        Loss of Lock (LOL) events.";
+      reference "QSFP-DD CMIS 5.0 Page 11h (Lane-Specific Flags)";
+    }
   }
 
   grouping physical-channel-top {


### PR DESCRIPTION
### Change Scope

* Add counter paths to indicate number of errors in optical per physical lane.
* This change is backwards compatible.

### Platform Implementations

 * Implementation A: [Nvidia Implementation](https://docs.nvidia.com/networking/display/nvidianvosusermanualfornvlinkswitchesv25024282/transceiver-commands).
 * Implementation B: [Juniper Implementation](https://www.juniper.net/documentation/us/en/software/junos/interfaces-ethernet/topics/topic-map/400-zr-zrm-coherent-optics.html).

### Tree View

```diff
 module: openconfig-platform
   +--rw components
      +--rw component* [name]
         +--rw oc-transceiver:transceiver
         |  +--rw oc-transceiver:physical-channels
         |  |  +--rw oc-transceiver:channel* [index]
         |  |     +--ro oc-transceiver:state
         |  |        +--ro oc-transceiver:index?                        uint16
         |  |        +--ro oc-transceiver:associated-optical-channel?   -> /oc-platform:components/component/name
         |  |        +--ro oc-transceiver:description?                  string
         |  |        +--ro oc-transceiver:tx-laser?                     boolean
         |  |        +--ro oc-transceiver:target-output-power?          decimal64
         |  |        +--ro oc-transceiver:laser-age?                    oc-types:percentage
         |  |        +--ro oc-transceiver:laser-temperature
         |  |        |  +--ro oc-transceiver:instant?    decimal64
         |  |        |  +--ro oc-transceiver:avg?        decimal64
         |  |        |  +--ro oc-transceiver:min?        decimal64
         |  |        |  +--ro oc-transceiver:max?        decimal64
         |  |        |  +--ro oc-transceiver:interval?   oc-types:stat-interval
         |  |        |  +--ro oc-transceiver:min-time?   oc-types:timeticks64
         |  |        |  +--ro oc-transceiver:max-time?   oc-types:timeticks64
         |  |        +--ro oc-transceiver:target-frequency-deviation
         |  |        |  +--ro oc-transceiver:instant?    decimal64
         |  |        |  +--ro oc-transceiver:avg?        decimal64
         |  |        |  +--ro oc-transceiver:min?        decimal64
         |  |        |  +--ro oc-transceiver:max?        decimal64
         |  |        |  +--ro oc-transceiver:interval?   oc-types:stat-interval
         |  |        |  +--ro oc-transceiver:min-time?   oc-types:timeticks64
         |  |        |  +--ro oc-transceiver:max-time?   oc-types:timeticks64
         |  |        +--ro oc-transceiver:tec-current
         |  |        |  +--ro oc-transceiver:instant?    decimal64
         |  |        |  +--ro oc-transceiver:avg?        decimal64
         |  |        |  +--ro oc-transceiver:min?        decimal64
         |  |        |  +--ro oc-transceiver:max?        decimal64
         |  |        |  +--ro oc-transceiver:interval?   oc-types:stat-interval
         |  |        |  +--ro oc-transceiver:min-time?   oc-types:timeticks64
         |  |        |  +--ro oc-transceiver:max-time?   oc-types:timeticks64
         |  |        +--ro oc-transceiver:tx-failure?                   boolean
         |  |        +--ro oc-transceiver:rx-los?                       boolean
         |  |        +--ro oc-transceiver:rx-cdr-lol?                   boolean
+        |  |        +--ro oc-transceiver:counters
+        |  |        |  +--ro oc-transceiver:tx-fault-count?   oc-yang:counter64
+        |  |        |  +--ro oc-transceiver:tx-los-count?     oc-yang:counter64
+        |  |        |  +--ro oc-transceiver:tx-lol-count?     oc-yang:counter64
+        |  |        |  +--ro oc-transceiver:rx-los-count?     oc-yang:counter64
+        |  |        |  +--ro oc-transceiver:rx-lol-count?     oc-yang:counter64
+        |  |        +--ro oc-transceiver:host-snr
+        |  |        |  +--ro oc-transceiver:instant?    decimal64
+        |  |        |  +--ro oc-transceiver:avg?        decimal64
+        |  |        |  +--ro oc-transceiver:min?        decimal64
+        |  |        |  +--ro oc-transceiver:max?        decimal64
+        |  |        |  +--ro oc-transceiver:interval?   oc-types:stat-interval
+        |  |        |  +--ro oc-transceiver:min-time?   oc-types:timeticks64
+        |  |        |  +--ro oc-transceiver:max-time?   oc-types:timeticks64
+        |  |        +--ro oc-transceiver:media-snr
+        |  |        |  +--ro oc-transceiver:instant?    decimal64
+        |  |        |  +--ro oc-transceiver:avg?        decimal64
+        |  |        |  +--ro oc-transceiver:min?        decimal64
+        |  |        |  +--ro oc-transceiver:max?        decimal64
+        |  |        |  +--ro oc-transceiver:interval?   oc-types:stat-interval
+        |  |        |  +--ro oc-transceiver:min-time?   oc-types:timeticks64
+        |  |        |  +--ro oc-transceiver:max-time?   oc-types:timeticks64

```
