### PR TITLE
Fix ygnmi CI check by installing goimports

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -268,7 +268,7 @@ steps:
 ############### YGNMI ###############
 - name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
-  args: ['-c', "/go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
+  args: ['-c', "export PATH=/go/bin:$$PATH && go install golang.org/x/tools/cmd/goimports@latest && /go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']
   volumes:
   - name: 'gopath'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -268,7 +268,7 @@ steps:
 ############### YGNMI ###############
 - name: 'us-west1-docker.pkg.dev/$PROJECT_ID/models-ci/models-ci-image'
   entrypoint: 'bash'
-  args: ['-c', "export PATH=/go/bin:$$PATH && go install golang.org/x/tools/cmd/goimports@latest && /go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
+  args: ['-c', "export PATH=/go/bin:$$PATH && go install golang.org/x/tools/cmd/goimports@v0.42.0 && /go/src/github.com/openconfig/models-ci/validators/ygnmi/test.sh"]
   secretEnv: ['GITHUB_ACCESS_TOKEN']
   volumes:
   - name: 'gopath'


### PR DESCRIPTION
This PR installs goimports in the ygnmi step of cloudbuild.yaml to fix failures due to unused imports.