### PR TITLE
Add multicast-focused AFTs

### DIFF
--- a/release/models/aft/openconfig-aft-counters.yang
+++ b/release/models/aft/openconfig-aft-counters.yang
@@ -18,7 +18,15 @@ module openconfig-aft-counters {
   description
     "Submodule providing a unified subtree for AFT entry counters.";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2026-05-20" {
+    description
+      "Add IPv4, IPv6, and MPLS multicast AFT counter containers, and a
+       new aft-multicast-entry-counter-state grouping for multicast-only
+       counters (rpf-discards).";
+    reference "3.4.0";
+  }
 
   revision "2026-02-09" {
     description
@@ -70,6 +78,19 @@ module openconfig-aft-counters {
       description
         "The number of octets which have matched, and been forwarded,
         based on the AFT backup entry";
+    }
+  }
+
+  grouping aft-multicast-entry-counter-state {
+    description
+      "Counters specific to multicast forwarding entries.";
+
+    leaf rpf-discards {
+      type oc-yang:counter64;
+      description
+        "The number of packets discarded because the arrival interface
+        did not match the reverse-path interface programmed for this
+        multicast entry.";
     }
   }
 
@@ -181,6 +202,141 @@ module openconfig-aft-counters {
               type oc-mplst:mpls-label;
               description
                 "The MPLS label that should be matched to utilize the AFT entry.";
+            }
+
+            uses aft-entry-counter-state;
+          }
+        }
+      }
+
+      container ipv4-multicast {
+        description
+          "Counters for IPv4 multicast AFT entries.";
+
+        list ipv4-multicast-entry {
+          key "source-address group-address";
+          description
+            "Counters for each IPv4 multicast AFT entry, keyed by the
+            (source, group) pair.";
+
+          leaf source-address {
+            type leafref {
+              path "../state/source-address";
+            }
+            description
+              "Reference to the IPv4 source address.";
+          }
+
+          leaf group-address {
+            type leafref {
+              path "../state/group-address";
+            }
+            description
+              "Reference to the IPv4 multicast group address.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the IPv4 multicast AFT entry.";
+
+            leaf source-address {
+              type oc-inet:ipv4-address;
+              description
+                "The IPv4 source address for this multicast entry. The
+                value 0.0.0.0 represents any-source (*,G) entries.";
+            }
+
+            leaf group-address {
+              type oc-inet:ipv4-address;
+              description
+                "The IPv4 multicast group address for this entry.";
+            }
+
+            uses aft-entry-counter-state;
+            uses aft-multicast-entry-counter-state;
+          }
+        }
+      }
+
+      container ipv6-multicast {
+        description
+          "Counters for IPv6 multicast AFT entries.";
+
+        list ipv6-multicast-entry {
+          key "source-address group-address";
+          description
+            "Counters for each IPv6 multicast AFT entry, keyed by the
+            (source, group) pair.";
+
+          leaf source-address {
+            type leafref {
+              path "../state/source-address";
+            }
+            description
+              "Reference to the IPv6 source address.";
+          }
+
+          leaf group-address {
+            type leafref {
+              path "../state/group-address";
+            }
+            description
+              "Reference to the IPv6 multicast group address.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the IPv6 multicast AFT entry.";
+
+            leaf source-address {
+              type oc-inet:ipv6-address;
+              description
+                "The IPv6 source address for this multicast entry. The
+                value :: represents any-source (*,G) entries.";
+            }
+
+            leaf group-address {
+              type oc-inet:ipv6-address;
+              description
+                "The IPv6 multicast group address for this entry.";
+            }
+
+            uses aft-entry-counter-state;
+            uses aft-multicast-entry-counter-state;
+          }
+        }
+      }
+
+      container mpls-multicast {
+        description
+          "Counters for MPLS multicast (P2MP) AFT entries.";
+
+        list multicast-label-entry {
+          key "label";
+          description
+            "Counters for each MPLS multicast AFT entry, keyed by the
+            incoming label.";
+
+          leaf label {
+            type leafref {
+              path "../state/label";
+            }
+            description
+              "Reference to the MPLS label.";
+          }
+
+          container state {
+            config false;
+            description
+              "Counter state for the MPLS multicast AFT entry.";
+
+            leaf label {
+              type oc-mplst:mpls-label;
+              description
+                "The MPLS label that should be matched to utilize the
+                AFT entry.";
             }
 
             uses aft-entry-counter-state;

--- a/release/models/aft/openconfig-aft-ipv4-multicast.yang
+++ b/release/models/aft/openconfig-aft-ipv4-multicast.yang
@@ -1,0 +1,109 @@
+submodule openconfig-aft-ipv4-multicast {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding table for IPv4 multicast.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2026-05-20" {
+    description
+      "Initial revision of the IPv4 multicast abstract forwarding table.";
+    reference "0.1.0";
+  }
+
+  grouping aft-ipv4-multicast-structural {
+    description
+      "Structural grouping defining the schema for the IPv4 multicast
+      abstract forwarding table.";
+
+    list ipv4-multicast-entry {
+      key "source-address group-address";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the IPv4 multicast entries within the abstract
+        forwarding table. Each entry is keyed by the (source, group)
+        pair. The source-address 0.0.0.0 represents any-source (*,G)
+        entries used for shared-tree and BiDir RP forwarding.";
+
+      leaf source-address {
+        type leafref {
+          path "../state/source-address";
+        }
+        description
+          "Reference to the IPv4 source address. Use 0.0.0.0 for
+          any-source (*,G) entries.";
+      }
+
+      leaf group-address {
+        type leafref {
+          path "../state/group-address";
+        }
+        description
+          "Reference to the IPv4 multicast group address.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the IPv4 multicast AFT
+          entry.";
+        uses aft-ipv4-multicast-entry-state;
+      }
+
+    }
+  }
+
+  grouping aft-ipv4-multicast-entry-state {
+    description
+      "Operational state parameters for the IPv4 multicast entry.";
+
+    leaf source-address {
+      type oc-inet:ipv4-address;
+      description
+        "The IPv4 source address for this multicast entry. The value
+        0.0.0.0 represents any-source (*,G) entries.";
+    }
+
+    leaf group-address {
+      type oc-inet:ipv4-address;
+      description
+        "The IPv4 multicast group address for this entry.";
+    }
+
+    uses aft-common-entry-state;
+    uses aft-common-ip-state;
+
+    container reverse-path-interface {
+      description
+        "Reference to the incoming (reverse-path) interface used by
+        the forwarding plane to validate the arrival of packets for
+        this multicast entry. Packets received on any other interface
+        are discarded (see the rpf-discards counter).
+
+        For directly-connected sources, or where the system does not
+        program an RPF interface for the entry (e.g. bidirectional
+        PIM in some implementations), this container may be absent.";
+
+      uses oc-if:interface-ref-state;
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-ipv6-multicast.yang
+++ b/release/models/aft/openconfig-aft-ipv6-multicast.yang
@@ -1,0 +1,109 @@
+submodule openconfig-aft-ipv6-multicast {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding table for IPv6 multicast.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2026-05-20" {
+    description
+      "Initial revision of the IPv6 multicast abstract forwarding table.";
+    reference "0.1.0";
+  }
+
+  grouping aft-ipv6-multicast-structural {
+    description
+      "Structural grouping defining the schema for the IPv6 multicast
+      abstract forwarding table.";
+
+    list ipv6-multicast-entry {
+      key "source-address group-address";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the IPv6 multicast entries within the abstract
+        forwarding table. Each entry is keyed by the (source, group)
+        pair. The source-address :: represents any-source (*,G)
+        entries used for shared-tree and BiDir RP forwarding.";
+
+      leaf source-address {
+        type leafref {
+          path "../state/source-address";
+        }
+        description
+          "Reference to the IPv6 source address. Use :: for
+          any-source (*,G) entries.";
+      }
+
+      leaf group-address {
+        type leafref {
+          path "../state/group-address";
+        }
+        description
+          "Reference to the IPv6 multicast group address.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the IPv6 multicast AFT
+          entry.";
+        uses aft-ipv6-multicast-entry-state;
+      }
+
+    }
+  }
+
+  grouping aft-ipv6-multicast-entry-state {
+    description
+      "Operational state parameters for the IPv6 multicast entry.";
+
+    leaf source-address {
+      type oc-inet:ipv6-address;
+      description
+        "The IPv6 source address for this multicast entry. The value
+        :: represents any-source (*,G) entries.";
+    }
+
+    leaf group-address {
+      type oc-inet:ipv6-address;
+      description
+        "The IPv6 multicast group address for this entry.";
+    }
+
+    uses aft-common-entry-state;
+    uses aft-common-ip-state;
+
+    container reverse-path-interface {
+      description
+        "Reference to the incoming (reverse-path) interface used by
+        the forwarding plane to validate the arrival of packets for
+        this multicast entry. Packets received on any other interface
+        are discarded (see the rpf-discards counter).
+
+        For directly-connected sources, or where the system does not
+        program an RPF interface for the entry (e.g. bidirectional
+        PIM in some implementations), this container may be absent.";
+
+      uses oc-if:interface-ref-state;
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-mpls-multicast.yang
+++ b/release/models/aft/openconfig-aft-mpls-multicast.yang
@@ -1,0 +1,143 @@
+submodule openconfig-aft-mpls-multicast {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding table for MPLS multicast (P2MP) label forwarding.
+
+    This AFT type represents the forwarding state of MPLS P2MP transit
+    nodes, such as those running mLDP or RSVP-TE P2MP. At these nodes,
+    packets arrive with a specific incoming MPLS label and are replicated
+    to one or more outgoing interfaces, each potentially with a different
+    label stack. There is no IP-layer (source, group) state at transit
+    nodes; that state is captured in the ipv4-multicast and
+    ipv6-multicast AFT types at PE nodes.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2026-05-05" {
+    description
+      "Initial revision of the MPLS multicast abstract forwarding table.";
+    reference "0.1.0";
+  }
+
+  grouping aft-mpls-multicast-structural {
+    description
+      "Structural grouping defining the schema for the MPLS multicast
+      abstract forwarding table.";
+
+    list multicast-label-entry {
+      key "label";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the MPLS multicast entries within the abstract
+        forwarding table. This list is keyed by the top-most incoming
+        MPLS label matched on the ingress packet.";
+
+      leaf label {
+        type leafref {
+          path "../state/label";
+        }
+        description
+          "Reference to the top-most MPLS label matched by the
+          entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the MPLS multicast AFT
+          entry.";
+        uses aft-mpls-multicast-entry-state;
+      }
+
+      uses aft-mpls-multicast-entry-label-state;
+    }
+  }
+
+  grouping aft-mpls-multicast-entry-state {
+    description
+      "Operational state parameters for the MPLS multicast entry.";
+
+    leaf label {
+      type oc-mplst:mpls-label;
+      description
+        "The top-most MPLS label that is matched on the ingress packet
+        to select this forwarding entry.";
+    }
+
+    uses aft-common-entry-state;
+    uses aft-common-install-protocol;
+  }
+
+  grouping aft-mpls-multicast-entry-label-state {
+    description
+      "Parameters relating to the MPLS label stack for a multicast
+      forwarding entry.";
+
+    container decap-mpls-label-stacks {
+      description
+        "Surrounding container for the set of labels to be decapsulated
+        from the incoming packet before replication.";
+
+      list decap-mpls-label-stack {
+        ordered-by user;
+        description
+          "The MPLS label stack to be popped from the ingress packet
+          before replication. The stack is encoded as an ordered list
+          such that the first entry is the label that is outer-most
+          (i.e., furthest from the bottom of the stack). This encoding
+          supports duplicate label values.
+
+          A swap operation is reflected by entries in this
+          decap-mpls-label-stack and the encap-mpls-label-stack on
+          the associated next-hops.";
+
+        key "id";
+
+        leaf id {
+          type leafref {
+            path "../state/id";
+          }
+          description
+            "Reference to the list key.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the decapsulated label
+            entry.";
+
+          leaf id {
+            type uint8;
+            description
+              "Index identifying this label within the stack.";
+          }
+
+          leaf label {
+            type oc-mplst:mpls-label;
+            description
+              "MPLS label value.";
+          }
+        }
+      }
+    }
+  }
+}

--- a/release/models/aft/openconfig-aft-network-instance.yang
+++ b/release/models/aft/openconfig-aft-network-instance.yang
@@ -19,7 +19,14 @@ module openconfig-aft-network-instance {
      when building the OpenConfig network instance model to
      add per-NI AFTs.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2026-04-02" {
+    description
+      "Add next-hop-group augmentations for IPv4, IPv6, and MPLS
+      multicast AFT entry types.";
+    reference "0.4.0";
+  }
 
   revision "2023-04-25" {
     description
@@ -176,6 +183,39 @@ module openconfig-aft-network-instance {
     description
       "Add leaves that require referencing of a network instance to the
       operational state parameters of an entry within the Ethernet AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv4-multicast/oc-ni:ipv4-multicast-entry/" +
+          "oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv4 multicast
+      AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv6-multicast/oc-ni:ipv6-multicast-entry/" +
+          "oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv6 multicast
+      AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:mpls-multicast/oc-ni:multicast-label-entry/" +
+          "oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the MPLS multicast
+      AFT.";
 
     uses aft-entry-nexthop-group-state;
   }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -22,6 +22,12 @@ module openconfig-aft {
   include openconfig-aft-common;
   // Include the state synced submodule.
   include openconfig-aft-state-synced;
+  // Include the IPv4 multicast AFT submodule.
+  include openconfig-aft-ipv4-multicast;
+  // Include the IPv6 multicast AFT submodule.
+  include openconfig-aft-ipv6-multicast;
+  // Include the MPLS multicast AFT submodule.
+  include openconfig-aft-mpls-multicast;
 
   organization
     "OpenConfig working group";
@@ -42,7 +48,17 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-05-05" {
+    description
+      "Add ipv4-multicast, ipv6-multicast, and mpls-multicast AFT types
+      for representing the active multicast forwarding table. Supports
+      native IP multicast (PIM-SM/DM/SSM/BiDir, DVMRP), MPLS P2MP
+      ingress/egress PE (mLDP, RSVP-TE P2MP), and MPLS P2MP transit
+      nodes.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -275,6 +291,68 @@ module openconfig-aft {
           exporting the data structure.";
 
         uses aft-ipv6-unicast-structural;
+      }
+
+      container ipv4-multicast {
+        config false;
+        description
+          "The abstract forwarding table for IPv4 multicast. Entries
+          within this table are keyed by the (source, group) pair
+          matched by ingress packets. The source address 0.0.0.0
+          represents any-source (*,G) entries.
+
+          This table captures multicast forwarding state installed by
+          any protocol (PIM-SM, PIM-DM, PIM-SSM, PIM-BiDir, DVMRP,
+          BGP MVPN, static) and represents the active replication
+          state including the upstream reverse-path interface and the
+          list of outgoing interfaces. For MPLS P2MP ingress and
+          egress PE nodes, outgoing interfaces may carry MPLS label
+          stacks or indicate MPLS decapsulation respectively.
+
+          MPLS P2MP transit node state, which has no IP-layer (S,G)
+          knowledge, is represented in the mpls-multicast table.";
+
+        uses aft-ipv4-multicast-structural;
+      }
+
+      container ipv6-multicast {
+        config false;
+        description
+          "The abstract forwarding table for IPv6 multicast. Entries
+          within this table are keyed by the (source, group) pair
+          matched by ingress packets. The source address ::
+          represents any-source (*,G) entries.
+
+          This table captures multicast forwarding state installed by
+          any protocol (PIM-SM, PIM-DM, PIM-SSM, PIM-BiDir, BGP MVPN,
+          static) and represents the active replication state
+          including the upstream reverse-path interface and the list
+          of outgoing interfaces. For MPLS P2MP ingress and egress PE
+          nodes, outgoing interfaces may carry MPLS label stacks or
+          indicate MPLS decapsulation respectively.
+
+          MPLS P2MP transit node state is represented in the
+          mpls-multicast table.";
+
+        uses aft-ipv6-multicast-structural;
+      }
+
+      container mpls-multicast {
+        config false;
+        description
+          "The abstract forwarding table for MPLS multicast (P2MP)
+          label forwarding. Entries within this table are keyed by
+          the top-most incoming MPLS label.
+
+          This table represents the forwarding state of MPLS P2MP
+          transit nodes such as those running mLDP or RSVP-TE P2MP,
+          where packets arrive with a specific label and are
+          replicated to one or more outgoing interfaces each
+          potentially with a different label stack. IP-layer (S,G)
+          state at PE nodes is captured in the ipv4-multicast and
+          ipv6-multicast tables.";
+
+        uses aft-mpls-multicast-structural;
       }
 
       container policy-forwarding {


### PR DESCRIPTION
As an operator, I need a standard way to monitor the current forwarding behavior of multicast on my network, across multiple vendor types.  

Most(?) platforms forward multicast under a input interface / OIL model, keyed by various FECs.  This change attempts to provide an initial implementation for IPv4, IPv6, and MPLS forwarding of multicast traffic.

### Change Scope

* Add multicast-focused AFTs
* This change only adds new AFTs, and should be backwards compatible with existing implementations of AFT

### Platform Implementations

 * Implementation A: [Arista](https://arista.com/en/um-eos/eos-multicast-architecture/#xx1209301)
 * Implementation B: [Cisco](https://www.cisco.com/en/US/docs/routers/crs/software/crs_r4.0/multicast/command/reference/b_mrcrs40book_chapter_011.html)
 * Implementation C: [Linux](https://man7.org/linux/man-pages/man8/ip-mroute.8.html)

### Tree View

```diff
--- /home/bewing/old-tree.txt   2026-05-20 11:44:22.678265610 -0500
+++ /home/bewing/new-tree.txt   2026-05-20 12:50:19.973577532 -0500
@@ -3853,390 +3853,475 @@
         |  |        +--rw next-hop* [index]
         |  |           +--rw index     -> ../config/index
         |  |           +--rw config
         |  |           |  +--rw index?   -> ../../../../../../next-hops/next-hop/index
         |  |           +--ro state
         |  |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
         |  +--rw next-hops
         |     +--rw next-hop* [index]
         |        +--rw index            -> ../config/index
         |        +--rw config
         |        |  +--rw index?                                     string
         |        |  +--rw next-hop?                                  union
         |        |  +--rw recurse?                                   boolean
         |        |  +--rw metric?                                    uint32
         |        |  +--rw preference?                                uint32
         |        |  +--rw wecmp-weight?                              union
         |        |  +--rw oc-loc-rt-netinst:next-network-instance?   -> /oc-ni:network-instances/network-instance/config/name
         |        |  +--rw oc-loc-rt-netinst:nh-network-instance?     -> /oc-ni:network-instances/network-instance/config/name
         |        +--ro state
         |        |  +--ro index?                                     string
         |        |  +--ro next-hop?                                  union
         |        |  +--ro recurse?                                   boolean
         |        |  +--ro metric?                                    uint32
         |        |  +--ro preference?                                uint32
         |        |  +--ro wecmp-weight?                              union
         |        |  +--ro oc-loc-rt-netinst:next-network-instance?   -> /oc-ni:network-instances/network-instance/config/name
         |        |  +--ro oc-loc-rt-netinst:nh-network-instance?     -> /oc-ni:network-instances/network-instance/config/name
         |        +--rw encap-headers
         |           +--rw encap-header* [index]
         |              +--rw index     -> ../config/index
         |              +--rw config
         |              |  +--rw index?   uint8
         |              |  +--rw type?    oc-aftt:encapsulation-header-type
         |              +--ro state
         |              |  +--ro index?   uint8
         |              |  +--ro type?    oc-aftt:encapsulation-header-type
         |              +--rw udp-v4
         |              |  +--rw config
         |              |  |  +--rw src-ip?         oc-inet:ipv4-address
         |              |  |  +--rw dst-ip?         oc-inet:ipv4-address
         |              |  |  +--rw dscp?           oc-inet:dscp
         |              |  |  +--rw src-udp-port?   oc-inet:port-number
         |              |  |  +--rw dst-udp-port?   oc-inet:port-number
         |              |  |  +--rw ip-ttl?         uint8
         |              |  +--ro state
         |              |     +--ro src-ip?         oc-inet:ipv4-address
         |              |     +--ro dst-ip?         oc-inet:ipv4-address
         |              |     +--ro dscp?           oc-inet:dscp
         |              |     +--ro src-udp-port?   oc-inet:port-number
         |              |     +--ro dst-udp-port?   oc-inet:port-number
         |              |     +--ro ip-ttl?         uint8
         |              +--rw gre
         |              |  +--rw config
         |              |  |  +--rw src-ip?   oc-inet:ip-address
         |              |  |  +--rw dst-ip?   oc-inet:ip-address
         |              |  |  +--rw ttl?      uint8
         |              |  +--ro state
         |              |     +--ro src-ip?   oc-inet:ip-address
         |              |     +--ro dst-ip?   oc-inet:ip-address
         |              |     +--ro ttl?      uint8
         |              +--rw mpls
         |                 +--rw config
         |                 |  +--rw traffic-class?   oc-mplst:mpls-tc
         |                 |  +--rw label?           oc-mplst:mpls-label
         |                 +--ro state
         |                    +--ro traffic-class?   oc-mplst:mpls-tc
         |                    +--ro label?           oc-mplst:mpls-label
         +--rw afts
         |  +--ro ipv4-unicast
         |  |  +--ro ipv4-entry* [prefix]
         |  |     +--ro prefix    -> ../state/prefix
         |  |     +--ro state
         |  |        +--ro prefix?                                     oc-inet:ipv4-prefix
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?          oc-yang:counter64
         |  |        |  x--ro octets-forwarded?           oc-yang:counter64
         |  |        |  x--ro packets-forwarded-backup?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded-backup?    oc-yang:counter64
         |  |        +--ro entry-metadata?                             binary
         |  |        +--ro origin-protocol?                            identityref
         |  |        +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
         |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
         |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
         |  |        +--ro oc-aftni:origin-network-instance?           oc-ni:network-instance-ref
         |  +--ro ipv6-unicast
         |  |  +--ro ipv6-entry* [prefix]
         |  |     +--ro prefix    -> ../state/prefix
         |  |     +--ro state
         |  |        +--ro prefix?                                     oc-inet:ipv6-prefix
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?          oc-yang:counter64
         |  |        |  x--ro octets-forwarded?           oc-yang:counter64
         |  |        |  x--ro packets-forwarded-backup?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded-backup?    oc-yang:counter64
         |  |        +--ro entry-metadata?                             binary
         |  |        +--ro origin-protocol?                            identityref
         |  |        +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
         |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
         |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
         |  |        +--ro oc-aftni:origin-network-instance?           oc-ni:network-instance-ref
+        |  +--ro ipv4-multicast
+        |  |  +--ro ipv4-multicast-entry* [source-address group-address]
+        |  |     +--ro source-address    -> ../state/source-address
+        |  |     +--ro group-address     -> ../state/group-address
+        |  |     +--ro state
+        |  |        +--ro source-address?                             oc-inet:ipv4-address
+        |  |        +--ro group-address?                              oc-inet:ipv4-address
+        |  |        +--ro counters
+        |  |        |  x--ro packets-forwarded?   oc-yang:counter64
+        |  |        |  x--ro octets-forwarded?    oc-yang:counter64
+        |  |        +--ro entry-metadata?                             binary
+        |  |        +--ro origin-protocol?                            identityref
+        |  |        +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
+        |  |        +--ro reverse-path-interface
+        |  |        |  +--ro interface-ref
+        |  |        |     +--ro state
+        |  |        |        +--ro interface?      -> /oc-if:interfaces/interface/name
+        |  |        |        +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
+        |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
+        |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
+        |  +--ro ipv6-multicast
+        |  |  +--ro ipv6-multicast-entry* [source-address group-address]
+        |  |     +--ro source-address    -> ../state/source-address
+        |  |     +--ro group-address     -> ../state/group-address
+        |  |     +--ro state
+        |  |        +--ro source-address?                             oc-inet:ipv6-address
+        |  |        +--ro group-address?                              oc-inet:ipv6-address
+        |  |        +--ro counters
+        |  |        |  x--ro packets-forwarded?   oc-yang:counter64
+        |  |        |  x--ro octets-forwarded?    oc-yang:counter64
+        |  |        +--ro entry-metadata?                             binary
+        |  |        +--ro origin-protocol?                            identityref
+        |  |        +--ro decapsulate-header?                         oc-aftt:encapsulation-header-type
+        |  |        +--ro reverse-path-interface
+        |  |        |  +--ro interface-ref
+        |  |        |     +--ro state
+        |  |        |        +--ro interface?      -> /oc-if:interfaces/interface/name
+        |  |        |        +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
+        |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
+        |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
+        |  +--ro mpls-multicast
+        |  |  +--ro multicast-label-entry* [label]
+        |  |     +--ro label                      -> ../state/label
+        |  |     +--ro state
+        |  |     |  +--ro label?                                      oc-mplst:mpls-label
+        |  |     |  +--ro counters
+        |  |     |  |  x--ro packets-forwarded?   oc-yang:counter64
+        |  |     |  |  x--ro octets-forwarded?    oc-yang:counter64
+        |  |     |  +--ro entry-metadata?                             binary
+        |  |     |  +--ro origin-protocol?                            identityref
+        |  |     |  +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
+        |  |     |  +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
+        |  |     +--ro decap-mpls-label-stacks
+        |  |        +--ro decap-mpls-label-stack* [id]
+        |  |           +--ro id       -> ../state/id
+        |  |           +--ro state
+        |  |              +--ro id?      uint8
+        |  |              +--ro label?   oc-mplst:mpls-label
         |  +--ro policy-forwarding
         |  |  +--ro policy-forwarding-entry* [index]
         |  |     +--ro index    -> ../state/index
         |  |     +--ro state
         |  |        +--ro index?                                      uint64
         |  |        +--ro ip-prefix?                                  oc-inet:ip-prefix
         |  |        +--ro mac-address?                                oc-yang:mac-address
         |  |        +--ro mpls-label?                                 oc-mplst:mpls-label
         |  |        +--ro mpls-tc?                                    oc-mplst:mpls-tc
         |  |        +--ro ip-dscp?                                    oc-inet:dscp
         |  |        +--ro ip-protocol?                                oc-pkt-match-types:ip-protocol-type
         |  |        +--ro l4-src-port?                                oc-inet:port-number
         |  |        +--ro l4-dst-port?                                oc-inet:port-number
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded?    oc-yang:counter64
         |  |        +--ro entry-metadata?                             binary
         |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
         |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
         |  +--ro mpls
         |  |  +--ro label-entry* [label]
         |  |     +--ro label                      -> ../state/label
         |  |     +--ro state
         |  |     |  +--ro label?                                      oc-mplst:mpls-label
         |  |     |  +--ro counters
         |  |     |  |  x--ro packets-forwarded?   oc-yang:counter64
         |  |     |  |  x--ro octets-forwarded?    oc-yang:counter64
         |  |     |  +--ro entry-metadata?                             binary
         |  |     |  x--ro popped-mpls-label-stack*                    oc-mplst:mpls-label
         |  |     |  +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
         |  |     |  +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
         |  |     +--ro decap-mpls-label-stacks
         |  |        +--ro decap-mpls-label-stack* [id]
         |  |           +--ro id       -> ../state/id
         |  |           +--ro state
         |  |              +--ro id?      uint8
         |  |              +--ro label?   oc-mplst:mpls-label
         |  +--ro ethernet
         |  |  +--ro mac-entry* [mac-address]
         |  |     +--ro mac-address    -> ../state/mac-address
         |  |     +--ro state
         |  |        +--ro mac-address?                                oc-yang:mac-address
         |  |        +--ro counters
         |  |        |  x--ro packets-forwarded?   oc-yang:counter64
         |  |        |  x--ro octets-forwarded?    oc-yang:counter64
         |  |        +--ro entry-metadata?                             binary
         |  |        +--ro oc-aftni:next-hop-group?                    -> /oc-ni:network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/id
         |  |        +--ro oc-aftni:next-hop-group-network-instance?   oc-ni:network-instance-ref
         |  +--ro state-synced
         |  |  +--ro state
         |  |     +--ro ipv4-unicast?   boolean
         |  |     +--ro ipv6-unicast?   boolean
         |  +--ro next-hop-groups
         |  |  +--ro next-hop-group* [id]
         |  |     +--ro id             -> ../state/id
         |  |     +--ro state
         |  |     |  +--ro id?                      uint64
         |  |     |  +--ro next-hop-group-name?     string
         |  |     |  +--ro programmed-id?           uint64
         |  |     |  +--ro color?                   uint64
         |  |     |  +--ro backup-next-hop-group?   -> ../../../next-hop-group/state/id
         |  |     |  +--ro backup-active?           boolean
         |  |     +--ro next-hops
         |  |     |  +--ro next-hop* [index]
         |  |     |     +--ro index    -> ../state/index
         |  |     |     +--ro state
         |  |     |        +--ro index?    -> ../../../../../../next-hops/next-hop/state/index
         |  |     |        +--ro weight?   uint64
         |  |     +--ro conditional
         |  |        +--ro condition* [id]
         |  |           +--ro id                  -> ../state/id
         |  |           +--ro state
         |  |           |  +--ro id?               uint64
         |  |           |  +--ro dscp*             oc-inet:dscp
         |  |           |  +--ro next-hop-group?   -> ../../../../../next-hop-group/state/id
         |  |           +--ro input-interfaces
         |  |              +--ro input-interface* [id]
         |  |                 +--ro id       -> ../state/id
         |  |                 +--ro state
         |  |                    +--ro id?             string
         |  |                    +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |                    +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
         |  +--ro next-hops
         |  |  +--ro next-hop* [index]
         |  |     +--ro index            -> ../state/index
         |  |     +--ro state
         |  |     |  +--ro index?                       uint64
         |  |     |  +--ro programmed-index?            uint64
         |  |     |  +--ro ip-address?                  oc-inet:ip-address
         |  |     |  +--ro mac-address?                 oc-yang:mac-address
         |  |     |  +--ro pop-top-label?               boolean
         |  |     |  x--ro pushed-mpls-label-stack*     oc-mplst:mpls-label
         |  |     |  +--ro encapsulate-header?          oc-aftt:encapsulation-header-type
         |  |     |  +--ro decapsulate-header?          oc-aftt:encapsulation-header-type
         |  |     |  +--ro origin-protocol?             identityref
         |  |     |  +--ro lsp-name?                    string
         |  |     |  +--ro counters
         |  |     |  |  x--ro packets-forwarded?   oc-yang:counter64
         |  |     |  |  x--ro octets-forwarded?    oc-yang:counter64
         |  |     |  +--ro vni-label?                   oc-evpn-types:evi-id
         |  |     |  +--ro tunnel-src-ip-address?       oc-inet:ip-address
         |  |     |  +--ro oc-aftni:network-instance?   oc-ni:network-instance-ref
         |  |     +--ro ip-in-ip
         |  |     |  +--ro state
         |  |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     +--ro gre
         |  |     |  +--ro state
         |  |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro ttl?      uint8
         |  |     +--ro encap-headers
         |  |     |  +--ro encap-header* [index]
         |  |     |     +--ro index     -> ../state/index
         |  |     |     +--ro state
         |  |     |     |  +--ro index?   uint8
         |  |     |     |  +--ro type?    oc-aftt:encapsulation-header-type
         |  |     |     +--ro gre
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     |     +--ro ttl?      uint8
         |  |     |     +--ro ipv4
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro ipv6
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?   oc-inet:ip-address
         |  |     |     |     +--ro dst-ip?   oc-inet:ip-address
         |  |     |     +--ro mpls
         |  |     |     |  +--ro state
         |  |     |     |  |  +--ro traffic-class?      oc-mplst:mpls-tc
         |  |     |     |  |  x--ro mpls-label-stack*   oc-mplst:mpls-label
         |  |     |     |  +--ro encap-mpls-label-stacks
         |  |     |     |     +--ro encap-mpls-label-stack* [id]
         |  |     |     |        +--ro id       -> ../state/id
         |  |     |     |        +--ro state
         |  |     |     |           +--ro id?      uint8
         |  |     |     |           +--ro label?   oc-mplst:mpls-label
         |  |     |     +--ro udp-v4
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?         oc-inet:ipv4-address
         |  |     |     |     +--ro dst-ip?         oc-inet:ipv4-address
         |  |     |     |     +--ro dscp?           oc-inet:dscp
         |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro ip-ttl?         uint8
         |  |     |     +--ro udp-v6
         |  |     |     |  +--ro state
         |  |     |     |     +--ro src-ip?         oc-inet:ipv6-address
         |  |     |     |     +--ro dst-ip?         oc-inet:ipv6-address
         |  |     |     |     +--ro dscp?           oc-inet:dscp
         |  |     |     |     +--ro src-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro dst-udp-port?   oc-inet:port-number
         |  |     |     |     +--ro ip-ttl?         uint8
         |  |     |     +--ro vxlan
         |  |     |        +--ro state
         |  |     |           +--ro vni-label?               oc-evpn-types:evi-id
         |  |     |           +--ro tunnel-src-ip-address?   oc-inet:ip-address
         |  |     +--ro interface-ref
         |  |        +--ro state
         |  |           +--ro interface?      -> /oc-if:interfaces/interface/name
         |  |           +--ro subinterface?   -> /oc-if:interfaces/interface[oc-if:name=current()/../interface]/subinterfaces/subinterface/index
         |  +--ro oc-aft-counters:counters
         |  |  +--ro oc-aft-counters:ipv4-unicast
         |  |  |  +--ro oc-aft-counters:ipv4-entry* [prefix]
         |  |  |     +--ro oc-aft-counters:prefix    -> ../state/prefix
         |  |  |     +--ro oc-aft-counters:state
         |  |  |        +--ro oc-aft-counters:prefix?                     oc-inet:ipv4-prefix
         |  |  |        +--ro oc-aft-counters:packets-forwarded?          oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded?           oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:packets-forwarded-backup?   oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded-backup?    oc-yang:counter64
         |  |  +--ro oc-aft-counters:ipv6-unicast
         |  |  |  +--ro oc-aft-counters:ipv6-entry* [prefix]
         |  |  |     +--ro oc-aft-counters:prefix    -> ../state/prefix
         |  |  |     +--ro oc-aft-counters:state
         |  |  |        +--ro oc-aft-counters:prefix?                     oc-inet:ipv6-prefix
         |  |  |        +--ro oc-aft-counters:packets-forwarded?          oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded?           oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:packets-forwarded-backup?   oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded-backup?    oc-yang:counter64
         |  |  +--ro oc-aft-counters:mpls
         |  |  |  +--ro oc-aft-counters:label-entry* [label]
         |  |  |     +--ro oc-aft-counters:label    -> ../state/label
         |  |  |     +--ro oc-aft-counters:state
         |  |  |        +--ro oc-aft-counters:label?               oc-mplst:mpls-label
         |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
+        |  |  +--ro oc-aft-counters:ipv4-multicast
+        |  |  |  +--ro oc-aft-counters:ipv4-multicast-entry* [source-address group-address]
+        |  |  |     +--ro oc-aft-counters:source-address    -> ../state/source-address
+        |  |  |     +--ro oc-aft-counters:group-address     -> ../state/group-address
+        |  |  |     +--ro oc-aft-counters:state
+        |  |  |        +--ro oc-aft-counters:source-address?      oc-inet:ipv4-address
+        |  |  |        +--ro oc-aft-counters:group-address?       oc-inet:ipv4-address
+        |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
+        |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
+        |  |  |        +--ro oc-aft-counters:rpf-discards?        oc-yang:counter64
+        |  |  +--ro oc-aft-counters:ipv6-multicast
+        |  |  |  +--ro oc-aft-counters:ipv6-multicast-entry* [source-address group-address]
+        |  |  |     +--ro oc-aft-counters:source-address    -> ../state/source-address
+        |  |  |     +--ro oc-aft-counters:group-address     -> ../state/group-address
+        |  |  |     +--ro oc-aft-counters:state
+        |  |  |        +--ro oc-aft-counters:source-address?      oc-inet:ipv6-address
+        |  |  |        +--ro oc-aft-counters:group-address?       oc-inet:ipv6-address
+        |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
+        |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
+        |  |  |        +--ro oc-aft-counters:rpf-discards?        oc-yang:counter64
+        |  |  +--ro oc-aft-counters:mpls-multicast
+        |  |  |  +--ro oc-aft-counters:multicast-label-entry* [label]
+        |  |  |     +--ro oc-aft-counters:label    -> ../state/label
+        |  |  |     +--ro oc-aft-counters:state
+        |  |  |        +--ro oc-aft-counters:label?               oc-mplst:mpls-label
+        |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
+        |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
         |  |  +--ro oc-aft-counters:ethernet
         |  |  |  +--ro oc-aft-counters:mac-entry* [mac-address]
         |  |  |     +--ro oc-aft-counters:mac-address    -> ../state/mac-address
         |  |  |     +--ro oc-aft-counters:state
         |  |  |        +--ro oc-aft-counters:mac-address?         oc-yang:mac-address
         |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
         |  |  +--ro oc-aft-counters:policy-forwarding
         |  |  |  +--ro oc-aft-counters:policy-forwarding-entry* [index]
         |  |  |     +--ro oc-aft-counters:index    -> ../state/index
         |  |  |     +--ro oc-aft-counters:state
         |  |  |        +--ro oc-aft-counters:index?               uint64
         |  |  |        +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
         |  |  |        +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
         |  |  +--ro oc-aft-counters:next-hops
         |  |     +--ro oc-aft-counters:next-hop* [index]
         |  |        +--ro oc-aft-counters:index    -> ../state/index
         |  |        +--ro oc-aft-counters:state
         |  |           +--ro oc-aft-counters:index?               uint64
         |  |           +--ro oc-aft-counters:packets-forwarded?   oc-yang:counter64
         |  |           +--ro oc-aft-counters:octets-forwarded?    oc-yang:counter64
         |  +--rw oc-aft-gf:global-filter
         |  |  +--rw oc-aft-gf:config
         |  |  |  +--rw oc-aft-gf:ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
         |  |  |  +--rw oc-aft-gf:ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
         |  |  +--ro oc-aft-gf:state
         |  |     +--ro oc-aft-gf:ipv6-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
         |  |     +--ro oc-aft-gf:ipv4-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/config/name
         |  +--rw oc-aftsummary:aft-summaries
         |     +--rw oc-aftsummary:ipv4-unicast
         |     |  +--ro oc-aftsummary:protocols
         |     |     +--ro oc-aftsummary:protocol* [origin-protocol]
         |     |        +--ro oc-aftsummary:origin-protocol    -> ../state/origin-protocol
         |     |        +--ro oc-aftsummary:state
         |     |           +--ro oc-aftsummary:origin-protocol?   identityref
         |     |           +--ro oc-aftsummary:counters
         |     |              +--ro oc-aftsummary:aft-entries?   uint64
         |     +--rw oc-aftsummary:ipv6-unicast
         |        +--ro oc-aftsummary:protocols
         |           +--ro oc-aftsummary:protocol* [origin-protocol]
         |              +--ro oc-aftsummary:origin-protocol    -> ../state/origin-protocol
         |              +--ro oc-aftsummary:state
         |                 +--ro oc-aftsummary:origin-protocol?   identityref
         |                 +--ro oc-aftsummary:counters
         |                    +--ro oc-aftsummary:aft-entries?   uint64
         +--rw protocols
         |  +--rw protocol* [identifier name]
         |     +--rw identifier          -> ../config/identifier
         |     +--rw name                -> ../config/name
         |     +--rw config
         |     |  +--rw identifier?       identityref
         |     |  +--rw name?             string
         |     |  +--rw enabled?          boolean
         |     |  +--rw default-metric?   uint32
         |     +--ro state
         |     |  +--ro identifier?       identityref
         |     |  +--ro name?             string
         |     |  +--ro enabled?          boolean
         |     |  +--ro default-metric?   uint32
         |     +--rw static-routes
         |     |  +--rw static* [prefix]
         |     |     +--rw prefix                              -> ../config/prefix
         |     |     +--rw config
         |     |     |  +--rw prefix?        inet:ip-prefix
         |     |     |  +--rw set-tag?       oc-pt:tag-type
         |     |     |  +--rw description?   string
         |     |     +--ro state
         |     |     |  +--ro prefix?        inet:ip-prefix
         |     |     |  +--ro set-tag?       oc-pt:tag-type
         |     |     |  +--ro description?   string
         |     |     +--rw next-hops
         |     |     |  +--rw next-hop* [index]
         |     |     |     +--rw index            -> ../config/index
         |     |     |     +--rw config
         |     |     |     |  +--rw index?                                     string
         |     |     |     |  +--rw next-hop?                                  union
         |     |     |     |  +--rw recurse?                                   boolean
         |     |     |     |  +--rw metric?                                    uint32
         |     |     |     |  +--rw preference?                                uint32
         |     |     |     |  +--rw wecmp-weight?                              union
         |     |     |     |  +--rw oc-loc-rt-netinst:next-network-instance?   -> /oc-ni:network-instances/network-instance/config/name
         |     |     |     |  +--rw oc-loc-rt-netinst:nh-network-instance?     -> /oc-ni:network-instances/network-instance/config/name
         |     |     |     +--ro state
         |     |     |     |  +--ro index?                                     string
         |     |     |     |  +--ro next-hop?                                  union
         |     |     |     |  +--ro recurse?                                   boolean
         |     |     |     |  +--ro metric?                                    uint32
         |     |     |     |  +--ro preference?                                uint32
         |     |     |     |  +--ro wecmp-weight?                              union
         |     |     |     |  +--ro oc-loc-rt-netinst:next-network-instance?   -> /oc-ni:network-instances/network-instance/config/name
         |     |     |     |  +--ro oc-loc-rt-netinst:nh-network-instance?     -> /oc-ni:network-instances/network-instance/config/name
         |     |     |     +--rw enable-bfd
         |     |     |     |  +--rw config
         |     |     |     |  |  +--rw enabled?                       boolean
         |     |     |     |  |  +--rw desired-minimum-tx-interval?   uint32
         |     |     |     |  |  +--rw required-minimum-receive?      uint32
         |     |     |     |  |  +--rw detection-multiplier?          uint8
         |     |     |     |  +--ro state
         |     |     |     |     +--ro enabled?                       boolean
         |     |     |     |     +--ro desired-minimum-tx-interval?   uint32
```