### PR TITLE
adding 800GBASE-2xFR4 and 800GBASE-DR8 PMD

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,8 +22,14 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "1.3.0";
-
+  oc-ext:openconfig-version "1.4.0";
+  
+  revision "2026-04-24" {
+    description
+      "Add ETH_800GBASE_DR8 and ETH_800GBASE_2XFR4 PMD types.";
+    reference "1.4.0";
+  }
+  
   revision "2025-08-12" {
     description
       "Add ETH_800GBASE_ZR PMD type.";

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -1315,9 +1315,9 @@ module openconfig-transport-types {
     reference "IEEE 802.3df";
   }
 
-  identity ETH_800GBASE_2xFR4 {
+  identity ETH_800GBASE_2XFR4 {
     base ETHERNET_PMD_TYPE;
-    description "Ethernet compliance code: 800GBASE_2xFR4";
+    description "Ethernet compliance code: 800GBASE_2XFR4";
     reference "IEEE 802.3cu";
   }
 

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -1309,6 +1309,16 @@ module openconfig-transport-types {
     description "Ethernet compliance code: 800GBASE_ZR";
   }
 
+  identity ETH_800GBASE_DR8 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 800GBASE_DR8";
+  }
+
+  identity ETH_800GBASE_2xFR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 800GBASE_2xFR4";
+  }
+
   identity ETH_UNDEFINED {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: undefined";

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -1312,11 +1312,13 @@ module openconfig-transport-types {
   identity ETH_800GBASE_DR8 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 800GBASE_DR8";
+    reference "IEEE 802.3df";
   }
 
   identity ETH_800GBASE_2xFR4 {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 800GBASE_2xFR4";
+    reference "IEEE 802.3cu";
   }
 
   identity ETH_UNDEFINED {

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -23,13 +23,13 @@ module openconfig-transport-types {
     for optical transport models.";
 
   oc-ext:openconfig-version "1.4.0";
-  
+
   revision "2026-04-24" {
     description
       "Add ETH_800GBASE_DR8 and ETH_800GBASE_2XFR4 PMD types.";
     reference "1.4.0";
   }
-  
+
   revision "2025-08-12" {
     description
       "Add ETH_800GBASE_ZR PMD type.";


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. Replace
all the text in `[]` with your own content.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* Adding 800GBASE-2xFR4 and 800GBASE-DR8 PMD
* It is backward compatible

### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].

### Tree View

* [Please provide a view of the tree being modified.  It's preferred if a `diff` format is used for ease of review.]
* [Here are recommended steps to generate the tree view as a diff]

```
git checkout mychangebranch
pyang -f tree -p release/models/*/* > ~/new-tree.txt 
git checkout master
git pull
pyang -f tree -p release/models/*/* > ~/old-tree.txt
diff -bU 100 ~/old-tree.txt ~/new-tree.txt   | less
```

[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         +--ro state
         |  +--ro counters
         |  |  +--ro in-octets?               oc-yang:counter64
         |  |  +--ro in-pkts?                 oc-yang:counter64
         |  |  +--ro in-unicast-pkts?         oc-yang:counter64
         |  |  +--ro in-broadcast-pkts?       oc-yang:counter64
         |  |  +--ro in-multicast-pkts?       oc-yang:counter64
         |  |  +--ro in-errors?               oc-yang:counter64
         |  |  +--ro in-discards?             oc-yang:counter64
         |  |  +--ro out-octets?              oc-yang:counter64
         |  |  +--ro out-pkts?                oc-yang:counter64
         |  |  +--ro out-unicast-pkts?        oc-yang:counter64
         |  |  +--ro out-broadcast-pkts?      oc-yang:counter64
         |  |  +--ro out-multicast-pkts?      oc-yang:counter64
         |  |  +--ro out-discards?            oc-yang:counter64
         |  |  +--ro out-errors?              oc-yang:counter64
         |  |  +--ro last-clear?              oc-types:timeticks64
         |  |  +--ro in-unknown-protos?       oc-yang:counter64
         |  |  +--ro in-fcs-errors?           oc-yang:counter64
+        |  |  x--ro carrier-transitions?     oc-yang:counter64
-        |  |  +--ro carrier-transitions?     oc-yang:counter64
+        |  |  +--ro interface-transitions?   oc-yang:counter64
+        |  |  +--ro link-transitions?        oc-yang:counter64
         |  |  +--ro resets?                oc-yang:counter64
```
