### PR TITLE
Interface MTU type adjustments and description updates

### DIFF
--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -45,29 +45,40 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.9.0";
+  oc-ext:openconfig-version "3.9.1";
 
-    revision "2025-06-20" {
+  revision "2026-04-05" {
     description
-      "Add IPv6 Router Advertisement Options for DNS Configuration (RDNSS) RFC 8106.";
-      reference "3.9.0";
+      "Update IPv6 mtu reference from obsoleted RFC 2460 to RFC 8200.
+      Add RFC 2675 reference for jumbogram support justifying the uint32
+      type.";
+    reference "3.9.1";
   }
 
-    revision "2025-06-20" {
+  revision "2025-06-20" {
     description
-      "Add model for support of URPF source address validation through network-instance different then one used for destination lookup";
-      reference "3.8.0";
+      "Add IPv6 Router Advertisement Options for DNS Configuration
+      (RDNSS) RFC 8106.";
+    reference "3.9.0";
+  }
+
+  revision "2025-06-20" {
+    description
+      "Add model for support of URPF source address validation through
+      network-instance different then one used for destination lookup";
+    reference "3.8.0";
   }
 
   revision "2025-05-12" {
     description
       "Add model for support of URPF source address verification";
-      reference "3.7.0";
+    reference "3.7.0";
   }
 
   revision "2024-05-28" {
     description
-      "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted for IPv6.";
+      "Add gratuitous-arp-accepted for IPv4 and unsolicited-na-accepted
+      for IPv6.";
     reference "3.6.0";
   }
 
@@ -83,10 +94,10 @@ module openconfig-if-ip {
     reference "3.5.0";
   }
 
-revision "2023-06-30" {
+  revision "2023-06-30" {
     description
-      "Deprecate IPv6 router advertisment config suppress leaf and add config
-      mode leaf.";
+      "Deprecate IPv6 router advertisment config suppress leaf and add
+      config mode leaf.";
     reference "3.4.0";
   }
 
@@ -134,9 +145,8 @@ revision "2023-06-30" {
 
   revision "2017-07-14" {
     description
-      "Added Ethernet/IP state data; Add dhcp-client;
-      migrate to OpenConfig types modules; Removed or
-      renamed opstate values";
+      "Added Ethernet/IP state data; Add dhcp-client; migrate to
+      OpenConfig types modules; Removed or renamed opstate values";
     reference "2.0.0";
   }
 
@@ -524,13 +534,13 @@ revision "2023-06-30" {
      units octets;
      description
        "The size, in octets, of the largest IPv4 packet that the
-        interface will send and receive.
+       interface will send and receive.
 
-        The server may restrict the allowed values for this leaf,
-        depending on the interface's type.
+       The server may restrict the allowed values for this leaf,
+       depending on the interface's type.
 
-        If this leaf is not configured, the operationally used MTU
-        depends on the interface's type.";
+       If this leaf is not configured, the operationally used MTU
+       depends on the interface's type.";
      reference
        "RFC 791: Internet Protocol";
     }
@@ -651,8 +661,9 @@ revision "2023-06-30" {
         If this leaf is not configured, the operationally used MTU
         depends on the interface's type.";
       reference
-        "RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
-                  Section 5";
+        "RFC 8200: Internet Protocol, Version 6 (IPv6) Specification
+                   Section 5
+         RFC 2675: IPv6 Jumbograms";
     }
 
     leaf dup-addr-detect-transmits {

--- a/release/models/interfaces/openconfig-if-ip.yang
+++ b/release/models/interfaces/openconfig-if-ip.yang
@@ -47,7 +47,7 @@ module openconfig-if-ip {
 
   oc-ext:openconfig-version "3.9.1";
 
-  revision "2026-04-05" {
+  revision "2026-05-11" {
     description
       "Update IPv6 mtu reference from obsoleted RFC 2460 to RFC 8200.
       Add RFC 2675 reference for jumbogram support justifying the uint32

--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -1,0 +1,56 @@
+module openconfig-if-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces/types";
+
+  prefix "oc-ift";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2026-04-05" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef max-frame-size {
+    type uint32;
+    units octets;
+    description
+     "The maximum frame size in octets that may be transmitted or
+     received on an interface. For Ethernet interfaces, this value
+     includes the Ethernet header but excludes the 4-octet frame check
+     sequence (FCS) per IEEE 802.3. For non-Ethernet interface types
+     (e.g., loopback, tunnel), the value represents the maximum
+     transmission unit of the interface without Layer 2 framing overhead
+     specific to the encapsulation type.
+
+     If configured, the max-frame-size also limits the maximum frame
+     size of any child sub-interfaces. The MTU available to higher layer
+     protocols is restricted to the maximum frame payload size, and may
+     be further restricted by explicit Layer 3 or protocol specific MTU
+     configuration.";
+  }
+}

--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -19,7 +19,7 @@ module openconfig-if-types {
 
   description
     "This module defines types and identities used in OpenConfig models
-    related to Interfaces."
+    related to Interfaces.";
 
   oc-ext:openconfig-version "0.1.0";
 

--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -23,7 +23,7 @@ module openconfig-if-types {
 
   oc-ext:openconfig-version "0.1.0";
 
-  revision "2026-04-05" {
+  revision "2026-05-11" {
     description
       "Initial revision.";
     reference "0.1.0";

--- a/release/models/interfaces/openconfig-if-types.yang
+++ b/release/models/interfaces/openconfig-if-types.yang
@@ -18,7 +18,8 @@ module openconfig-if-types {
     netopenconfig@googlegroups.com";
 
   description
-    "";
+    "This module defines types and identities used in OpenConfig models
+    related to Interfaces."
 
   oc-ext:openconfig-version "0.1.0";
 

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -54,7 +54,7 @@ module openconfig-interfaces {
 
   oc-ext:openconfig-version "4.0.0";
 
-  revision "2026-04-05" {
+  revision "2026-05-11" {
     description
       "Change interface mtu type from uint16 to max-frame-size (uint32)
       typedef to support MTU values exceeding 16-bit boundaries as seen

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -13,6 +13,7 @@ module openconfig-interfaces {
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-transport-types { prefix oc-opt-types; }
+  import openconfig-if-types { prefix oc-ift; }
 
   // meta
   organization "OpenConfig working group";
@@ -51,48 +52,54 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.8.1";
+  oc-ext:openconfig-version "4.0.0";
+
+  revision "2026-04-05" {
+    description
+      "Change interface mtu type from uint16 to max-frame-size (uint32)
+      typedef to support MTU values exceeding 16-bit boundaries as seen
+      on loopback and non-Ethernet interface types. Clarify L2 frame
+      size semantics in description.";
+    reference "4.0.0";
+  }
 
   revision "2026-01-06" {
-      description
-        "Fix typos in descriptions for hardware-specific and interface statistics entities.";
-      reference
-        "3.8.1";
+    description
+      "Fix typos in descriptions for hardware-specific and interface
+      statistics entities.";
+    reference "3.8.1";
   }
 
   revision "2024-12-05" {
-      description
-        "Add interface-transitions and link-transitions counters";
-      reference
-        "3.8.0";
+    description
+      "Add interface-transitions and link-transitions counters";
+    reference "3.8.0";
   }
 
   revision "2024-12-05" {
-      description
-        "Description typo for unnumbered/interface-ref/config/subinterface leaf";
-      reference
-        "3.7.2";
+    description
+      "Description typo for unnumbered/interface-ref/config/subinterface
+      leaf";
+    reference "3.7.2";
   }
 
   revision "2024-04-04" {
-      description
-        "Use single quotes in descriptions.";
-      reference
-        "3.7.1";
+    description
+      "Use single quotes in descriptions.";
+    reference "3.7.1";
   }
 
   revision "2023-11-06" {
-      description
-        "Clarify description for admin-status TESTING.";
-      reference
-        "3.7.0";
+    description
+      "Clarify description for admin-status TESTING.";
+    reference "3.7.0";
   }
 
   revision "2023-08-29" {
-      description
-        "Add augment for penalty-based additive-increase, exponential-decrease link damping algorithm.";
-      reference
-        "3.6.0";
+    description
+      "Add augment for penalty-based additive-increase,
+      exponential-decrease link damping algorithm.";
+    reference "3.6.0";
   }
 
   revision "2023-07-14" {
@@ -458,12 +465,11 @@ module openconfig-interfaces {
     }
 
     leaf mtu {
-      type uint16;
+      type oc-ift:max-frame-size;
       description
-        "Set the max transmission unit size in octets
-        for the physical interface.  If this is not set, the mtu is
-        set to the operational default -- e.g., 1514 bytes on an
-        Ethernet interface.";
+        "The maximum frame size for the physical interface. If this is
+        not set, the mtu is set to the operational default -- e.g., 1514
+        bytes on an Ethernet interface.";
     }
 
     leaf loopback-mode {


### PR DESCRIPTION
  * (M) release/models/interfaces/openconfig-interfaces.yang
    - Change interface MTU type from uint16 to max-frame-size (uint32)
    - Increment to version 4.0.0
  * (M) release/models/interfaces/openconfig-if-ip.yang
    - Update IPv4/IPv6 MTU descriptions
    - Increment to version 3.9.1
  * (A) release/models/interfaces/openconfig-if-types.yang
    - Initial version 0.1.0
    - Introduction of max-frame-size typedef

### Change Scope

Per discussion in the OC community call on 2026-04-02, this PR moves forward on
https://github.com/openconfig/public/issues/1449.

- Introduce `max-frame-size` typedef (`uint32`) in new
  `openconfig-if-types.yang` with L2 frame size semantics excluding FCS per IEEE
  802.3
- Change interface `mtu` leaf type from `uint16` to `max-frame-size`
  (`openconfig-interfaces` `3.8.1` -> `4.0.0`)
- Update IPv6 `mtu` references from obsoleted RFC 2460 to RFC 8200, add RFC 2675
  (`openconfig-if-ip` `3.9.0` -> `3.9.1`)

While this change is backwards incompatible per type changes, it is anticipated
that implementations and consumers can adjust to the larger space.

### Platform Implementations

N/A

### Tree View

```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         +--rw name                   -> ../config/name
         +--rw config
         |  +--rw name?                          string
         |  +--rw type                           identityref
-        |  +--rw mtu?                           uint16
+        |  +--rw mtu?                           oc-ift:max-frame-size
         |  +--rw loopback-mode?                 oc-opt-types:loopback-mode-type
         |  +--rw description?                   string
         |  +--rw enabled?                       boolean
         |  +--rw oc-vlan:tpid?                  identityref
         |  +--rw oc-if-sdn:forwarding-viable?   boolean
         |  +--rw oc-p4rt:id?                    uint32
         |  +--rw oc-hashing:hashing-policy?     -> /oc-sys:system/hashing/hashing-policies/hashing-policy/name
         +--ro state
         |  +--ro name?                              string
         |  +--ro type                               identityref
-        |  +--ro mtu?                               uint16
+        |  +--ro mtu?                               oc-ift:max-frame-size
         |  +--ro loopback-mode?                     oc-opt-types:loopback-mode-type
         |  +--ro description?                       string
         |  +--ro enabled?                           boolean
         |  +--ro ifindex?                           uint32
         |  +--ro admin-status                       enumeration
         |  +--ro oper-status                        enumeration
         |  +--ro last-change?                       oc-types:timeticks64
         |  +--ro logical?                           boolean
         |  +--ro management?                        boolean
         |  +--ro cpu?                               boolean
         |  +--ro counters
         |  |  +--ro in-octets?               oc-yang:counter64
         |  |  +--ro in-pkts?                 oc-yang:counter64
         |  |  +--ro in-unicast-pkts?         oc-yang:counter64
         |  |  +--ro in-broadcast-pkts?       oc-yang:counter64
         |  |  +--ro in-multicast-pkts?       oc-yang:counter64
         |  |  +--ro in-errors?               oc-yang:counter64
         |  |  +--ro in-discards?             oc-yang:counter64
         |  |  +--ro out-octets?              oc-yang:counter64
         |  |  +--ro out-pkts?                oc-yang:counter64
         |  |  +--ro out-unicast-pkts?        oc-yang:counter64
         |  |  +--ro out-broadcast-pkts?      oc-yang:counter64
         |  |  +--ro out-multicast-pkts?      oc-yang:counter64
         |  |  +--ro out-discards?            oc-yang:counter64
         |  |  +--ro out-errors?              oc-yang:counter64
         |  |  +--ro last-clear?              oc-types:timeticks64
         |  |  +--ro in-unknown-protos?       oc-yang:counter64
         |  |  +--ro in-fcs-errors?           oc-yang:counter64
         |  |  x--ro carrier-transitions?     oc-yang:counter64
         |  |  +--ro interface-transitions?   oc-yang:counter64
         |  |  +--ro link-transitions?        oc-yang:counter64
         |  |  +--ro resets?                  oc-yang:counter64
         |  +--ro oc-vlan:tpid?                      identityref
         |  +--ro oc-atei:out-rate?                  oc-types:ieeefloat32
         |  +--ro oc-atei:in-rate?                   oc-types:ieeefloat32
         |  +--ro oc-if-sdn:forwarding-viable?       boolean
         |  +--ro oc-port:hardware-port?             -> /oc-platform:components/component/name
         |  +--ro oc-transceiver:transceiver?        -> /oc-platform:components/component[oc-platform:name=current()/../oc-port:hardware-port]/oc-platform:subcomponents/subcomponent/name
         |  +--ro oc-transceiver:physical-channel*   -> /oc-platform:components/component[oc-platform:name=current()/../oc-transceiver:transceiver]/transceiver/physical-channels/channel/index
         |  +--ro oc-p4rt:id?                        uint32
         |  +--ro oc-hashing:hashing-policy?         -> /oc-sys:system/hashing/hashing-policies/hashing-policy/name
         +--rw hold-time
         |  +--rw config
         |  |  +--rw up?     uint32
         |  |  +--rw down?   uint32
         |  +--ro state
         |     +--ro up?     uint32
         |     +--ro down?   uint32
         +--rw penalty-based-aied
         |  +--rw config
@@ -13933,108 +13933,108 @@
         |     |        +--ro key-type?    identityref
         |     |        +--ro key-value?   string
         |     +--rw servers
         |        +--rw server* [address]
         |           +--rw address    -> ../config/address
         |           +--rw config
         |           |  +--rw address?            oc-inet:host
         |           |  +--rw port?               oc-inet:port-number
         |           |  +--rw version?            uint8
         |           |  +--rw association-type?   enumeration
         |           |  +--rw iburst?             boolean
         |           |  +--rw prefer?             boolean
         |           |  +--rw network-instance?   oc-ni:network-instance-ref
         |           |  +--rw source-address?     oc-inet:ip-address
         |           |  +--rw key-id?             -> ../../../../ntp-keys/ntp-key/key-id
         |           +--ro state
         |              +--ro address?            oc-inet:host
         |              +--ro port?               oc-inet:port-number
         |              +--ro version?            uint8
         |              +--ro association-type?   enumeration
         |              +--ro iburst?             boolean
         |              +--ro prefer?             boolean
         |              +--ro network-instance?   oc-ni:network-instance-ref
         |              +--ro source-address?     oc-inet:ip-address
         |              +--ro key-id?             -> ../../../../ntp-keys/ntp-key/key-id
         |              +--ro stratum?            uint8
         |              +--ro root-delay?         int64
         |              +--ro root-dispersion?    int64
         |              +--ro offset?             int64
         |              +--ro poll-interval?      uint32
         +--rw assigned-ap-managers
         |  +--rw ap-manager* [id]
         |     +--rw id        -> ../config/id
         |     +--rw config
         |     |  +--rw id?                        string
         |     |  +--rw fqdn?                      oc-inet:domain-name
         |     |  +--rw ap-manager-ipv4-address?   oc-inet:ipv4-address
         |     |  +--rw ap-manager-ipv6-address*   oc-inet:ipv6-address
         |     +--ro state
         |        +--ro id?                        string
         |        +--ro fqdn?                      oc-inet:domain-name
         |        +--ro ap-manager-ipv4-address?   oc-inet:ipv4-address
         |        +--ro ap-manager-ipv6-address*   oc-inet:ipv6-address
         |        +--ro joined?                    boolean
         +--rw oc-ap-if:interfaces
            +--rw oc-ap-if:interface* [name]
               +--rw oc-ap-if:name             -> ../config/name
               +--rw oc-ap-if:config
               |  +--rw oc-ap-if:name?            string
               |  +--rw oc-ap-if:type             identityref
-              |  +--rw oc-ap-if:mtu?             uint16
+              |  +--rw oc-ap-if:mtu?             oc-ift:max-frame-size
               |  +--rw oc-ap-if:loopback-mode?   oc-opt-types:loopback-mode-type
               |  +--rw oc-ap-if:description?     string
               |  +--rw oc-ap-if:enabled?         boolean
               +--ro oc-ap-if:state
               |  +--ro oc-ap-if:name?            string
               |  +--ro oc-ap-if:type             identityref
-              |  +--ro oc-ap-if:mtu?             uint16
+              |  +--ro oc-ap-if:mtu?             oc-ift:max-frame-size
               |  +--ro oc-ap-if:loopback-mode?   oc-opt-types:loopback-mode-type
               |  +--ro oc-ap-if:description?     string
               |  +--ro oc-ap-if:enabled?         boolean
               |  +--ro oc-ap-if:ifindex?         uint32
               |  +--ro oc-ap-if:admin-status     enumeration
               |  +--ro oc-ap-if:oper-status      enumeration
               |  +--ro oc-ap-if:last-change?     oc-types:timeticks64
               |  +--ro oc-ap-if:logical?         boolean
               |  +--ro oc-ap-if:management?      boolean
               |  +--ro oc-ap-if:cpu?             boolean
               |  +--ro oc-ap-if:counters
               |     +--ro oc-ap-if:in-octets?               oc-yang:counter64
               |     +--ro oc-ap-if:in-pkts?                 oc-yang:counter64
               |     +--ro oc-ap-if:in-unicast-pkts?         oc-yang:counter64
               |     +--ro oc-ap-if:in-broadcast-pkts?       oc-yang:counter64
               |     +--ro oc-ap-if:in-multicast-pkts?       oc-yang:counter64
               |     +--ro oc-ap-if:in-errors?               oc-yang:counter64
               |     +--ro oc-ap-if:in-discards?             oc-yang:counter64
               |     +--ro oc-ap-if:out-octets?              oc-yang:counter64
               |     +--ro oc-ap-if:out-pkts?                oc-yang:counter64
               |     +--ro oc-ap-if:out-unicast-pkts?        oc-yang:counter64
               |     +--ro oc-ap-if:out-broadcast-pkts?      oc-yang:counter64
               |     +--ro oc-ap-if:out-multicast-pkts?      oc-yang:counter64
               |     +--ro oc-ap-if:out-discards?            oc-yang:counter64
               |     +--ro oc-ap-if:out-errors?              oc-yang:counter64
               |     +--ro oc-ap-if:last-clear?              oc-types:timeticks64
               |     +--ro oc-ap-if:in-unknown-protos?       oc-yang:counter64
               |     +--ro oc-ap-if:in-fcs-errors?           oc-yang:counter64
               |     x--ro oc-ap-if:carrier-transitions?     oc-yang:counter64
               |     +--ro oc-ap-if:interface-transitions?   oc-yang:counter64
               |     +--ro oc-ap-if:link-transitions?        oc-yang:counter64
               |     +--ro oc-ap-if:resets?                  oc-yang:counter64
               +--rw oc-ap-if:ethernet
               |  +--rw oc-ap-if:config
               |  |  +--rw oc-ap-if:mac-address?                oc-yang:mac-address
               |  |  +--rw oc-ap-if:enable-flow-control?        boolean
               |  |  +--rw oc-ap-if:auto-negotiate?             boolean
               |  |  +--rw oc-ap-if:standalone-link-training?   boolean
               |  |  +--rw oc-ap-if:duplex-mode?                enumeration
               |  |  +--rw oc-ap-if:port-speed?                 identityref
               |  |  +--rw oc-ap-if:fec-mode?                   identityref
               |  +--ro oc-ap-if:state
               |  |  +--ro oc-ap-if:mac-address?                oc-yang:mac-address
               |  |  +--ro oc-ap-if:enable-flow-control?        boolean
               |  |  +--ro oc-ap-if:auto-negotiate?             boolean
               |  |  +--ro oc-ap-if:standalone-link-training?   boolean
               |  |  +--ro oc-ap-if:duplex-mode?                enumeration
               |  |  +--ro oc-ap-if:port-speed?                 identityref
               |  |  +--ro oc-ap-if:fec-mode?                   identityref
               |  |  +--ro oc-ap-if:hw-mac-address?             oc-yang:mac-address
```
