### PR TITLE
Available Memory Leaf

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -1170,8 +1170,9 @@ module openconfig-system {
       type uint64;
       units bytes;
       description
-        "Memory that is available for allocation. This is largely the sum of
-        free memory + cache & buffer usage";
+        "Available memory includes free memory plus cached/buffered memory that
+        can be reclaimed instantly by the operating system for new
+        applications";
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -1170,9 +1170,10 @@ module openconfig-system {
       type uint64;
       units bytes;
       description
-        "Available memory includes free memory plus cached/buffered memory that
-        can be reclaimed instantly by the operating system for new
-        applications";
+        "The amount of memory that is available for use.
+        This includes memory that is currently unused, as well as memory
+        used for system caches and buffers that can be reclaimed by the
+        operating system.";
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -48,7 +48,13 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.0.0";
+  oc-ext:openconfig-version "3.1.0";
+
+  revision "2026-03-31" {
+    description
+      "Added a leaf for available memory.";
+    reference "3.1.0";
+  }
 
   revision "2025-07-08" {
     description
@@ -1158,6 +1164,14 @@ module openconfig-system {
       units bytes;
       description
         "Memory that is not used and is available for allocation.";
+    }
+
+    leaf available {
+      type uint64;
+      units bytes;
+      description
+        "Memory that is available for allocation. This is largely the sum of
+        free memory + cache & buffer usage";
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -1171,9 +1171,10 @@ module openconfig-system {
       units bytes;
       description
         "The amount of memory that is available for use.
-        This includes memory that is currently unused, as well as memory
-        used for system caches and buffers that can be reclaimed by the
-        operating system.";
+
+        In addition to the memory reported by free, this leaf also includes
+        memory used for system caches and buffers that can be
+        reclaimed by the operating system.";
     }
   }
 


### PR DESCRIPTION
### Change Scope

* This change adds a new leaf for "available" memory: `/system/memory/state/available`
* This change is backwards compatible.

### Platform Implementations

 * https://man7.org/linux/man-pages/man1/free.1.html
 * https://learn.microsoft.com/en-us/powershell/scripting/learn/ps101/07-working-with-wmi?view=powershell-7.6

### Tree View

```
  +--rw system
     +--rw memory
     |  +--rw config
     |  +--ro state
     |     +--ro physical?    uint64
     |     +--ro reserved?    uint64
     |     +--ro used?        uint64
     |     +--ro free?        uint64
+    |     +--ro available?   uint64
```