### PR TITLE
Add leaves for common org-defined TLVs to LLDP neighbor state

### DIFF
--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -33,9 +33,9 @@ module openconfig-lldp {
       "Add LLDP neighbor state leaves for LLDP-MED inventory serial
       number, IEEE 802.1 port VLAN ID, and IEEE 802.3 link aggregation
       and max frame size.";
-        reference "1.2.0";
+    reference "1.2.0";
   }
-  
+
   revision "2026-04-06" {
     description
       "Add global TTL configuration/state leaf, interface port-description and custom-tlv-names leaves, custom TLV name leaf, global custom-tlvs list, and add interface counter timestamps for LLDP.";
@@ -412,26 +412,30 @@ module openconfig-lldp {
         indicates that the port is not VLAN-aware.";
     }
 
-    leaf link-aggregation-capable {
-      type boolean;
+    container link-aggregation {
       description
-        "Indicates whether the neighbor port is capable of being
-        aggregated, as advertised in the IEEE 802.3 Link Aggregation
-        TLV.";
-    }
+        "Link aggregation state advertised by the neighbor in
+        the IEEE 802.3 Link Aggregation TLV.";
 
-    leaf link-aggregation-enabled {
-      type boolean;
-      description
-        "Indicates whether the neighbor port is currently aggregated,
-        as advertised in the IEEE 802.3 Link Aggregation TLV.";
-    }
+      leaf capable {
+        type boolean;
+        description
+          "Indicates whether the neighbor port is capable of being
+          aggregated.";
+      }
 
-    leaf link-aggregation-port-id {
-      type uint32;
-      description
-        "The aggregated port identifier of the neighbor port as
-        advertised in the IEEE 802.3 Link Aggregation TLV.";
+      leaf enabled {
+        type boolean;
+        description
+          "Indicates whether the neighbor port is currently
+          aggregated.";
+      }
+
+      leaf port-id {
+        type uint32;
+        description
+          "The aggregated port identifier of the neighbor port.";
+      }
     }
 
     leaf max-frame-size {

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -14,7 +14,6 @@ module openconfig-lldp {
   import openconfig-extensions { prefix oc-ext; }
 
 
-
   // meta
   organization "OpenConfig working group";
 

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -12,7 +12,7 @@ module openconfig-lldp {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-extensions { prefix oc-ext; }
-  import openconfig-vlan-types { prefix oc-vlan-types; }
+
 
 
   // meta
@@ -380,19 +380,28 @@ module openconfig-lldp {
     }
 
     leaf port-vlan-id {
-      type oc-vlan-types:vlan-id;
+      type uint16 {
+        range "0..4094";
+      }
       description
         "The port VLAN identifier advertised by the
-        neighbor in the IEEE 802.1 Port VLAN ID TLV.";
+        neighbor in the IEEE 802.1 Port VLAN ID TLV. A value of 0
+        indicates that the port is not VLAN-aware.";
     }
 
-    leaf link-aggregation-status {
-      type uint8;
+    leaf link-aggregation-capable {
+      type boolean;
       description
-        "The link aggregation status of the neighbor port as
-        advertised in the IEEE 802.3 Link Aggregation TLV.
-        Bit 0 indicates aggregation capability, bit 1 indicates
-        aggregation status.";
+        "Indicates whether the neighbor port is capable of being
+        aggregated, as advertised in the IEEE 802.3 Link Aggregation
+        TLV.";
+    }
+
+    leaf link-aggregation-enabled {
+      type boolean;
+      description
+        "Indicates whether the neighbor port is currently aggregated,
+        as advertised in the IEEE 802.3 Link Aggregation TLV.";
     }
 
     leaf link-aggregation-port-id {

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -25,7 +25,15 @@ module openconfig-lldp {
     "This module defines configuration and operational state data
     for the LLDP protocol.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2026-04-14" {
+    description
+      "Add LLDP neighbor state leaves for LLDP-MED inventory serial
+      number, IEEE 802.1 port VLAN ID, and IEEE 802.3 link aggregation
+      and max frame size.";
+    reference "1.1.0";
+  }
 
   revision "2026-01-14" {
     description
@@ -361,6 +369,54 @@ module openconfig-lldp {
         list structure to accomodate multiple addresses and distinct
         typing to pair up with the 802.1AB Management Address TLV
         specification.";
+    }
+
+    leaf med-inventory-serial-number {
+      type string;
+      description
+        "The serial number of the remote device as advertised in
+        the LLDP-MED Inventory - Serial Number TLV.";
+      reference
+        "ANSI/TIA-1057 Section 10.2.6.2";
+    }
+
+    leaf port-vlan-id {
+      type uint16;
+      description
+        "The port VLAN identifier (PVID) advertised by the
+        neighbor in the IEEE 802.1 Port VLAN ID TLV.";
+      reference
+        "IEEE 802.1Q Annex D";
+    }
+
+    leaf link-aggregation-status {
+      type uint8;
+      description
+        "The link aggregation status of the neighbor port as
+        advertised in the IEEE 802.3 Link Aggregation TLV.
+        Bit 0 indicates aggregation capability, bit 1 indicates
+        aggregation status.";
+      reference
+        "IEEE 802.1AB-2005 Annex G.4";
+    }
+
+    leaf link-aggregation-port-id {
+      type uint32;
+      description
+        "The aggregated port identifier of the neighbor port as
+        advertised in the IEEE 802.3 Link Aggregation TLV.";
+      reference
+        "IEEE 802.1AB-2005 Annex G.4";
+    }
+
+    leaf max-frame-size {
+      type uint16;
+      description
+        "The maximum frame size in octets supported by the
+        neighbor port as advertised in the IEEE 802.3 Maximum
+        Frame Size TLV.";
+      reference
+        "IEEE 802.1AB-2005 Annex G.5";
     }
   }
 

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -12,6 +12,7 @@ module openconfig-lldp {
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-vlan-types { prefix oc-vlan-types; }
 
 
   // meta
@@ -25,7 +26,15 @@ module openconfig-lldp {
     "This module defines configuration and operational state data
     for the LLDP protocol.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2026-04-14" {
+    description
+      "Add LLDP neighbor state leaves for LLDP-MED inventory serial
+      number, IEEE 802.1 port VLAN ID, and IEEE 802.3 link aggregation
+      and max frame size.";
+    reference "1.1.0";
+  }
 
   revision "2026-01-14" {
     description
@@ -361,6 +370,44 @@ module openconfig-lldp {
         list structure to accomodate multiple addresses and distinct
         typing to pair up with the 802.1AB Management Address TLV
         specification.";
+    }
+
+    leaf med-inventory-serial-number {
+      type string;
+      description
+        "The serial number of the remote device as advertised in
+        the LLDP-MED Inventory - Serial Number TLV.";
+    }
+
+    leaf port-vlan-id {
+      type oc-vlan-types:vlan-id;
+      description
+        "The port VLAN identifier advertised by the
+        neighbor in the IEEE 802.1 Port VLAN ID TLV.";
+    }
+
+    leaf link-aggregation-status {
+      type uint8;
+      description
+        "The link aggregation status of the neighbor port as
+        advertised in the IEEE 802.3 Link Aggregation TLV.
+        Bit 0 indicates aggregation capability, bit 1 indicates
+        aggregation status.";
+    }
+
+    leaf link-aggregation-port-id {
+      type uint32;
+      description
+        "The aggregated port identifier of the neighbor port as
+        advertised in the IEEE 802.3 Link Aggregation TLV.";
+    }
+
+    leaf max-frame-size {
+      type uint16;
+      description
+        "The maximum frame size in octets supported by the
+        neighbor port as advertised in the IEEE 802.3 Maximum
+        Frame Size TLV.";
     }
   }
 

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -400,6 +400,9 @@ module openconfig-lldp {
       description
         "The serial number of the remote device as advertised in
         the LLDP-MED Inventory - Serial Number TLV.";
+      reference
+        "ANSI/TIA-1057, Sec 10.2.6.4 - Inventory - Serial Number
+        TLV (OUI 00-12-BB, subtype 8)";
     }
 
     leaf port-vlan-id {
@@ -410,32 +413,40 @@ module openconfig-lldp {
         "The port VLAN identifier advertised by the
         neighbor in the IEEE 802.1 Port VLAN ID TLV. A value of 0
         indicates that the port is not VLAN-aware.";
+      reference
+        "Annex D of IEEE Std 802.1Q - Port VLAN ID TLV
+        (OUI 00-80-C2, subtype 1)";
     }
 
-    container link-aggregation {
+    leaf link-aggregation-capable {
+      type boolean;
       description
-        "Link aggregation state advertised by the neighbor in
-        the IEEE 802.3 Link Aggregation TLV.";
+        "Indicates whether the neighbor port is capable of being
+        aggregated, as advertised in the IEEE 802.3 Link Aggregation
+        TLV.";
+      reference
+        "Sec 79.3.3 of IEEE Std 802.3 - Link Aggregation TLV
+        (OUI 00-12-0F, subtype 3)";
+    }
 
-      leaf capable {
-        type boolean;
-        description
-          "Indicates whether the neighbor port is capable of being
-          aggregated.";
-      }
+    leaf link-aggregation-enabled {
+      type boolean;
+      description
+        "Indicates whether the neighbor port is currently aggregated,
+        as advertised in the IEEE 802.3 Link Aggregation TLV.";
+      reference
+        "Sec 79.3.3 of IEEE Std 802.3 - Link Aggregation TLV
+        (OUI 00-12-0F, subtype 3)";
+    }
 
-      leaf enabled {
-        type boolean;
-        description
-          "Indicates whether the neighbor port is currently
-          aggregated.";
-      }
-
-      leaf port-id {
-        type uint32;
-        description
-          "The aggregated port identifier of the neighbor port.";
-      }
+    leaf link-aggregation-port-id {
+      type uint32;
+      description
+        "The aggregated port identifier of the neighbor port as
+        advertised in the IEEE 802.3 Link Aggregation TLV.";
+      reference
+        "Sec 79.3.3 of IEEE Std 802.3 - Link Aggregation TLV
+        (OUI 00-12-0F, subtype 3)";
     }
 
     leaf max-frame-size {
@@ -444,6 +455,9 @@ module openconfig-lldp {
         "The maximum frame size in octets supported by the
         neighbor port as advertised in the IEEE 802.3 Maximum
         Frame Size TLV.";
+      reference
+        "Sec 79.3.4 of IEEE Std 802.3 - Maximum Frame Size TLV
+        (OUI 00-12-0F, subtype 4)";
     }
   }
 

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -418,7 +418,24 @@ module openconfig-lldp {
         (OUI 00-80-C2, subtype 1)";
     }
 
-    leaf link-aggregation-capable {
+    leaf max-frame-size {
+      type uint16;
+      description
+        "The maximum frame size in octets supported by the
+        neighbor port as advertised in the IEEE 802.3 Maximum
+        Frame Size TLV.";
+      reference
+        "Sec 79.3.4 of IEEE Std 802.3 - Maximum Frame Size TLV
+        (OUI 00-12-0F, subtype 4)";
+    }
+  }
+
+  grouping lldp-link-aggregation-state {
+    description
+      "Operational state data for IEEE 802.3 Link Aggregation TLV
+      received from an LLDP neighbor.";
+
+    leaf capable {
       type boolean;
       description
         "Indicates whether the neighbor port is capable of being
@@ -429,7 +446,7 @@ module openconfig-lldp {
         (OUI 00-12-0F, subtype 3)";
     }
 
-    leaf link-aggregation-enabled {
+    leaf enabled {
       type boolean;
       description
         "Indicates whether the neighbor port is currently aggregated,
@@ -439,7 +456,7 @@ module openconfig-lldp {
         (OUI 00-12-0F, subtype 3)";
     }
 
-    leaf link-aggregation-port-id {
+    leaf port-id {
       type uint32;
       description
         "The aggregated port identifier of the neighbor port as
@@ -448,16 +465,30 @@ module openconfig-lldp {
         "Sec 79.3.3 of IEEE Std 802.3 - Link Aggregation TLV
         (OUI 00-12-0F, subtype 3)";
     }
+  }
 
-    leaf max-frame-size {
-      type uint16;
+  grouping lldp-link-aggregation-top {
+    description
+      "Top-level grouping for LLDP link aggregation data";
+
+    container link-aggregation {
+      config false;
       description
-        "The maximum frame size in octets supported by the
-        neighbor port as advertised in the IEEE 802.3 Maximum
-        Frame Size TLV.";
+        "Enclosing container for IEEE 802.3 Link Aggregation TLV
+        data received from an LLDP neighbor.";
       reference
-        "Sec 79.3.4 of IEEE Std 802.3 - Maximum Frame Size TLV
-        (OUI 00-12-0F, subtype 4)";
+        "Sec 79.3.3 of IEEE Std 802.3 - Link Aggregation TLV
+        (OUI 00-12-0F, subtype 3)";
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for link aggregation";
+
+        uses lldp-link-aggregation-state;
+      }
     }
   }
 
@@ -693,6 +724,7 @@ module openconfig-lldp {
           uses lldp-neighbor-state;
         }
 
+        uses lldp-link-aggregation-top;
         uses lldp-management-addresses;
         uses lldp-custom-tlv-top;
         uses lldp-capabilities-top;

--- a/release/models/lldp/openconfig-lldp.yang
+++ b/release/models/lldp/openconfig-lldp.yang
@@ -13,6 +13,7 @@ module openconfig-lldp {
   import openconfig-inet-types { prefix oc-inet; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-types { prefix oc-types; }
+  import openconfig-vlan-types { prefix oc-vlan-types; }
 
 
   // meta
@@ -406,9 +407,7 @@ module openconfig-lldp {
     }
 
     leaf port-vlan-id {
-      type uint16 {
-        range "0..4094";
-      }
+      type oc-vlan-types:vlan-id-or-none;
       description
         "The port VLAN identifier advertised by the
         neighbor in the IEEE 802.1 Port VLAN ID TLV. A value of 0

--- a/release/models/vlan/openconfig-vlan-types.yang
+++ b/release/models/vlan/openconfig-vlan-types.yang
@@ -21,7 +21,15 @@ module openconfig-vlan-types {
     "This module defines configuration and state variables for VLANs,
     in addition to VLAN parameters associated with interfaces";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-06-24" {
+    description
+      "Add vlan-id-or-none typedef to support VLAN ID values that
+      include 0 to indicate that the system either does not know
+      the PVID or does not support Port-based VLAN operation.";
+    reference "3.3.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -134,6 +142,16 @@ module openconfig-vlan-types {
     }
     description
       "Type definition representing a single-tagged VLAN";
+  }
+
+  typedef vlan-id-or-none {
+    type uint16 {
+      range 0..4094;
+    }
+    description
+      "Type definition representing a single-tagged VLAN identifier
+      where a value of 0 indicates that the system either does not
+      know the PVID or does not support Port-based VLAN operation.";
   }
 
   typedef vlan-range {


### PR DESCRIPTION
Resolves Issue https://github.com/openconfig/public/issues/1471

* (M) release/models/lldp/openconfig-lldp.yang
* (M) release/models/vlan/openconfig-vlan-types.yang

### Change Scope

* Add the following new read-only leaves under `/lldp/interfaces/interface/neighbors/neighbor/state` for widely implemented, standards-based LLDP TLVs: 

  - `med-inventory-serial-number` (string) — LLDP-MED Inventory Serial Number TLV (OUI 00-12-BB, subtype 8)
  - `port-vlan-id` (oc-vlan-types:vlan-id-or-none) — IEEE 802.1 Port VLAN ID TLV (OUI 00-80-C2, subtype 1)
  - `max-frame-size` (uint16) — IEEE 802.3 Maximum Frame Size (OUI 00-12-0F, subtype 4)

* Add a new container for link aggregation leaves in `/lldp/interfaces/interface/neighbors/neighbor/`

  -  `link-aggregation` (container) — IEEE 802.3 Link Aggregation TLV (OUI 00-12-0F, subtype 3), containing:
  -  - `capable` (boolean)
  -  - `enabled` (boolean)
  -   - `port-id` (uint32)

* Add `vlan-id-or-none` typedef in openconfig-vlan-types.yang to support VLAN ID values that include 0 to indicate that the system either does not know the PVID or does not support Port-based VLAN operation. Use this type in port-vlan-id neighbor leaf in LLDP.

* These TLVs are defined in IEEE 802.1, IEEE 802.3, and ANSI/TIA-1057 and are broadly supported across network platforms. They are essential for network automation use cases including inventory management. 

* This change is **backward compatible** (minor version bump 1.1.0 → 1.2.0). 

### Platform Implementations

 * Arista: These TLVs are supported in EOS CLI via `show lldp neighbors detail`. See [LLDP EOS User Manual](https://www.arista.com/en/um-eos/eos-link-layer-discovery-protocol) and sample CLI output below.

   ```
   Interface Ethernet36/1 detected 1 LLDP neighbors:

     Neighbor 3838.a6a5.5d04/"Ethernet36/1", age 7 seconds
     - IEEE802.1 Port VLAN ID: 0
     - IEEE802.3 Link Aggregation
       Link Aggregation Status: Capable, Enabled (0x03)
       Port ID                : 1000002
     - IEEE802.3 Maximum Frame Size: 10240 bytes
     - LLDP-MED Inventory Serial Number TLV: "FGN234408B7"
   ```

### Tree View

```diff
 module: openconfig-lldp
 path: /lldp/interfaces/interface/neighbors/neighbor
   +--ro state
      +--ro system-name?                   string
      +--ro system-description?            string
      +--ro chassis-id?                    string
      +--ro chassis-id-type?               oc-lldp-types:chassis-id-type
      +--ro management-interface?          oc-if:interface-id
      +--ro id?                            string
      +--ro age?                           uint64
      +--ro last-update?                   int64
      +--ro ttl?                           uint16
      +--ro port-id?                       string
      +--ro port-id-type?                  oc-lldp-types:port-id-type
      +--ro port-description?              string
      x--ro management-address?            string
      x--ro management-address-type?       string
+     +--ro med-inventory-serial-number?   string
+     +--ro port-vlan-id?                  oc-vlan-types:vlan-id-or-none
+     +--ro max-frame-size?                uint16
+  +--ro link-aggregation
+    +--ro state
+      +--ro capable?                      boolean
+      +--ro enabled?                      boolean
+      +--ro port-id?                      uint32
```