### PR TITLE
lacp: add fallback-timeout configuration to aggregate interfaces

### DIFF
--- a/release/models/lacp/openconfig-lacp.yang
+++ b/release/models/lacp/openconfig-lacp.yang
@@ -422,6 +422,13 @@ grouping aggregation-lacp-members-statistics {
         after the expiry of the timeout period.";
     }
 
+    leaf fallback-timeout {
+      type uint16;
+      units "seconds";
+      description
+        "The timeout in seconds to wait for LACP PDUs before falling back to a single port.";
+    }
+
     uses aggregation-lacp-global-config;
   }
 

--- a/release/models/lacp/openconfig-lacp.yang
+++ b/release/models/lacp/openconfig-lacp.yang
@@ -26,7 +26,14 @@ module openconfig-lacp {
     managing aggregate interfaces.   It works in conjunction with
     the OpenConfig interfaces and aggregate interfaces models.";
 
-  oc-ext:openconfig-version "2.1.0";
+oc-ext:openconfig-version "2.2.0";
+
+revision "2026-04-09" {
+description
+"Add LACP fallback timeout leaf.";
+reference "2.2.0";
+}
+
 
   revision "2024-09-24" {
     description


### PR DESCRIPTION
### Change Scope

* This PR adds a fallback-timeout leaf to the openconfig-lacp model under /lacp/interfaces/interface/config/. This leaf specifies the timeout in seconds to wait for LACP PDUs before the interface falls back to a single port active state. This allows for faster or more predictable failover behaviors when LACP negotiation fails
* This change is backwards compatible as it only adds a new optional leaf to the existing model

### Platform Implementations

 * Arista : [Supported via the `port-channel lacp fallback timeout <seconds>` command in EOS](https://www.arista.com/en/um-eos/eos-port-channels-and-lacp#xzx_D2yPRtO7x3) 
 * Nokia : [Supported via the `lacp-fallback-timeout <seconds>` command in SR Linux](https://documentation.nokia.com/srlinux/24-3/books/interfaces/lag.html#:~:text=Configuring%20LACP%20and%20LACP%20fallback])
 * Cisco : [Supported via the `bundle lacp-fallback timeout <seconds>` command in IOS-XR](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/Interfaces/24xx/configuration/guide/b-interfaces-config-guide-cisco8k-r24xx/configuring-link-bundling.html#task_844BB227554D4C42A96F1AF8D5AC477C) 
 
### Tree View

```

[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-lacp
   +--rw lacp
      +--rw config
      |  +--rw system-priority?   uint16
      +--ro state
      |  +--ro system-priority?   uint16
      +--rw interfaces
         +--rw interface* [name]
            +--rw name       -> ../config/name
            +--rw config
            |  +--rw name?              oc-if:base-interface-ref
            |  +--rw interval?          lacp-period-type
            |  +--rw lacp-mode?         lacp-activity-type
            |  +--rw system-id-mac?     oc-yang:mac-address
            |  +--rw fallback?          boolean
+           |  +--rw fallback-timeout?   uint16
            |  +--rw system-priority?   uint16
            +--ro state
            |  +--ro name?              oc-if:base-interface-ref
            |  +--ro interval?          lacp-period-type
            |  +--ro lacp-mode?         lacp-activity-type
            |  +--ro system-id-mac?     oc-yang:mac-address
            |  +--ro fallback?          boolean
+           |  +--ro fallback-timeout?   uint16
            |  +--ro system-priority?   uint16
            +--rw members
               +--rw member* [interface]
                  +--rw interface    -> ../config/interface
                  +--rw config
                  |  +--rw interface?       oc-if:base-interface-ref
                  |  +--rw port-priority?   uint16
                  +--ro state
                     +--ro interface?               oc-if:base-interface-ref
                     +--ro port-priority?           uint16
                     +--ro activity?                lacp-activity-type
                     +--ro timeout?                 lacp-timeout-type
                     +--ro synchronization?         lacp-synchronization-type
                     +--ro aggregatable?            boolean
                     +--ro collecting?              boolean
                     +--ro distributing?            boolean
                     +--ro system-id?               oc-yang:mac-address
                     +--ro oper-key?                uint16
                     +--ro partner-id?              oc-yang:mac-address
                     +--ro partner-key?             uint16
                     +--ro port-num?                uint16
                     +--ro partner-port-num?        uint16
                     +--ro partner-port-priority?   uint16
                     +--ro last-change?             oc-types:timeticks64
                     +--ro counters
                        +--ro lacp-in-pkts?               oc-yang:counter64
                        +--ro lacp-out-pkts?              oc-yang:counter64
                        +--ro lacp-rx-errors?             oc-yang:counter64
                        +--ro lacp-tx-errors?             oc-yang:counter64
                        +--ro lacp-unknown-errors?        oc-yang:counter64
                        +--ro lacp-errors?                oc-yang:counter64
                        +--ro lacp-timeout-transitions?   oc-yang:counter64
```
