### PR TITLE
Extend LLDP model with global TTL, custom TLV, and per-interface enhancements

### DIFF
--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -12,6 +12,7 @@ module openconfig-lldp {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
 
 
   // meta

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -25,7 +25,13 @@ module openconfig-lldp {
     "This module defines configuration and operational state data
     for the LLDP protocol.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2026-04-06" {
+    description
+      "Add global TTL configuration/state leaf, interface port-description and custom-tlv-names leaves, custom TLV name leaf, global custom-tlvs list, and add interface counter timestamps for LLDP.";
+    reference "1.0.1";
+  }
 
   revision "2026-01-14" {
     description
@@ -143,6 +149,24 @@ module openconfig-lldp {
         description
           "The number of frame transmit errors on the
           interface.";
+      }
+
+      leaf last-packet-transmitted {
+        type oc-yang:date-and-time;
+        description
+          "Timestamp of the last LLDP packet transmitted on this interface.";
+      }
+
+      leaf last-good-packet-received {
+        type oc-yang:date-and-time;
+        description
+          "Timestamp of the last valid LLDP packet received on this interface.";
+      }
+
+      leaf loopback-packets-received {
+        type oc-yang:date-and-time;
+        description
+          "Timestamp of the last loopback LLDP packet received on this interface.";
       }
   }
 
@@ -441,11 +465,19 @@ module openconfig-lldp {
   grouping lldp-custom-tlv-config {
     description
       "Configuration data for custom LLDP TLVs";
+
+    uses lldp-custom-tlv-common;
   }
 
-  grouping lldp-custom-tlv-state {
+  grouping lldp-custom-tlv-common {
     description
-      "Operational state data for custom LLDP TLVs";
+      "Common data for custom LLDP TLVs";
+
+    leaf name {
+      type string;
+      description
+        "Name of the custom TLV.";
+    }
 
     leaf type {
       type int32;
@@ -479,6 +511,13 @@ module openconfig-lldp {
         "A variable-length octet-string containing the
         instance-specific information for this TLV.";
     }
+  }
+
+  grouping lldp-custom-tlv-state {
+    description
+      "Operational state data for custom LLDP TLVs";
+
+    uses lldp-custom-tlv-common;
   }
 
   grouping lldp-custom-tlv-top {
@@ -522,9 +561,7 @@ module openconfig-lldp {
 
         container config {
           description
-            "Configuration data ";
-
-          uses lldp-custom-tlv-config;
+            "Configuration data for custom LLDP TLVs";
         }
 
         container state {
@@ -534,7 +571,6 @@ module openconfig-lldp {
           description
             "Operational state data ";
 
-          uses lldp-custom-tlv-config;
           uses lldp-custom-tlv-state;
         }
       }
@@ -603,6 +639,23 @@ module openconfig-lldp {
       default "true";
       description
         "Enable or disable the LLDP protocol on the interface.";
+    }
+
+    leaf port-description {
+      type string;
+      description
+        "The binary string containing the actual port identifier for
+        the port which this LLDP PDU was transmitted. The source and
+        format of this field is defined by PtopoPortId from
+        RFC2922.";
+    }
+
+    leaf-list custom-tlv-names {
+      type leafref {
+        path "../../../../custom-tlvs/tlv/name";
+      }
+      description
+        "References to global custom TLV names associated with this interface.";
     }
   }
 
@@ -681,6 +734,13 @@ module openconfig-lldp {
         "System level hello timer for the LLDP protocol.";
     }
 
+    leaf ttl {
+      type uint64;
+      units "seconds";
+      description
+        "Time-to-live value for LLDP PDUs transmitted by this system.";
+    }
+
     leaf-list suppress-tlv-advertisement {
       type identityref {
         base oc-lldp-types:LLDP_TLV;
@@ -703,6 +763,47 @@ module openconfig-lldp {
         "Global LLDP counters";
 
       uses lldp-global-counters;
+    }
+  }
+
+  grouping lldp-global-custom-tlv-top {
+    description
+      "Top-level grouping for global custom LLDP TLVs";
+
+    container custom-tlvs {
+      description
+        "Enclosing container for list of global custom TLVs";
+
+      list tlv {
+        key "name";
+        description
+          "List of global custom LLDP TLVs";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container config {
+          description
+            "Configuration data for global custom TLVs";
+
+          uses lldp-custom-tlv-common;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for global custom TLVs";
+
+          uses lldp-custom-tlv-common;
+        }
+      }
     }
   }
 
@@ -736,6 +837,7 @@ module openconfig-lldp {
 
       uses lldp-management-addresses;
       uses lldp-interface-top;
+      uses lldp-global-custom-tlv-top;
     }
   }
 

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -722,7 +722,7 @@ module openconfig-lldp {
 
         leaf name {
           type leafref {
-            path "../../../../../custom-tlvs/tlv/config/name";
+            path "../../../../../custom-tlvs/tlv/name";
           }
           description
             "Reference to the globally-configured custom TLV name. The override

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -658,10 +658,10 @@ module openconfig-lldp {
         advertised port description, overriding any system-generated
         strings or the generic interface description found in
         /interfaces/interface/config/description.
-        
+
         If this leaf is not populated, the implementation
         should default to advertising the value of
-        /interfaces/interface/state/description.
+        /interfaces/interface/state/description.";
       reference
         "Sec 8.5.4 of IEEE Std 802.1AB-2016";
     }
@@ -767,7 +767,7 @@ module openconfig-lldp {
         Note: The TTL value is independent from the hello-timer interval.
         The hello-timer controls how frequently LLDP PDUs are transmitted,
         while the TTL value indicates the validity duration of information
-        contained in those PDUs at the receiving system.
+        contained in those PDUs at the receiving system.";
       reference
         "Sec 8.5.3 of IEEE Std 802.1AB-2016";
     }

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -479,22 +479,6 @@ module openconfig-lldp {
     description
       "Common data for custom LLDP TLVs";
 
-    leaf name {
-      type string;
-      description
-        "Administrative name of the custom TLV for human identification
-        and reference purposes, allowing operators to define a template
-        once at the global level and then reference it by name elsewhere
-        rather than by their numeric type, OUI, and subtype values.";
-    }
-
-    leaf type {
-      type int32;
-      description
-        "The integer value identifying the type of information
-        contained in the value field.";
-    }
-
     leaf oui {
       type string;
       description
@@ -525,6 +509,13 @@ module openconfig-lldp {
   grouping lldp-custom-tlv-state {
     description
       "Operational state data for custom LLDP TLVs";
+
+    leaf type {
+      type int32;
+      description
+        "The integer value identifying the type of information
+        contained in the value field.";
+    }
 
     uses lldp-custom-tlv-common;
   }
@@ -694,6 +685,71 @@ module openconfig-lldp {
     uses lldp-interface-packet-timestamps;
   }
 
+  grouping lldp-interface-custom-tlv-override-config {
+    description
+      "Configuration data for per-interface custom TLV value overrides";
+
+    leaf value {
+      type binary;
+      description
+        "Override value for the custom TLV on this interface. When present,
+        this value overrides the global custom TLV value for transmission on
+        this interface. The override applies only if the TLV is present in
+        the interface's custom-tlv-names list.
+
+        A variable-length octet-string containing the instance-specific
+        information for this custom TLV override.";
+    }
+  }
+
+  grouping lldp-interface-custom-tlv-override-top {
+    description
+      "Top-level grouping for per-interface custom TLV value overrides";
+
+    container custom-tlv-value-overrides {
+      description
+        "Enclosing container for list of per-interface custom TLV value
+        overrides. Overrides only apply to TLVs that are (1) defined in the
+        global /lldp/custom-tlvs list and (2) referenced in this interface's
+        custom-tlv-names list.";
+
+      list tlv {
+        key "name";
+        description
+          "List of custom TLV value overrides for this interface. Each entry
+          corresponds to a globally-configured custom TLV and allows
+          per-interface customization of the transmitted value.";
+
+        leaf name {
+          type leafref {
+            path "../../../../../custom-tlvs/tlv/config/name";
+          }
+          description
+            "Reference to the globally-configured custom TLV name. The override
+            only applies if this name is also present in the interface's
+            custom-tlv-names list.";
+        }
+
+        container config {
+          description
+            "Configuration data for per-interface custom TLV value override";
+
+          uses lldp-interface-custom-tlv-override-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for per-interface custom TLV value override";
+
+          uses lldp-interface-custom-tlv-override-config;
+        }
+      }
+    }
+  }
+
   grouping lldp-interface-top {
     description
       "Top-level grouping ";
@@ -733,6 +789,7 @@ module openconfig-lldp {
           uses lldp-interface-state;
         }
 
+        uses lldp-interface-custom-tlv-override-top;
         uses lldp-neighbor-top;
       }
     }
@@ -804,7 +861,10 @@ module openconfig-lldp {
 
     container custom-tlvs {
       description
-        "Enclosing container for list of global custom TLVs";
+        "Enclosing container for list of global custom TLVs. 
+        Implementation Note: Custom TLV OUI/subtype combinations 
+        MUST NOT collide with standard LLDP TLVs. Configuration 
+        of conflicting OUI/subtype values is not permitted.";
 
       list tlv {
         key "name";
@@ -823,6 +883,15 @@ module openconfig-lldp {
           description
             "Configuration data for global custom TLVs";
 
+          leaf name {
+            type string;
+            description
+              "Administrative name of the custom TLV for human identification
+              and reference purposes, allowing operators to define a template
+              once at the global level and then reference it by name elsewhere
+              rather than by their numeric type, OUI, and subtype values.";
+          }
+
           uses lldp-custom-tlv-common;
         }
 
@@ -832,6 +901,15 @@ module openconfig-lldp {
 
           description
             "Operational state data for global custom TLVs";
+
+          leaf name {
+            type string;
+            description
+              "Administrative name of the custom TLV for human identification
+              and reference purposes, allowing operators to define a template
+              once at the global level and then reference it by name elsewhere
+              rather than by their numeric type, OUI, and subtype values.";
+          }
 
           uses lldp-custom-tlv-common;
         }

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -689,6 +689,16 @@ module openconfig-lldp {
     description
       "Configuration data for per-interface custom TLV value overrides";
 
+    leaf name {
+      type leafref {
+        path "/lldp/custom-tlvs/tlv/config/name";
+      }
+      description
+        "Reference to the globally-configured custom TLV name. The override
+        only applies if this name is also present in the interface's
+        custom-tlv-names list.";
+    }
+
     leaf value {
       type binary;
       description
@@ -722,12 +732,10 @@ module openconfig-lldp {
 
         leaf name {
           type leafref {
-            path "../../../../../custom-tlvs/tlv/name";
+            path "../config/name";
           }
           description
-            "Reference to the globally-configured custom TLV name. The override
-            only applies if this name is also present in the interface's
-            custom-tlv-names list.";
+            "Reference to the custom TLV name key";
         }
 
         container config {

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -25,12 +25,12 @@ module openconfig-lldp {
     "This module defines configuration and operational state data
     for the LLDP protocol.";
 
-  oc-ext:openconfig-version "1.0.1";
+  oc-ext:openconfig-version "1.1.0";
 
   revision "2026-04-06" {
     description
       "Add global TTL configuration/state leaf, interface port-description and custom-tlv-names leaves, custom TLV name leaf, global custom-tlvs list, and add interface counter timestamps for LLDP.";
-    reference "1.0.1";
+    reference "1.1.0";
   }
 
   revision "2026-01-14" {
@@ -151,22 +151,27 @@ module openconfig-lldp {
           interface.";
       }
 
+      leaf loopback-packets-received {
+        type oc-yang:counter64;
+        description
+          "The number of Loopback LLDP PDU received on this interface.";
+      }
+  }
+
+  grouping lldp-interface-packet-timestamps {
+    description
+      "Definition of per-interface LLDP packet timestamps";
+
       leaf last-packet-transmitted {
-        type oc-yang:date-and-time;
+        type oc-types:timeticks64;
         description
           "Timestamp of the last LLDP packet transmitted on this interface.";
       }
 
       leaf last-good-packet-received {
-        type oc-yang:date-and-time;
+        type oc-types:timeticks64;
         description
           "Timestamp of the last valid LLDP packet received on this interface.";
-      }
-
-      leaf loopback-packets-received {
-        type oc-yang:counter64;
-        description
-          "The number of Loopback LLDP PDU received on this interface.";
       }
   }
 
@@ -476,7 +481,10 @@ module openconfig-lldp {
     leaf name {
       type string;
       description
-        "Name of the custom TLV.";
+        "Administrative name of the custom TLV for human identification
+        and reference purposes, allowing operators to define a template
+        once at the global level and then reference it by name elsewhere
+        rather than by their numeric type, OUI, and subtype values.";
     }
 
     leaf type {
@@ -644,9 +652,18 @@ module openconfig-lldp {
     leaf port-description {
       type string;
       description
-        "The description of the port to be advertised in the Port
-        Description TLV (Type 4) for LLDP PDUs transmitted on this
-        interface.";
+        "The binary string advertised in the 'Port Description' TLV
+        (Type 3) of LLDP.
+        When this leaf is populated, its value must be used as the
+        advertised port description, overriding any system-generated
+        strings or the generic interface description found in
+        /interfaces/interface/config/description.
+        
+        If this leaf is not populated, the implementation
+        should default to advertising the value of
+        /interfaces/interface/state/description.
+      reference
+        "Sec 8.5.4 of IEEE Std 802.1AB-2016";
     }
 
     leaf-list custom-tlv-names {
@@ -654,7 +671,11 @@ module openconfig-lldp {
         path "../../../../custom-tlvs/tlv/name";
       }
       description
-        "References to global custom TLV names associated with this interface.";
+        "References to global custom TLV names to be advertised on this
+        interface. If a custom TLV name is present in this list, the
+        corresponding custom TLV will be advertised in LLDP PDUs transmitted
+        on this interface. If a custom TLV name is not present in this list,
+        it will not be advertised on this interface.";
     }
   }
 
@@ -668,6 +689,8 @@ module openconfig-lldp {
 
       uses lldp-interface-counters;
     }
+
+    uses lldp-interface-packet-timestamps;
   }
 
   grouping lldp-interface-top {
@@ -737,7 +760,16 @@ module openconfig-lldp {
       type uint16;
       units "seconds";
       description
-        "Time-to-live value for LLDP PDUs transmitted by this system.";
+        "Time-to-live value for LLDP PDUs transmitted by this system.
+        This value is carried in the TTL TLV and indicates the time
+        interval for which information contained in the LLDP PDU is
+        valid at the receiving system.
+        Note: The TTL value is independent from the hello-timer interval.
+        The hello-timer controls how frequently LLDP PDUs are transmitted,
+        while the TTL value indicates the validity duration of information
+        contained in those PDUs at the receiving system.
+      reference
+        "Sec 8.5.3 of IEEE Std 802.1AB-2016";
     }
 
     leaf-list suppress-tlv-advertisement {

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -861,9 +861,9 @@ module openconfig-lldp {
 
     container custom-tlvs {
       description
-        "Enclosing container for list of global custom TLVs. 
-        Implementation Note: Custom TLV OUI/subtype combinations 
-        MUST NOT collide with standard LLDP TLVs. Configuration 
+        "Enclosing container for list of global custom TLVs.
+        Implementation Note: Custom TLV OUI/subtype combinations
+        MUST NOT collide with standard LLDP TLVs. Configuration
         of conflicting OUI/subtype values is not permitted.";
 
       list tlv {

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -164,9 +164,9 @@ module openconfig-lldp {
       }
 
       leaf loopback-packets-received {
-        type oc-yang:date-and-time;
+        type oc-yang:counter64;
         description
-          "Timestamp of the last loopback LLDP packet received on this interface.";
+          "The number of Loopback LLDP PDU received on this interface.";
       }
   }
 
@@ -644,10 +644,9 @@ module openconfig-lldp {
     leaf port-description {
       type string;
       description
-        "The binary string containing the actual port identifier for
-        the port which this LLDP PDU was transmitted. The source and
-        format of this field is defined by PtopoPortId from
-        RFC2922.";
+        "The description of the port to be advertised in the Port
+        Description TLV (Type 4) for LLDP PDUs transmitted on this
+        interface.";
     }
 
     leaf-list custom-tlv-names {
@@ -735,7 +734,7 @@ module openconfig-lldp {
     }
 
     leaf ttl {
-      type uint64;
+      type uint16;
       units "seconds";
       description
         "Time-to-live value for LLDP PDUs transmitted by this system.";

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -151,12 +151,6 @@ module openconfig-lldp {
           "The number of frame transmit errors on the
           interface.";
       }
-
-      leaf loopback-packets-received {
-        type oc-yang:counter64;
-        description
-          "The number of Loopback LLDP PDU received on this interface.";
-      }
   }
 
   grouping lldp-interface-packet-timestamps {
@@ -479,6 +473,22 @@ module openconfig-lldp {
     description
       "Common data for custom LLDP TLVs";
 
+    leaf name {
+      type string;
+      description
+        "Administrative name of the custom TLV for human identification
+        and reference purposes, allowing operators to define a template
+        once at the global level and then reference it by name elsewhere
+        rather than by their numeric type, OUI, and subtype values.";
+    }
+
+    leaf type {
+      type int32;
+      description
+        "The integer value identifying the type of information
+        contained in the value field.";
+    }
+
     leaf oui {
       type string;
       description
@@ -509,13 +519,6 @@ module openconfig-lldp {
   grouping lldp-custom-tlv-state {
     description
       "Operational state data for custom LLDP TLVs";
-
-    leaf type {
-      type int32;
-      description
-        "The integer value identifying the type of information
-        contained in the value field.";
-    }
 
     uses lldp-custom-tlv-common;
   }
@@ -685,79 +688,6 @@ module openconfig-lldp {
     uses lldp-interface-packet-timestamps;
   }
 
-  grouping lldp-interface-custom-tlv-override-config {
-    description
-      "Configuration data for per-interface custom TLV value overrides";
-
-    leaf name {
-      type leafref {
-        path "/lldp/custom-tlvs/tlv/config/name";
-      }
-      description
-        "Reference to the globally-configured custom TLV name. The override
-        only applies if this name is also present in the interface's
-        custom-tlv-names list.";
-    }
-
-    leaf value {
-      type binary;
-      description
-        "Override value for the custom TLV on this interface. When present,
-        this value overrides the global custom TLV value for transmission on
-        this interface. The override applies only if the TLV is present in
-        the interface's custom-tlv-names list.
-
-        A variable-length octet-string containing the instance-specific
-        information for this custom TLV override.";
-    }
-  }
-
-  grouping lldp-interface-custom-tlv-override-top {
-    description
-      "Top-level grouping for per-interface custom TLV value overrides";
-
-    container custom-tlv-value-overrides {
-      description
-        "Enclosing container for list of per-interface custom TLV value
-        overrides. Overrides only apply to TLVs that are (1) defined in the
-        global /lldp/custom-tlvs list and (2) referenced in this interface's
-        custom-tlv-names list.";
-
-      list tlv {
-        key "name";
-        description
-          "List of custom TLV value overrides for this interface. Each entry
-          corresponds to a globally-configured custom TLV and allows
-          per-interface customization of the transmitted value.";
-
-        leaf name {
-          type leafref {
-            path "../config/name";
-          }
-          description
-            "Reference to the custom TLV name key";
-        }
-
-        container config {
-          description
-            "Configuration data for per-interface custom TLV value override";
-
-          uses lldp-interface-custom-tlv-override-config;
-        }
-
-        container state {
-
-          config false;
-
-          description
-            "Operational state data for per-interface custom TLV value override";
-
-          uses lldp-interface-custom-tlv-override-config;
-        }
-      }
-    }
-  }
-
   grouping lldp-interface-top {
     description
       "Top-level grouping ";
@@ -797,7 +727,6 @@ module openconfig-lldp {
           uses lldp-interface-state;
         }
 
-        uses lldp-interface-custom-tlv-override-top;
         uses lldp-neighbor-top;
       }
     }
@@ -891,15 +820,6 @@ module openconfig-lldp {
           description
             "Configuration data for global custom TLVs";
 
-          leaf name {
-            type string;
-            description
-              "Administrative name of the custom TLV for human identification
-              and reference purposes, allowing operators to define a template
-              once at the global level and then reference it by name elsewhere
-              rather than by their numeric type, OUI, and subtype values.";
-          }
-
           uses lldp-custom-tlv-common;
         }
 
@@ -909,15 +829,6 @@ module openconfig-lldp {
 
           description
             "Operational state data for global custom TLVs";
-
-          leaf name {
-            type string;
-            description
-              "Administrative name of the custom TLV for human identification
-              and reference purposes, allowing operators to define a template
-              once at the global level and then reference it by name elsewhere
-              rather than by their numeric type, OUI, and subtype values.";
-          }
 
           uses lldp-custom-tlv-common;
         }


### PR DESCRIPTION

### Change Scope
*   This PR proposes enhancements to the existing LLDP model with the following changes:
 
    1. Adding a global ttl configuration/state leaf under /lldp.
    2. Extending interface LLDP config and state with port-description and interface-level custom-tlv-names.
    3. Introducing a shared custom-TLV grouping so both config and state reuse the same custom TLV fields.     
    4. Adding a top-level /lldp/custom-tlvs/tlv[name] list for global custom TLV definitions.     
    5. Adding interface state timestamp counters for LLDP packet events.

* This change is backwards compatible as it adds leaves to existing model.
 
### Platform Implementations
*   LLDPCLI, LLDPAD (LLDP daemons for Linux): https://lldpd.github.io/usage.html

```
lldpcli configure lldp custom-tlv oui 00,00,00 subtype 1 oui-info "your data"
```
*   SONiC: https://github.com/cshivashgit/SONiC/blob/lldp-custom-tlv-hld/doc/lldp_custom_tlv/lldp-custom-tlv-hld.md#config-db-schema 
*   Vendors use custom TLVs to support features like Cisco's [LLDP-MED](https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9300/software/release/16-6/configuration_guide/int_and_hw/b_166_int_and_hw_9300_cg/b_166_int_and_hw_9300_cg_chapter_011.html) (Media Endpoint Discovery), which is itself a collection of organizationally specific TLVs. In Cisco [NX-OS](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/system_management/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_System_Management_Configuration_Guide/sm_lldp.pdf), you can select which TLVs to include using the lldp tlv-select command. Aruba's [AOS-CX](https://www.youtube.com/watch?v=lPbtpFcTqgE) introduced a specific OUI (83A30) to help identify Aruba devices and automatically apply network profiles.

### Tree View
 
```diff
module: openconfig-lldp
  +--rw lldp
     +--rw config
     |  +--rw enabled?                      boolean
     |  +--rw hello-timer?                  uint64
+    |  +--rw ttl?                          uint16
     |  +--rw suppress-tlv-advertisement*   identityref
     |  +--rw system-name?                  string
     |  +--rw system-description?           string
     |  +--rw chassis-id?                   string
     |  +--rw chassis-id-type?              oc-lldp-types:chassis-id-type
     |  +--rw management-interface?         oc-if:interface-id
     +--ro state
     |  +--ro enabled?                      boolean
     |  +--ro hello-timer?                  uint64
+    |  +--ro ttl?                          uint16
     |  +--ro suppress-tlv-advertisement*   identityref
     |  +--ro system-name?                  string
     |  +--ro system-description?           string
     |  +--ro chassis-id?                   string
     |  +--ro chassis-id-type?              oc-lldp-types:chassis-id-type
     |  +--ro management-interface?         oc-if:interface-id
     |  +--ro counters
     |     +--ro frame-in?           oc-yang:counter64
     |     +--ro frame-out?          oc-yang:counter64
     |     +--ro frame-error-in?     oc-yang:counter64
     |     +--ro frame-discard?      oc-yang:counter64
     |     +--ro tlv-discard?        oc-yang:counter64
     |     +--ro tlv-unknown?        oc-yang:counter64
     |     +--ro last-clear?         oc-yang:date-and-time
     |     +--ro tlv-accepted?       oc-yang:counter64
     |     +--ro entries-aged-out?   oc-yang:counter64
     +--ro mgmt-addresses
     |  +--ro mgmt-address* [address]
     |     +--ro address    -> ../state/address
     |     +--ro state
     |        +--ro address?                    union
     |        +--ro interface-number?           uint32
     |        +--ro interface-number-subtype?   oc-lldp-types:mgmt-interface-number-subtype
     +--rw interfaces
     |  +--rw interface* [name]
     |     +--rw name         -> ../config/name
     |     +--rw config
     |     |  +--rw name?               oc-if:base-interface-ref
     |     |  +--rw enabled?            boolean
+    |     |  +--rw port-description?   string
+    |     |  +--rw custom-tlv-names*   -> ../../../../custom-tlvs/tlv/name
     |     +--ro state
     |     |  +--ro name?                        oc-if:base-interface-ref
     |     |  +--ro enabled?                     boolean
+    |     |  +--ro port-description?            string
+    |     |  +--ro custom-tlv-names*            -> ../../../../custom-tlvs/tlv/name
     |     |  +--ro counters
     |     |  |  +--ro frame-in?                    oc-yang:counter64
     |     |  |  +--ro frame-out?                   oc-yang:counter64
     |     |  |  +--ro frame-error-in?              oc-yang:counter64
     |     |  |  +--ro frame-discard?               oc-yang:counter64
     |     |  |  +--ro tlv-discard?                 oc-yang:counter64
     |     |  |  +--ro tlv-unknown?                 oc-yang:counter64
     |     |  |  +--ro last-clear?                  oc-yang:date-and-time
     |     |  |  +--ro frame-error-out?             oc-yang:counter64
+    |     |  +--ro last-packet-transmitted?     oc-types:timeticks64
+    |     |  +--ro last-good-packet-received?   oc-types:timeticks64
     |     +--ro neighbors
     |        +--ro neighbor* [id]
     |           +--ro id                -> ../state/id
     |           +--ro config
     |           +--ro state
     |           |  +--ro system-name?               string
     |           |  +--ro system-description?        string
     |           |  +--ro chassis-id?                string
     |           |  +--ro chassis-id-type?           oc-lldp-types:chassis-id-type
     |           |  +--ro management-interface?      oc-if:interface-id
     |           |  +--ro id?                        string
     |           |  +--ro age?                       uint64
     |           |  +--ro last-update?               int64
     |           |  +--ro ttl?                       uint16
     |           |  +--ro port-id?                   string
     |           |  +--ro port-id-type?              oc-lldp-types:port-id-type
     |           |  +--ro port-description?          string
     |           |  x--ro management-address?        string
     |           |  x--ro management-address-type?   string
     |           +--ro mgmt-addresses
     |           |  +--ro mgmt-address* [address]
     |           |     +--ro address    -> ../state/address
     |           |     +--ro state
     |           |        +--ro address?                    union
     |           |        +--ro interface-number?           uint32
     |           |        +--ro interface-number-subtype?   oc-lldp-types:mgmt-interface-number-subtype
     |           +--ro custom-tlvs
     |           |  +--ro tlv* [type oui oui-subtype]
     |           |     +--ro type           -> ../state/type
     |           |     +--ro oui            -> ../state/oui
     |           |     +--ro oui-subtype    -> ../state/oui-subtype
     |           |     +--ro config
     |           |     +--ro state
+    |           |        +--ro name?          string
     |           |        +--ro type?          int32
     |           |        +--ro oui?           string
     |           |        +--ro oui-subtype?   string
     |           |        +--ro value?         binary
     |           +--ro capabilities
     |              +--ro capability* [name]
     |                 +--ro name      -> ../state/name
     |                 +--ro config
     |                 +--ro state
     |                    +--ro name?      identityref
     |                    +--ro enabled?   boolean
+    +--rw custom-tlvs
+       +--rw tlv* [name]
+          +--rw name      -> ../config/name
+          +--rw config
+          |  +--rw name?          string
+          |  +--rw oui?           string
+          |  +--rw oui-subtype?   string
+          |  +--rw type?          int32
+          |  +--rw value?         binary
+          +--ro state
+             +--ro name?          string
+             +--ro oui?           string
+             +--ro oui-subtype?   string
+             +--ro type?          int32
+             +--ro value?         binary
```

