### PR TITLE
Adding SLM YANG model, and moving PM model to remote MEP level. Making PM profiles per PM type.

### DIFF
--- a/release/models/oam/openconfig-oam-cfm.yang
+++ b/release/models/oam/openconfig-oam-cfm.yang
@@ -29,6 +29,12 @@ module openconfig-oam-cfm {
 
   oc-ext:openconfig-version "0.1.0";
 
+  revision "2026-04-23" {
+    description
+      "Add SLM model and move pm-profile to remote MEP level";
+    reference "0.2.0";
+  }
+
   revision "2024-09-11" {
     description
       "Initial revision";
@@ -139,9 +145,13 @@ module openconfig-oam-cfm {
                       } //end container mep state
 
                       container pm-profiles {
+                        status deprecated;
                         description
                           "This container includes configuration and state objects for the Frame Loss
-                          Measurement & Delay Measurement functions defined in [Y.1731] and [MEF SOAM PM IA].";
+                          Measurement & Delay Measurement functions defined in [Y.1731] and [MEF SOAM PM IA].
+
+                          This container has been deprecated in favor of keeping pm-profiles at the remote
+                          mep level.";
 
                         list pm-profile {
                           description " Measurement profile name and state.";
@@ -273,6 +283,8 @@ module openconfig-oam-cfm {
               uses performance-measurement-config;
               uses performance-measurement-state;
             }
+
+            uses synthetic-loss-measurement-state;
           }
         }
     } // End container cfm
@@ -937,61 +949,56 @@ module openconfig-oam-cfm {
   }
  }
 
-  grouping loss-measurement-state {
-    description "Loss measurement state grouping.";
+  grouping loss-measurement-common-stats {
+    description "Shared loss measurement grouping.";
 
-    container loss-measurement-state {
-      description "Loss measurement state container.";
-
-      leaf far-end-min-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the minimum one-way availability flr in the
-          egress direction (source --> destination),
-          from among the set of availability flr values
-          calculated by the MEP in this Measurement Interval. There is
-          one availability flr value for each 'delta_t' time period
-          within the Measurement Interval, as specified in MEF 10.2.1.
-
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-          reference
-            "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMinFlr";
+    leaf far-end-min-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf far-end-max-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the maximum one-way availability flr in the
-          forward direction (source --> destination),
-          from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
+      units milli-percent;
+      description
+        "This object contains the minimum one-way availability flr in the
+        egress direction (source --> destination),
+        from among the set of availability flr values
+        calculated by the MEP in this Measurement Interval. There is
+        one availability flr value for each 'delta_t' time period
+        within the Measurement Interval, as specified in MEF 10.2.1.
 
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMaxFlr";
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMinFlr";
+    }
+    leaf far-end-max-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf far-end-average-frame-loss-ratio {
+      units milli-percent;
+      description
+        "This object contains the maximum one-way availability flr in the
+        forward direction (source --> destination),
+        from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-        description
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMaxFlr";
+    }
+    leaf far-end-average-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
         "This object contains the average one-way availability flr in the
         forward direction, from among the set of availability flr
         values calculated by the MEP in this Measurement Interval.
@@ -1003,62 +1010,58 @@ module openconfig-oam-cfm {
         value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
         Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
+      reference
         "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardAvgFlr";
-        }
-
-      leaf near-end-min-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the minimum one-way availability flr in the
-          backward direction (destination --> source),
-          from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
-
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMinFlr";
+    }
+    leaf near-end-min-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf near-end-max-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the maximum one-way availability flr in the
-          backward direction, from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
+      units milli-percent;
+      description
+        "This object contains the minimum one-way availability flr in the
+        backward direction (destination --> source),
+        from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-          Service OAM Performance Monitoring YANG Module
-          MEF 39
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMaxFlr";
-        }
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMinFlr";
+    }
+    leaf near-end-max-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
+        "This object contains the maximum one-way availability flr in the
+        backward direction, from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-      leaf near-end-average-frame-loss-ratio {
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
+        Service OAM Performance Monitoring YANG Module
+        MEF 39
 
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-
-        description
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMaxFlr";
+    }
+    leaf near-end-average-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
         "This object contains the average one-way availability flr in the
         backward direction, from among the set of availability flr
         values calculated by the MEP in this Measurement Interval.
@@ -1070,17 +1073,9 @@ module openconfig-oam-cfm {
         value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
         Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
+      reference
         "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardAvgFlr";
-        }
-
-      uses loss-measurement-counters-state;
     }
-  }
-
-  grouping loss-measurement-counters-state {
-    description "Loss-measurement-related measurement counters state.";
-
     container counters {
       description
         "A collection of loss-measurement-related statistics objects.";
@@ -1103,6 +1098,64 @@ module openconfig-oam-cfm {
       leaf slr-received {
         type oc-yang:counter64;
         description "slm Probes sent.";
+      }
+    }
+  }
+
+  grouping loss-measurement-state {
+    description "Loss measurement state grouping.";
+
+    container loss-measurement-state {
+      description "Loss measurement state container.";
+      uses loss-measurement-common-stats;
+    }
+  }
+
+  grouping synthetic-loss-measurement-stats {
+    description "Synthetic loss measurement grouping.";
+
+    leaf cos {
+      type uint8;
+      description "Class of Service for this synthetic loss measurement entry.";
+    }
+    
+    leaf test-id {
+      type uint32;
+      description "Test ID for this synthetic loss measurement entry.";
+    }
+
+    uses loss-measurement-common-stats;
+  }
+
+  grouping synthetic-loss-measurement-state {
+    description "Synthetic loss measurement state grouping.";
+
+    container synthetic-loss-measurement-states {
+      config false;
+      description "Collection of synthetic loss measurement states.";
+
+      list synthetic-loss-measurement-state {
+        key "cos test-id";
+        description "Synthetic loss measurement state entry, keyed by CoS and test ID.";
+
+        leaf cos {
+          type leafref {
+            path "../state/cos";
+          }
+          description "Class of Service for this synthetic loss measurement entry.";
+        }
+
+        leaf test-id {
+          type leafref {
+            path "../state/test-id";
+          }
+          description "Test ID for this synthetic loss measurement entry.";
+        }
+        container state {
+          description "Statistical data for synthetic loss measurement";
+          config false;
+          uses synthetic-loss-measurement-stats;
+        }
       }
     }
   }
@@ -1316,3 +1369,5 @@ module openconfig-oam-cfm {
     uses cfm-top;
   }
 }
+
+

--- a/release/models/oam/openconfig-oam-cfm.yang
+++ b/release/models/oam/openconfig-oam-cfm.yang
@@ -29,6 +29,12 @@ module openconfig-oam-cfm {
 
   oc-ext:openconfig-version "0.1.0";
 
+  revision "2026-04-23" {
+    description
+      "Add SLM model and move pm-profile to remote MEP level";
+    reference "0.2.0";
+  }
+
   revision "2024-09-11" {
     description
       "Initial revision";
@@ -139,9 +145,13 @@ module openconfig-oam-cfm {
                       } //end container mep state
 
                       container pm-profiles {
+                        status deprecated;
                         description
                           "This container includes configuration and state objects for the Frame Loss
-                          Measurement & Delay Measurement functions defined in [Y.1731] and [MEF SOAM PM IA].";
+                          Measurement & Delay Measurement functions defined in [Y.1731] and [MEF SOAM PM IA].
+
+                          This container has been deprecated in favor of keeping pm-profiles at the remote
+                          mep level.";
 
                         list pm-profile {
                           description " Measurement profile name and state.";
@@ -273,6 +283,8 @@ module openconfig-oam-cfm {
               uses performance-measurement-config;
               uses performance-measurement-state;
             }
+
+            uses synthetic-loss-measurement-state;
           }
         }
     } // End container cfm
@@ -937,61 +949,56 @@ module openconfig-oam-cfm {
   }
  }
 
-  grouping loss-measurement-state {
-    description "Loss measurement state grouping.";
+  grouping loss-measurement-common-stats {
+    description "Shared loss measurement grouping.";
 
-    container loss-measurement-state {
-      description "Loss measurement state container.";
-
-      leaf far-end-min-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the minimum one-way availability flr in the
-          egress direction (source --> destination),
-          from among the set of availability flr values
-          calculated by the MEP in this Measurement Interval. There is
-          one availability flr value for each 'delta_t' time period
-          within the Measurement Interval, as specified in MEF 10.2.1.
-
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-          reference
-            "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMinFlr";
+    leaf far-end-min-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf far-end-max-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the maximum one-way availability flr in the
-          forward direction (source --> destination),
-          from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
+      units milli-percent;
+      description
+        "This object contains the minimum one-way availability flr in the
+        egress direction (source --> destination),
+        from among the set of availability flr values
+        calculated by the MEP in this Measurement Interval. There is
+        one availability flr value for each 'delta_t' time period
+        within the Measurement Interval, as specified in MEF 10.2.1.
 
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMaxFlr";
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMinFlr";
+    }
+    leaf far-end-max-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf far-end-average-frame-loss-ratio {
+      units milli-percent;
+      description
+        "This object contains the maximum one-way availability flr in the
+        forward direction (source --> destination),
+        from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-        description
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardMaxFlr";
+    }
+    leaf far-end-average-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
         "This object contains the average one-way availability flr in the
         forward direction, from among the set of availability flr
         values calculated by the MEP in this Measurement Interval.
@@ -1003,62 +1010,58 @@ module openconfig-oam-cfm {
         value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
         Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
+      reference
         "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsForwardAvgFlr";
-        }
-
-      leaf near-end-min-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the minimum one-way availability flr in the
-          backward direction (destination --> source),
-          from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
-
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMinFlr";
+    }
+    leaf near-end-min-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
       }
-      leaf near-end-max-frame-loss-ratio {
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-        description
-          "This object contains the maximum one-way availability flr in the
-          backward direction, from among the set of availability flr
-          values calculated by the MEP in this Measurement Interval.
-          There is one availability flr value for each 'delta_t' time
-          period within the Measurement Interval, as specified in MEF
-          10.2.1.
+      units milli-percent;
+      description
+        "This object contains the minimum one-way availability flr in the
+        backward direction (destination --> source),
+        from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-          The flr value is a ratio that is expressed as a percent with a
-          value of 0 (ratio 0.00) through 100000 (ratio 1.00).
-          Service OAM Performance Monitoring YANG Module
-          MEF 39
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
-          Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
-          "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMaxFlr";
-        }
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMinFlr";
+    }
+    leaf near-end-max-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
+        "This object contains the maximum one-way availability flr in the
+        backward direction, from among the set of availability flr
+        values calculated by the MEP in this Measurement Interval.
+        There is one availability flr value for each 'delta_t' time
+        period within the Measurement Interval, as specified in MEF
+        10.2.1.
 
-      leaf near-end-average-frame-loss-ratio {
+        The flr value is a ratio that is expressed as a percent with a
+        value of 0 (ratio 0.00) through 100000 (ratio 1.00).
+        Service OAM Performance Monitoring YANG Module
+        MEF 39
 
-        type uint32 {
-          range "0..100000";
-        }
-        units milli-percent;
-
-        description
+        Units are in milli-percent, where 1 indicates 0.001 percent.";
+      reference
+        "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardMaxFlr";
+    }
+    leaf near-end-average-frame-loss-ratio {
+      type uint32 {
+        range "0..100000";
+      }
+      units milli-percent;
+      description
         "This object contains the average one-way availability flr in the
         backward direction, from among the set of availability flr
         values calculated by the MEP in this Measurement Interval.
@@ -1070,17 +1073,9 @@ module openconfig-oam-cfm {
         value of 0 (ratio 0.00) through 100000 (ratio 1.00).
 
         Units are in milli-percent, where 1 indicates 0.001 percent.";
-        reference
+      reference
         "MEF-SOAM-PM-MIB.mefSoamLmCurrentAvailStatsBackwardAvgFlr";
-        }
-
-      uses loss-measurement-counters-state;
     }
-  }
-
-  grouping loss-measurement-counters-state {
-    description "Loss-measurement-related measurement counters state.";
-
     container counters {
       description
         "A collection of loss-measurement-related statistics objects.";
@@ -1103,6 +1098,64 @@ module openconfig-oam-cfm {
       leaf slr-received {
         type oc-yang:counter64;
         description "slm Probes sent.";
+      }
+    }
+  }
+
+  grouping loss-measurement-state {
+    description "Loss measurement state grouping.";
+
+    container loss-measurement-state {
+      description "Loss measurement state container.";
+      uses loss-measurement-common-stats;
+    }
+  }
+
+  grouping synthetic-loss-measurement-stats {
+    description "Synthetic loss measurement grouping.";
+
+    leaf cos {
+      type uint8;
+      description "Class of Service for this synthetic loss measurement entry.";
+    }
+    
+    leaf test-id {
+      type uint32;
+      description "Test ID for this synthetic loss measurement entry.";
+    }
+
+    uses loss-measurement-common-stats;
+  }
+
+  grouping synthetic-loss-measurement-state {
+    description "Synthetic loss measurement state grouping.";
+
+    container synthetic-loss-measurement-states {
+      config false;
+      description "Collection of synthetic loss measurement states.";
+
+      list synthetic-loss-measurement-state {
+        key "cos test-id";
+        description "Synthetic loss measurement state entry, keyed by CoS and test ID.";
+
+        leaf cos {
+          type leafref {
+            path "../state/cos";
+          }
+          description "Class of Service for this synthetic loss measurement entry.";
+        }
+
+        leaf test-id {
+          type leafref {
+            path "../state/test-id";
+          }
+          description "Test ID for this synthetic loss measurement entry.";
+        }
+        container state {
+          description "Statistical data for synthetic loss measurement";
+          config false;
+          uses synthetic-loss-measurement-stats;
+        }
       }
     }
   }


### PR DESCRIPTION
### Change Scope

* Some changes to the pm-profile in the CFM YANG model
   * pm-profile is currently stored at the local MEP level container, but Performance Measurement(PM) sessions are conducted between a pair of MEPs. This change moves the pm-profile to the remote MEP level container.
   * pm-profile stores the stats collected by each type of PM(e.g. LM and DM). Currently, the model for Synthetic Loss Measurement(SLM) stats is missing. This change adds the container for SLM stats. Note that unlike other PM types, multiple SLM sessions could exist between a pair of MEPs, depending on the cos and the test ID
   * pm-profile is applied per PM type
* Backward compatibility: local MEP level pm-profile, as well as other top level(i.e. not per PM type) PM config/states are deprecated.

### Platform Implementations

 * Arista OAM Performance Measurement:  https://www.arista.com/en/support/toi/eos-4-33-1f/21084-ethernet-oam-performance-monitoring-function-loss-measurement-lm-synthetic-loss-measurement-slm-and-delay-measurement-dm
 

### References
 * IEEE: https://ieeexplore.ieee.org/document/4431836

### Tree View

``` diff
        |                 |  +--ro counters
        |                 |     +--ro mep-ccm-sequence-errors    oc-yang:counter64
        |                 |     +--ro mep-ccms-sent              oc-yang:counter64
-       |                 +--rw pm-profiles
-       |                 |  +--rw pm-profile* [profile-name]
-       |                 |     +--rw profile-name    -> ../config/profile-name
-       |                 |     +--rw config
-       |                 |     |  +--rw profile-name?   string
-       |                 |     +--ro state
-       |                 |        +--ro profile-name?                    string
-       |                 |        +--ro enable?                          boolean
-       |                 |        +--ro measurement-type?                enumeration
-       |                 |        +--ro protocol-type?                   enumeration
-       |                 |        +--ro frame-size?                      uint16
-       |                 |        +--ro measurement-interval?            uint32
-       |                 |        +--ro repetition-period?               uint32
-       |                 |        +--ro intervals-archived?              uint16
-       |                 |        +--ro packets-per-meaurement-period?   uint16
-       |                 |        +--ro burst-interval?                  uint32
-       |                 |        +--ro packet-per-burst?                uint32
-       |                 |        +--ro loss-measurement-state
-       |                 |        |  +--ro far-end-min-frame-loss-ratio?        uint32
-       |                 |        |  +--ro far-end-max-frame-loss-ratio?        uint32
-       |                 |        |  +--ro far-end-average-frame-loss-ratio?    uint32
-       |                 |        |  +--ro near-end-min-frame-loss-ratio?       uint32
-       |                 |        |  +--ro near-end-max-frame-loss-ratio?       uint32
-       |                 |        |  +--ro near-end-average-frame-loss-ratio?   uint32
-       |                 |        |  +--ro counters
-       |                 |        |     +--ro slm-sent?       oc-yang:counter64
-       |                 |        |     +--ro slm-received?   oc-yang:counter64
-       |                 |        |     +--ro slr-sent?       oc-yang:counter64
-       |                 |        |     +--ro slr-received?   oc-yang:counter64
-       |                 |        +--ro delay-measurement-state
-       |                 |           +--ro frame-delay-two-way-min?       uint32
-       |                 |           +--ro frame-delay-two-way-max?       uint32
-       |                 |           +--ro frame-delay-two-way-average?   uint32
-       |                 |           +--ro frame-delay-two-way-stddev?    uint32
-       |                 |           +--ro counters
-       |                 |              +--ro dmm-sent?       oc-yang:counter64
-       |                 |              +--ro dmm-received?   oc-yang:counter64
-       |                 |              +--ro dmr-sent?       oc-yang:counter64
-       |                 |              +--ro dmr-received?   oc-yang:counter64
+       |                 x--rw pm-profiles
+       |                 |  x--rw pm-profile* [profile-name]
+       |                 |     x--rw profile-name    -> ../config/profile-name
+       |                 |     x--rw config
+       |                 |     |  x--rw profile-name?   string
+       |                 |     x--ro state
+       |                 |        x--ro enable?                          boolean
+       |                 |        x--ro pm-type-name?                    oc-cfm-types:pm-type
+       |                 |        x--ro protocol-type?                   enumeration
+       |                 |        x--ro frame-size?                      uint16
+       |                 |        x--ro measurement-interval?            uint32
+       |                 |        x--ro repetition-period?               uint32
+       |                 |        x--ro intervals-archived?              uint16
+       |                 |        x--ro packets-per-meaurement-period?   uint16
+       |                 |        x--ro burst-interval?                  uint32
+       |                 |        x--ro packet-per-burst?                uint32
+       |                 |        x--ro loss-measurement-state
+       |                 |        |  x--ro far-end-min-frame-loss-ratio?        uint32
+       |                 |        |  x--ro far-end-max-frame-loss-ratio?        uint32
+       |                 |        |  x--ro far-end-average-frame-loss-ratio?    uint32
+       |                 |        |  x--ro near-end-min-frame-loss-ratio?       uint32
+       |                 |        |  x--ro near-end-max-frame-loss-ratio?       uint32
+       |                 |        |  x--ro near-end-average-frame-loss-ratio?   uint32
+       |                 |        |  x--ro counters
+       |                 |        |     x--ro slm-sent?       oc-yang:counter64
+       |                 |        |     x--ro slm-received?   oc-yang:counter64
+       |                 |        |     x--ro slr-sent?       oc-yang:counter64
+       |                 |        |     x--ro slr-received?   oc-yang:counter64
+       |                 |        x--ro delay-measurement-state
+       |                 |           x--ro frame-delay-two-way-min?       uint32
+       |                 |           x--ro frame-delay-two-way-max?       uint32
+       |                 |           x--ro frame-delay-two-way-average?   uint32
+       |                 |           x--ro frame-delay-two-way-stddev?    uint32
+       |                 |           x--ro counters
+       |                 |              x--ro dmm-sent?       oc-yang:counter64
+       |                 |              x--ro dmm-received?   oc-yang:counter64
+       |                 |              x--ro dmr-sent?       oc-yang:counter64
+       |                 |              x--ro dmr-received?   oc-yang:counter64
        |                 +--rw rdi
        |                 |  +--rw config
        |                 |  |  +--rw transmit-on-defect?   boolean
@@ -139,24 +138,88 @@
        |                 |     +--ro action?          enumeration
        |                 +--rw remote-meps
        |                    +--rw remote-mep* [id]
-       |                       +--rw id        -> ../config/id
+       |                       +--rw id             -> ../config/id
        |                       +--rw config
        |                       |  +--rw id?            oc-cfm-types:mep-id-type
        |                       |  +--rw mac-address?   oc-yang:mac-address
        |                       +--ro state
-       |                          +--ro id?                        oc-cfm-types:mep-id-type
-       |                          +--ro mac-address?               oc-yang:mac-address
-       |                          +--ro oper-state?                oc-cfm-types:operational-state-type
-       |                          +--ro interface-state?           oc-cfm-types:interface-status-type
-       |                          +--ro fng-state?                 oc-cfm-types:fng-state-type
-       |                          +--ro highest-priority-defect?   oc-cfm-types:highest-defect-priority-type
-       |                          +--ro mep-defects*               oc-cfm-types:mep-defects-type
-       |                          +--ro present-rdi?               boolean
-       |                          +--ro config-errors-detected*    oc-cfm-types:config-error-type
-       |                          +--ro error-ccm-last-failure?    binary
-       |                          +--ro counters
-       |                             +--ro mep-ccm-sequence-errors    oc-yang:counter64
-       |                             +--ro mep-ccms-sent              oc-yang:counter64
+       |                       |  +--ro id?                        oc-cfm-types:mep-id-type
+       |                       |  +--ro mac-address?               oc-yang:mac-address
+       |                       |  +--ro oper-state?                oc-cfm-types:operational-state-type
+       |                       |  +--ro interface-state?           oc-cfm-types:interface-status-type
+       |                       |  +--ro fng-state?                 oc-cfm-types:fng-state-type
+       |                       |  +--ro highest-priority-defect?   oc-cfm-types:highest-defect-priority-type
+       |                       |  +--ro mep-defects*               oc-cfm-types:mep-defects-type
+       |                       |  +--ro present-rdi?               boolean
+       |                       |  +--ro config-errors-detected*    oc-cfm-types:config-error-type
+       |                       |  +--ro error-ccm-last-failure?    binary
+       |                       |  +--ro counters
+       |                       |     +--ro mep-ccm-sequence-errors    oc-yang:counter64
+       |                       |     +--ro mep-ccms-sent              oc-yang:counter64
+       |                       +--rw pm-profiles
+       |                          +--rw pm-profile* [profile-name]
+       |                             +--rw profile-name         -> ../config/profile-name
+       |                             +--rw config
+       |                             |  +--rw profile-name?   string
+       |                             +--ro state
+       |                             |  +--ro profile-name?   string
+       |                             |  +--ro enable?         boolean
+       |                             +--rw measurement-types
+       |                                +--rw measurement-type* [pm-type-name]
+       |                                   +--rw pm-type-name                         -> ../config/pm-type-name
+       |                                   +--rw config
+       |                                   |  +--rw pm-type-name?   oc-cfm-types:pm-type
+       |                                   +--ro state
+       |                                   |  +--ro enable?                          boolean
+       |                                   |  +--ro pm-type-name?                    oc-cfm-types:pm-type
+       |                                   |  +--ro protocol-type?                   enumeration
+       |                                   |  +--ro frame-size?                      uint16
+       |                                   |  +--ro measurement-interval?            uint32
+       |                                   |  +--ro repetition-period?               uint32
+       |                                   |  +--ro intervals-archived?              uint16
+       |                                   |  +--ro packets-per-meaurement-period?   uint16
+       |                                   |  +--ro burst-interval?                  uint32
+       |                                   |  +--ro packet-per-burst?                uint32
+       |                                   |  +--ro loss-measurement-state
+       |                                   |  |  +--ro far-end-min-frame-loss-ratio?        uint32
+       |                                   |  |  +--ro far-end-max-frame-loss-ratio?        uint32
+       |                                   |  |  +--ro far-end-average-frame-loss-ratio?    uint32
+       |                                   |  |  +--ro near-end-min-frame-loss-ratio?       uint32
+       |                                   |  |  +--ro near-end-max-frame-loss-ratio?       uint32
+       |                                   |  |  +--ro near-end-average-frame-loss-ratio?   uint32
+       |                                   |  |  +--ro counters
+       |                                   |  |     +--ro slm-sent?       oc-yang:counter64
+       |                                   |  |     +--ro slm-received?   oc-yang:counter64
+       |                                   |  |     +--ro slr-sent?       oc-yang:counter64
+       |                                   |  |     +--ro slr-received?   oc-yang:counter64
+       |                                   |  +--ro delay-measurement-state
+       |                                   |     +--ro frame-delay-two-way-min?       uint32
+       |                                   |     +--ro frame-delay-two-way-max?       uint32
+       |                                   |     +--ro frame-delay-two-way-average?   uint32
+       |                                   |     +--ro frame-delay-two-way-stddev?    uint32
+       |                                   |     +--ro counters
+       |                                   |        +--ro dmm-sent?       oc-yang:counter64
+       |                                   |        +--ro dmm-received?   oc-yang:counter64
+       |                                   |        +--ro dmr-sent?       oc-yang:counter64
+       |                                   |        +--ro dmr-received?   oc-yang:counter64
+       |                                   +--ro synthetic-loss-measurement-states
+       |                                      +--ro synthetic-loss-measurement-state* [cos test-id]
+       |                                         +--ro cos        -> ../state/cos
+       |                                         +--ro test-id    -> ../state/test-id
+       |                                         +--ro state
+       |                                            +--ro cos?                                 uint8
+       |                                            +--ro test-id?                             uint32
+       |                                            +--ro far-end-min-frame-loss-ratio?        uint32
+       |                                            +--ro far-end-max-frame-loss-ratio?        uint32
+       |                                            +--ro far-end-average-frame-loss-ratio?    uint32
+       |                                            +--ro near-end-min-frame-loss-ratio?       uint32
+       |                                            +--ro near-end-max-frame-loss-ratio?       uint32
+       |                                            +--ro near-end-average-frame-loss-ratio?   uint32
+       |                                            +--ro counters
+       |                                               +--ro slm-sent?       oc-yang:counter64
+       |                                               +--ro slm-received?   oc-yang:counter64
+       |                                               +--ro slr-sent?       oc-yang:counter64
+       |                                               +--ro slr-received?   oc-yang:counter64
        +--ro state
        |  +--ro local-meps?                    uint32
        |  +--ro local-meps-operational?        uint32
@@ -173,50 +236,115 @@
        |  +--ro peer-meps-timed-out?           uint32
        +--rw performance-measurement-profiles-global
           +--rw performance-measurement-profile* [profile-name]
-             +--rw profile-name    -> ../config/profile-name
+             +--rw profile-name         -> ../config/profile-name
              +--rw config
              |  +--rw profile-name?                    string
              |  +--rw enable?                          boolean
-             |  +--rw measurement-type?                enumeration
-             |  +--rw protocol-type?                   enumeration
-             |  +--rw frame-size?                      uint16
-             |  +--rw measurement-interval?            uint32
-             |  +--rw repetition-period?               uint32
-             |  +--rw intervals-archived?              uint16
-             |  +--rw packets-per-meaurement-period?   uint16
-             |  +--rw burst-interval?                  uint32
-             |  +--rw packet-per-burst?                uint32
+             |  x--rw measurement-type?                enumeration
+             |  x--rw protocol-type?                   enumeration
+             |  x--rw frame-size?                      uint16
+             |  x--rw measurement-interval?            uint32
+             |  x--rw repetition-period?               uint32
+             |  x--rw intervals-archived?              uint16
+             |  x--rw packets-per-meaurement-period?   uint16
+             |  x--rw burst-interval?                  uint32
+             |  x--rw packet-per-burst?                uint32
              +--ro state
-                +--ro profile-name?                    string
-                +--ro enable?                          boolean
-                +--ro measurement-type?                enumeration
-                +--ro protocol-type?                   enumeration
-                +--ro frame-size?                      uint16
-                +--ro measurement-interval?            uint32
-                +--ro repetition-period?               uint32
-                +--ro intervals-archived?              uint16
-                +--ro packets-per-meaurement-period?   uint16
-                +--ro burst-interval?                  uint32
-                +--ro packet-per-burst?                uint32
-                +--ro loss-measurement-state
-                |  +--ro far-end-min-frame-loss-ratio?        uint32
-                |  +--ro far-end-max-frame-loss-ratio?        uint32
-                |  +--ro far-end-average-frame-loss-ratio?    uint32
-                |  +--ro near-end-min-frame-loss-ratio?       uint32
-                |  +--ro near-end-max-frame-loss-ratio?       uint32
-                |  +--ro near-end-average-frame-loss-ratio?   uint32
-                |  +--ro counters
-                |     +--ro slm-sent?       oc-yang:counter64
-                |     +--ro slm-received?   oc-yang:counter64
-                |     +--ro slr-sent?       oc-yang:counter64
-                |     +--ro slr-received?   oc-yang:counter64
-                +--ro delay-measurement-state
-                   +--ro frame-delay-two-way-min?       uint32
-                   +--ro frame-delay-two-way-max?       uint32
-                   +--ro frame-delay-two-way-average?   uint32
-                   +--ro frame-delay-two-way-stddev?    uint32
-                   +--ro counters
-                      +--ro dmm-sent?       oc-yang:counter64
-                      +--ro dmm-received?   oc-yang:counter64
-                      +--ro dmr-sent?       oc-yang:counter64
-                      +--ro dmr-received?   oc-yang:counter64
+             |  +--ro profile-name?                    string
+             |  +--ro enable?                          boolean
+             |  x--ro measurement-type?                enumeration
+             |  x--ro protocol-type?                   enumeration
+             |  x--ro frame-size?                      uint16
+             |  x--ro measurement-interval?            uint32
+             |  x--ro repetition-period?               uint32
+             |  x--ro intervals-archived?              uint16
+             |  x--ro packets-per-meaurement-period?   uint16
+             |  x--ro burst-interval?                  uint32
+             |  x--ro packet-per-burst?                uint32
+             |  x--ro loss-measurement-state
+             |  |  x--ro far-end-min-frame-loss-ratio?        uint32
+             |  |  x--ro far-end-max-frame-loss-ratio?        uint32
+             |  |  x--ro far-end-average-frame-loss-ratio?    uint32
+             |  |  x--ro near-end-min-frame-loss-ratio?       uint32
+             |  |  x--ro near-end-max-frame-loss-ratio?       uint32
+             |  |  x--ro near-end-average-frame-loss-ratio?   uint32
+             |  |  x--ro counters
+             |  |     x--ro slm-sent?       oc-yang:counter64
+             |  |     x--ro slm-received?   oc-yang:counter64
+             |  |     x--ro slr-sent?       oc-yang:counter64
+             |  |     x--ro slr-received?   oc-yang:counter64
+             |  x--ro delay-measurement-state
+             |     x--ro frame-delay-two-way-min?       uint32
+             |     x--ro frame-delay-two-way-max?       uint32
+             |     x--ro frame-delay-two-way-average?   uint32
+             |     x--ro frame-delay-two-way-stddev?    uint32
+             |     x--ro counters
+             |        x--ro dmm-sent?       oc-yang:counter64
+             |        x--ro dmm-received?   oc-yang:counter64
+             |        x--ro dmr-sent?       oc-yang:counter64
+             |        x--ro dmr-received?   oc-yang:counter64
+             +--rw measurement-types
+                +--rw measurement-type* [pm-type-name]
+                   +--rw pm-type-name                         -> ../config/pm-type-name
+                   +--rw config
+                   |  +--rw enable?                          boolean
+                   |  +--rw pm-type-name?                    oc-cfm-types:pm-type
+                   |  +--rw protocol-type?                   enumeration
+                   |  +--rw frame-size?                      uint16
+                   |  +--rw measurement-interval?            uint32
+                   |  +--rw repetition-period?               uint32
+                   |  +--rw intervals-archived?              uint16
+                   |  +--rw packets-per-meaurement-period?   uint16
+                   |  +--rw burst-interval?                  uint32
+                   |  +--rw packet-per-burst?                uint32
+                   +--ro state
+                   |  +--ro enable?                          boolean
+                   |  +--ro pm-type-name?                    oc-cfm-types:pm-type
+                   |  +--ro protocol-type?                   enumeration
+                   |  +--ro frame-size?                      uint16
+                   |  +--ro measurement-interval?            uint32
+                   |  +--ro repetition-period?               uint32
+                   |  +--ro intervals-archived?              uint16
+                   |  +--ro packets-per-meaurement-period?   uint16
+                   |  +--ro burst-interval?                  uint32
+                   |  +--ro packet-per-burst?                uint32
+                   |  +--ro loss-measurement-state
+                   |  |  +--ro far-end-min-frame-loss-ratio?        uint32
+                   |  |  +--ro far-end-max-frame-loss-ratio?        uint32
+                   |  |  +--ro far-end-average-frame-loss-ratio?    uint32
+                   |  |  +--ro near-end-min-frame-loss-ratio?       uint32
+                   |  |  +--ro near-end-max-frame-loss-ratio?       uint32
+                   |  |  +--ro near-end-average-frame-loss-ratio?   uint32
+                   |  |  +--ro counters
+                   |  |     +--ro slm-sent?       oc-yang:counter64
+                   |  |     +--ro slm-received?   oc-yang:counter64
+                   |  |     +--ro slr-sent?       oc-yang:counter64
+                   |  |     +--ro slr-received?   oc-yang:counter64
+                   |  +--ro delay-measurement-state
+                   |     +--ro frame-delay-two-way-min?       uint32
+                   |     +--ro frame-delay-two-way-max?       uint32
+                   |     +--ro frame-delay-two-way-average?   uint32
+                   |     +--ro frame-delay-two-way-stddev?    uint32
+                   |     +--ro counters
+                   |        +--ro dmm-sent?       oc-yang:counter64
+                   |        +--ro dmm-received?   oc-yang:counter64
+                   |        +--ro dmr-sent?       oc-yang:counter64
+                   |        +--ro dmr-received?   oc-yang:counter64
+                   +--ro synthetic-loss-measurement-states
+                      +--ro synthetic-loss-measurement-state* [cos test-id]
+                         +--ro cos        -> ../state/cos
+                         +--ro test-id    -> ../state/test-id
+                         +--ro state
+                            +--ro cos?                                 uint8
+                            +--ro test-id?                             uint32
+                            +--ro far-end-min-frame-loss-ratio?        uint32
+                            +--ro far-end-max-frame-loss-ratio?        uint32
+                            +--ro far-end-average-frame-loss-ratio?    uint32
+                            +--ro near-end-min-frame-loss-ratio?       uint32
+                            +--ro near-end-max-frame-loss-ratio?       uint32
+                            +--ro near-end-average-frame-loss-ratio?   uint32
+                            +--ro counters
+                               +--ro slm-sent?       oc-yang:counter64
+                               +--ro slm-received?   oc-yang:counter64
+                               +--ro slr-sent?       oc-yang:counter64
+                               +--ro slr-received?   oc-yang:counter64

```
