### PR TITLE
Clarify enabled/admin-status descriptions for coherent transceiver low-power-mode

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,15 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.8.1";
+  oc-ext:openconfig-version "3.9.0";
+
+  revision "2026-04-23" {
+      description
+        "Clarify enabled and admin-status descriptions for
+        coherent transceiver low-power-mode behavior.";
+      reference
+        "3.9.0";
+  }
 
   revision "2026-01-06" {
       description
@@ -379,6 +387,25 @@ module openconfig-interfaces {
         "This leaf contains the configured, desired state of the
         interface.
 
+        When set to true, the interface is enabled and operational
+        traffic is permitted.
+
+        When set to false, the interface is administratively disabled.
+        For interfaces with a pluggable coherent transceiver (e.g.
+        ZR/ZR+ optics), setting this leaf to false SHOULD additionally
+        cause the transceiver module to be placed into low-power-mode,
+        conserving power and reducing thermal load when the interface
+        is not in use.  When a coherent transceiver is shared by
+        multiple channelized interfaces, the transceiver SHOULD only
+        enter low-power-mode after every channel sharing the module
+        has this leaf set to false.  This low-power-mode behavior
+        applies only to coherent optics; for interfaces using gray
+        (direct-detect) optics or non-pluggable interfaces (e.g.
+        fixed copper ports), setting this leaf to false disables the
+        interface without any optics-specific side effects, even when
+        the underlying module would otherwise support a low-power
+        mode.
+
         Systems that implement the IF-MIB use the value of this
         leaf in the 'running' datastore to set
         IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
@@ -633,7 +660,16 @@ module openconfig-interfaces {
         }
         enum DOWN {
           description
-            "Not ready to pass packets and not in some test mode.";
+            "Not ready to pass packets and not in some test mode.
+
+            For interfaces with a pluggable coherent transceiver
+            (e.g. ZR/ZR+ optics), the DOWN state indicates that the
+            transceiver module SHOULD also be in low-power-mode as a
+            result of the interface being administratively disabled
+            via the enabled configuration leaf, subject to all
+            channels sharing the transceiver being disabled.  This
+            does not apply to gray (direct-detect) optics or
+            non-pluggable interfaces.";
         }
         enum TESTING {
           description
@@ -656,7 +692,14 @@ module openconfig-interfaces {
         "The desired state of the interface.  In RFC 7223 this leaf
         has the same read semantics as ifAdminStatus.  Here, it
         reflects the administrative state as set by enabling or
-        disabling the interface.";
+        disabling the interface.
+
+        When the value is DOWN on an interface with a pluggable
+        coherent transceiver, the transceiver SHOULD be in
+        low-power-mode.  This behavior does not apply to gray
+        (direct-detect) optics or non-pluggable interfaces.  See
+        the description of the enabled leaf in the interface
+        configuration for details.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
       oc-ext:telemetry-on-change;

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -55,8 +55,8 @@ module openconfig-interfaces {
 
   revision "2026-04-23" {
       description
-        "Clarify enabled and admin-status descriptions for
-        coherent transceiver low-power-mode behavior.";
+        "Clarify enabled and admin-status descriptions for coherent
+        transceiver low-power-mode behavior.";
       reference
         "3.9.0";
   }

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -394,26 +394,25 @@ module openconfig-interfaces {
         For interfaces with a pluggable coherent transceiver (e.g.
         ZR/ZR+ optics), setting this leaf to false SHOULD additionally
         cause the transceiver module to be placed into low-power-mode,
-        conserving power and reducing thermal load when the interface
-        is not in use.  When a coherent transceiver is shared by
-        multiple channelized interfaces, the transceiver SHOULD only
-        enter low-power-mode after every channel sharing the module
-        has this leaf set to false.  This low-power-mode behavior
-        applies only to coherent optics; for interfaces using gray
-        (direct-detect) optics or non-pluggable interfaces (e.g.
-        fixed copper ports), setting this leaf to false disables the
-        interface without any optics-specific side effects, even when
-        the underlying module would otherwise support a low-power
-        mode.
+        conserving power and reducing thermal load when the interface is
+        not in use.  When a coherent transceiver is shared by multiple
+        channelized interfaces, the transceiver SHOULD only enter
+        low-power-mode after every channel sharing the module has this
+        leaf set to false.  This low-power-mode behavior applies only to
+        coherent optics; for interfaces using gray (direct-detect)
+        optics or non-pluggable interfaces (e.g. fixed copper ports),
+        setting this leaf to false disables the interface without any
+        optics-specific side effects, even when the underlying module
+        would otherwise support a low-power mode.
 
-        Systems that implement the IF-MIB use the value of this
-        leaf in the 'running' datastore to set
-        IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
-        has been initialized, as described in RFC 2863.
+        Systems that implement the IF-MIB use the value of this leaf in
+        the 'running' datastore to set IF-MIB.ifAdminStatus to 'up' or
+        'down' after an ifEntry has been initialized, as described in
+        RFC 2863.
 
-        Changes in this leaf in the 'running' datastore are
-        reflected in ifAdminStatus, but if ifAdminStatus is
-        changed over SNMP, this leaf is not affected.";
+        Changes in this leaf in the 'running' datastore are reflected in
+        ifAdminStatus, but if ifAdminStatus is changed over SNMP, this
+        leaf is not affected.";
       reference
         "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
     }
@@ -662,14 +661,14 @@ module openconfig-interfaces {
           description
             "Not ready to pass packets and not in some test mode.
 
-            For interfaces with a pluggable coherent transceiver
-            (e.g. ZR/ZR+ optics), the DOWN state indicates that the
+            For interfaces with a pluggable coherent transceiver (e.g.
+            ZR/ZR+ optics), the DOWN state indicates that the
             transceiver module SHOULD also be in low-power-mode as a
-            result of the interface being administratively disabled
-            via the enabled configuration leaf, subject to all
-            channels sharing the transceiver being disabled.  This
-            does not apply to gray (direct-detect) optics or
-            non-pluggable interfaces.";
+            result of the interface being administratively disabled via
+            the enabled configuration leaf, subject to all channels
+            sharing the transceiver being disabled.  This does not apply
+            to gray (direct-detect) optics or non-pluggable
+            interfaces.";
         }
         enum TESTING {
           description
@@ -689,17 +688,18 @@ module openconfig-interfaces {
       //are not used or not implemented consistently.
       mandatory true;
       description
-        "The desired state of the interface.  In RFC 7223 this leaf
-        has the same read semantics as ifAdminStatus.  Here, it
-        reflects the administrative state as set by enabling or
-        disabling the interface.
+        "The desired state of the interface.  In RFC 7223 this leaf has
+        the same read semantics as ifAdminStatus.  Here, it reflects the
+        administrative state as set by enabling or disabling the
+        interface.
 
-        When the value is DOWN on an interface with a pluggable
-        coherent transceiver, the transceiver SHOULD be in
-        low-power-mode.  This behavior does not apply to gray
-        (direct-detect) optics or non-pluggable interfaces.  See
-        the description of the enabled leaf in the interface
-        configuration for details.";
+        When the value is DOWN on an interface with a pluggable coherent
+        transceiver, the transceiver SHOULD be in low-power-mode,
+        subject to all channels sharing the transceiver being disabled.
+        This behavior does not apply to gray (direct-detect) optics or
+        non-pluggable interfaces. See the description of the enabled
+        leaf in the interface configuration for details.";
+
       reference
         "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
       oc-ext:telemetry-on-change;


### PR DESCRIPTION
* (M) release/models/interfaces/openconfig-interfaces.yang
    - Update `enabled` leaf description to indicate that disabling
      an interface SHOULD place a pluggable coherent transceiver
      (e.g. ZR/ZR+) into low-power-mode, including channelized
      cases where all channels sharing a module must be disabled
    - Mirror clarification on `admin-status` leaf and DOWN enum
    - Scope behavior to coherent optics; gray (direct-detect) and
      non-pluggable interfaces are unaffected
    - Increment version to 3.9.0

### Change Scope

This PR amends descriptions only.  No structural or type changes are made
to the model.

The `enabled` configuration leaf and `admin-status` operational state leaf
(including the `DOWN` enum) are clarified to indicate that, on interfaces
backed by a pluggable coherent transceiver (e.g. ZR/ZR+), administratively
disabling the interface SHOULD additionally place the transceiver into
low-power-mode.  When a coherent module is shared by multiple channelized
interfaces, low-power-mode is only entered once all channels sharing the
module have been disabled.

This behavior is explicitly scoped to coherent optics.  Gray
(direct-detect) optics and non-pluggable interfaces are not in scope, even
where the underlying module would otherwise support a low-power mode.

While these are description-only changes, behavior is being clarified for
a pre-existing leaf and may require implementations to adjust.  The model
is therefore bumped as a minor version `3.8.1` -> `3.9.0`.  If folks feel
otherwise, this could be treated as a patch update - e.g. `3.8.2`

### Platform Implementations

N/A

### Tree View

No tree changes - only description updates
