### PR TITLE
Add sent-path-count leaf

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,13 +24,19 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,13 +21,19 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,13 +24,19 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,13 +27,19 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,13 +30,19 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {
@@ -686,6 +692,15 @@ submodule openconfig-bgp-neighbor {
           neighbor after applying any policies. This count is
           the number of prefixes present in the post-policy
           Adj-RIB-Out for the neighbor";
+      }
+
+      leaf sent-path-count {
+        type uint32;
+        description
+          "The number of add-paths advertised to a neighbor after
+          the post-policy Adj-RIB-Out.  This value reflects the total
+          number of paths present in the post-policy Adj-RIB-Out for
+          the neighbor once add-path configuration is applied.";
       }
 
       leaf installed {

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,13 +25,19 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,13 +68,19 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-03-31" {
+    description
+      "Add prefix sent path count.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {


### PR DESCRIPTION
### Change Scope

Introduces a new sent-path-count under BGP prefix container.

The sent-path-count represents the number of add-paths advertised to a neighbor after the post-policy Adj-RIB-Out. This value reflects the total number of paths present in the post-policy Adj-RIB-Out for the neighbor once add-path configuration is applied.

This change is backwards-compatible, and the version number has been updated appropriately.

### Platform Implementations

 * Cisco IOS XR:

After enabling add-path:
```RP/0/0/CPU0:R4#show bgp ipv4 unicast neighbors  11.11.11.7 advertised-routes 
Wed Mar  4 16:10:21.812 EST
Network                Next Hop        From            AS Path
1.1.0.0/16             13.13.30.6      13.13.30.6      6?
                       10.10.30.3      10.10.30.3      3?
192.168.0.3/32         10.10.30.3      10.10.30.3      3i
192.168.0.6/32         13.13.30.6      13.13.30.6      6i
 
Processed 3 prefixes, 4 paths  <- Number of prefixes and paths reported. 
RP/0/0/CPU0:R4#
```

 * Implementation B: [link to documentation](http://foo.com) and/or implementation output.  TBD


### Tree View

```diff
 module: openconfig-bgp
          |     |  |     |  +--rw afi-safi* [afi-safi-name]
          |     |  |     |     +--rw afi-safi-name           -> ../config/afi-safi-name
          |     |  |     |     +--rw config
          |     |  |     |     |  +--rw afi-safi-name?         identityref
          |     |  |     |     |  +--rw enabled?               boolean
          |     |  |     |     |  +--rw send-community-type*   oc-bgp-types:community-type
          |     |  |     |     +--ro state
          |     |  |     |     |  +--ro afi-safi-name?         identityref
          |     |  |     |     |  +--ro enabled?               boolean
          |     |  |     |     |  +--ro send-community-type*   oc-bgp-types:community-type
          |     |  |     |     |  +--ro active?                boolean
          |     |  |     |     |  +--ro prefixes
          |     |  |     |     |     +--ro received?              uint32
          |     |  |     |     |     +--ro received-pre-policy?   uint32
          |     |  |     |     |     +--ro sent?                  uint32
+         |     |  |     |     |     +--ro sent-path-count?       uint32
          |     |  |     |     |     +--ro installed?             uint32
          |     |  |     |     +--rw graceful-restart
          |     |  |     |     |  +--rw config
          |     |  |     |     |  |  +--rw enabled?   boolean
          |     |  |     |     |  +--ro state
          |     |  |     |     |     +--ro enabled?      boolean
          |     |  |     |     |     +--ro received?     boolean
          |     |  |     |     |     +--ro advertised?   boolean
          |     |  |     |     +--rw add-paths
          |     |  |     |     |  +--rw config
          |     |  |     |     |  |  +--rw receive?                  boolean
          |     |  |     |     |  |  +--rw send?                     boolean
          |     |  |     |     |  |  +--rw send-max?                 uint8
          |     |  |     |     |  |  +--rw eligible-prefix-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
```

### Justification
This enhancement is driven by a requirement from an operator, where an additional metric is needed for better observability. In Add-Path scenarios, there is a need to track the total number of paths advertised (across all prefixes) to a specific neighbor.
Currently, there is an existing leaf “sent” under the prefixes container, which provides the number of prefixes advertised to a neighbor after policy application. Similarly, the proposed “sent-path-count” will provide visibility into the number of paths advertised after policy application.