### PR TITLE
Add MANUAL proxy-arp mode and manual-ip-range to openconfig-if-ip IPv4 mode

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -45,7 +45,14 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.9.0";
+  oc-ext:openconfig-version "3.10.0";
+
+   revision "2026-06-01" {
+     description
+       "Add ipv4-address-range typedef; manual-ip-range accepts CIDR
+       prefix or start-end ip range.";
+     reference "3.10.0";
+  }
 
     revision "2025-06-20" {
     description
@@ -1311,6 +1318,48 @@ revision "2023-06-30" {
   }
 
 
+  typedef ipv4-address-range {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+        + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+        + '(-'
+        + '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+        + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]))?';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+        + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+        + '(-(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+        + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]))?$';
+    }
+    description
+      "An IPv4 address or address range expressed in dotted-decimal notation.
+       A single address (e.g. 10.0.0.1) or a range of two addresses separated
+       by a hyphen without spaces: start-end (e.g. 10.0.0.1-10.0.0.5).
+       A single address is semantically equivalent to a range where the start
+       and end addresses are identical (e.g. 10.0.0.1 is equivalent to
+       10.0.0.1-10.0.0.1).
+       When a range is specified, the start address must be numerically less
+       than or equal to the end address; validation is enforced by the system.";
+  }
+
+  grouping ipv4-proxy-arp-manual-ip-range-config {
+    description
+      "Configuration parameters for a proxy ARP manual IPv4
+      ip-range entry.";
+
+    leaf ip-range {
+      type union {
+        type oc-inet:ipv4-prefix;
+        type ipv4-address-range;
+      }
+      description
+        "IPv4 ip-range: single IP (CIDR notation, e.g. 10.0.0.0/24) or
+        address range (start-end notation, e.g. 10.0.0.1-10.0.0.5)
+        for which proxy ARP replies are sent when mode is MANUAL.";
+    }
+  }
+
   grouping ipv4-proxy-arp-config {
     description
       "Configuration parameters for IPv4 proxy ARP";
@@ -1335,6 +1384,14 @@ revision "2023-06-30" {
             and target IP addresses are in different subnets, as well
             as those where they are in the same subnet.";
         }
+        enum MANUAL {
+          description
+            "Proxy ARP operating mode in which the system responds to
+            ARP requests only when the target IPv4 address matches an
+            explicitly configured entry in manual-ip-range. In this mode,
+            proxy ARP responses are selectively generated based on the ARP
+            target IP address.";
+        }
       }
       default "DISABLE";
       description
@@ -1345,7 +1402,10 @@ revision "2023-06-30" {
         value is specified, replies are only sent when the target address
         falls outside the locally configured subnets on the interface,
         whereas with the ALL value, all requests, regardless of their
-        target address are replied to.";
+        target address are replied to. If MANUAL is specified, replies
+        are only sent for target addresses matching entries in the
+        manual-ip-ranges list, or that match the IP address assigned to
+        the receiving interface.";
       reference "RFC1027: Using ARP to Implement Transparent Subnet Gateways";
     }
   }
@@ -1470,6 +1530,50 @@ revision "2023-06-30" {
           description
             "Operational state parameters for proxy ARP";
           uses ipv4-proxy-arp-config;
+        }
+
+        container manual-ip-ranges {
+          when "../config/mode = 'MANUAL'" {
+            description
+              "manual-ip-ranges is applicable only when proxy ARP mode
+              is MANUAL.";
+          }
+          description
+            "Collection of IPv4 prefixes or address ranges for which
+            proxy ARP replies are sent when mode is MANUAL.";
+
+          list manual-ip-range {
+            key "ip-range";
+            description
+              "A configured IPv4 ip-range entry for proxy ARP manual
+              mode.";
+
+            leaf ip-range {
+              type leafref {
+                path "../config/ip-range";
+              }
+              description
+                "IPv4 ip-range for which proxy ARP replies are sent
+                when mode is MANUAL.";
+            }
+
+            container config {
+              description
+                "Configuration parameters for a proxy ARP manual IPv4
+                ip-range entry.";
+
+              uses ipv4-proxy-arp-manual-ip-range-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters for a proxy ARP manual
+                IPv4 ip-range entry.";
+
+              uses ipv4-proxy-arp-manual-ip-range-config;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
…penconfig-if-ip model

### Change Scope

* [This change extends the openconfig-if-ip model to support selective (manual) IPv4 proxy ARP behavior using both CIDR prefixes and explicit IP address ranges. Introduces a new typedef ipv4-address-range to represent IPv4 address ranges (e.g. 10.0.0.1-10.0.0.5). Added a new container manual-ip-ranges under /ipv4/proxy-arp & models each entry using an OpenConfig list with condif/state separation. This allows each entry to be defined as either an IPv4 prefix (oc-inet:ipv4-prefix) or an address range (ipv4-address-range) via a union type. The changes also extends /proxy-arp/config/mode with a new value MANUAL, which is a mode in which proxy ARP responses are generated only when the target IPv4 address matches a configured prefix or range in manual-ip-ranges or matches an IP address assigned to the receiving interface]
* [This change is fully backward compatible:
Existing enum values (DISABLE, REMOTE_ONLY, ALL) remain unchanged.
Existing clients not using MANUAL mode are unaffected.
The new list is optional and has no operational effect unless mode=MANUAL.]

### Platform Implementations

 * Implementation A: Ciena 6500 
 The platform requires operator‑controlled manual proxy ARP for deployment scenarios.
 The implementation uses Linux kernel proxy ARP + NFtables filtering.
 [link to documentation](Vendor documentation for this feature is currently internal and not publicly
shareable prior to feature completion. The externally visible behavior is fully described by the YANG model semantics.)
 * Implementation B: OpenROADM Proxy ARP Model
 OpenROADM models a similar structure for proxy ARP entries as “proxy‑subnet” using CIDR prefixes, which our model aligns with conceptually.  [link to documentation](https://github.com/OpenROADM/OpenROADM_MSA_Public/blob/master/model/Device/org-openroadm-ip.yang#L410)

### Tree View
[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-if-ip
    augment /oc-if:interfaces/oc-if:interface/oc-if:subinterfaces/oc-if:subinterface:
     +--rw ipv4
        +--rw addresses
        |  +--rw address* [ip]
        |     +--rw ip        -> ../config/ip
        |     +--rw config
        |     |  +--rw ip?              oc-inet:ipv4-address
        |     |  +--rw prefix-length?   uint8
        |     |  +--rw type?            ipv4-address-type
        |     +--ro state
        |     |  +--ro ip?              oc-inet:ipv4-address
        |     |  +--ro prefix-length?   uint8
        |     |  +--ro type?            ipv4-address-type
        |     |  +--ro origin?          ip-address-origin
        |     +--rw vrrp
        |        +--rw vrrp-group* [virtual-router-id]
        |           +--rw virtual-router-id     -> ../config/virtual-router-id
        |           +--rw config
        |           |  +--rw virtual-router-id?        uint8
        |           |  +--rw virtual-address*          oc-inet:ip-address
        |           |  +--rw priority?                 uint8
        |           |  +--rw preempt?                  boolean
        |           |  +--rw preempt-delay?            uint16
        |           |  +--rw accept-mode?              boolean
        |           |  +--rw advertisement-interval?   uint16
        |           +--ro state
        |           |  +--ro virtual-router-id?        uint8
        |           |  +--ro virtual-address*          oc-inet:ip-address
        |           |  +--ro priority?                 uint8
        |           |  +--ro preempt?                  boolean
        |           |  +--ro preempt-delay?            uint16
        |           |  +--ro accept-mode?              boolean
        |           |  +--ro advertisement-interval?   uint16
        |           |  +--ro current-priority?         uint8
        |           +--rw interface-tracking
        |              +--rw config
        |              |  +--rw track-interface*      -> /oc-if:interfaces/interface/name
        |              |  +--rw priority-decrement?   uint8
        |              +--ro state
        |                 +--ro track-interface*      -> /oc-if:interfaces/interface/name
        |                 +--ro priority-decrement?   uint8
        +--rw proxy-arp
        |  +--rw config
        |  |  +--rw mode?   enumeration
        |  +--ro state
-       |     +--ro mode?   enumeration
+       |  |  +--ro mode?   enumeration
+       |  +--rw manual-ip-ranges
+       |     +--rw manual-ip-range* [ip-range]
+       |        +--rw ip-range    -> ../config/ip-range
+       |        +--rw config
+       |        |  +--rw ip-range?   union
+       |        +--ro state
+       |           +--ro ip-range?   union
        +--rw neighbors
        |  +--rw neighbor* [ip]
        |     +--rw ip        -> ../config/ip
        |     +--rw config
        |     |  +--rw ip?                   oc-inet:ipv4-address
        |     |  +--rw link-layer-address    oc-yang:phys-address
        |     +--ro state
        |        +--ro ip?                   oc-inet:ipv4-address
        |        +--ro link-layer-address    oc-yang:phys-address
        |        +--ro origin?               neighbor-origin

```
