### PR TITLE
Extend BGP Confederation schema with member-ASN ranges and loose-path-validation.

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,14 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,14 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -320,7 +320,7 @@ submodule openconfig-bgp-global {
         "Remote autonomous systems that are to be treated
         as part of the local confederation.";
     }
-  
+
     leaf loose-path-validation {
       type boolean;
       description

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,14 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -57,7 +64,7 @@ submodule openconfig-bgp-global {
 
   revision "2023-12-28" {
     description
-      "Add support for controling use of link-bandwidth extended
+      "Add support for controlling use of link-bandwidth extended
       community for BGP multipath.";
     reference "9.7.0";
   }
@@ -272,6 +279,24 @@ submodule openconfig-bgp-global {
     }
   }
 
+  grouping member-as-range-config {
+    description "Grouping of member-AS-range configurable
+    attributes";
+
+    leaf first-asn {
+      type oc-inet:as-number;
+      description
+        "Lowest AS number included in this range";
+
+    }
+
+    leaf last-asn {
+      type oc-inet:as-number;
+      description
+        "Highest AS number included in this range";
+    }
+  }
+
   grouping bgp-global-confederation-config {
     description
       "Configuration options specifying parameters when the local
@@ -292,6 +317,27 @@ submodule openconfig-bgp-global {
         "Remote autonomous systems that are to be treated
         as part of the local confederation.";
     }
+   
+    leaf loose-path-validation {
+      type boolean;
+      description
+        "When set to FALSE, presence of ASN not listed in
+        member-as, memeber-as-range in BGP_CONFEDERATION_SEQUENCE
+        object of AS_PATH could be recognized as malformed path
+        attribute. This behaviour is not mandated or suggested
+        by RFC5065.
+
+        When set to TRUE, in scenario described above the BGP
+        AS_PATH attribute must be considered a valid path attribute.
+        This behaviour is fully compliant with RFC5065.
+        
+        If implementation support peer-ASN (leftmost) validation
+        in AS_PATH against peer-ASN negotiated in OPEN message,
+        the loose-path-validation set to TRUE do not relax this
+        validation.";
+    }
+
+
   }
 
   grouping bgp-global-dynamic-neighbors {
@@ -503,6 +549,48 @@ submodule openconfig-bgp-global {
         description
           "State information relating to the BGP confederations";
         uses bgp-global-confederation-config;
+      }
+
+      container member-as-ranges {
+        description
+          "The configuration of continuous member-ASN ranges
+          constituting this confederation.";
+
+        list member-as-range {
+          key "first-asn last-asn";
+
+          description
+            "Range of member-ASN belonging to this confederation
+            ";
+          leaf first-asn {
+            type leafref {
+              path "../config/first-asn";
+            }
+            description
+              "Lowest AS number included in this range";
+          }
+          leaf last-asn {
+            type leafref {
+              path "../config/last-asn";
+            }
+            description
+              "Highest AS number included in this range";
+
+          }
+          container config {
+            description "Configuration container for Member-AS
+            range";
+
+            uses member-as-range-config;
+          }
+          container state {
+            config false;
+            description "State container for Member-AS
+            range";
+
+            uses member-as-range-config;
+          }
+        }
       }
     }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -320,7 +320,7 @@ submodule openconfig-bgp-global {
         "Remote autonomous systems that are to be treated
         as part of the local confederation.";
     }
-   
+  
     leaf loose-path-validation {
       type boolean;
       description
@@ -333,7 +333,6 @@ submodule openconfig-bgp-global {
         When set to TRUE, in scenario described above the BGP
         AS_PATH attribute must be considered a valid path attribute.
         This behaviour is fully compliant with RFC5065.
-        
         If an implementation supports peer-ASN (leftmost) validation
         in AS_PATH against peer-ASN negotiated in OPEN message,
         the loose-path-validation set to TRUE does not relax this

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -292,6 +292,9 @@ submodule openconfig-bgp-global {
 
     leaf last-asn {
       type oc-inet:as-number;
+      must ". >= ../first-asn" {
+        error-message "The last-asn must be greater than or equal to the first-asn.";
+      }
       description
         "Highest AS number included in this range";
     }

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -322,7 +322,7 @@ submodule openconfig-bgp-global {
       type boolean;
       description
         "When set to FALSE, presence of ASN not listed in
-        member-as, memeber-as-range in BGP_CONFEDERATION_SEQUENCE
+        member-as or member-as-range in BGP_CONFEDERATION_SEQUENCE
         object of AS_PATH could be recognized as malformed path
         attribute. This behaviour is not mandated or suggested
         by RFC5065.
@@ -331,9 +331,9 @@ submodule openconfig-bgp-global {
         AS_PATH attribute must be considered a valid path attribute.
         This behaviour is fully compliant with RFC5065.
         
-        If implementation support peer-ASN (leftmost) validation
+        If an implementation supports peer-ASN (leftmost) validation
         in AS_PATH against peer-ASN negotiated in OPEN message,
-        the loose-path-validation set to TRUE do not relax this
+        the loose-path-validation set to TRUE does not relax this
         validation.";
     }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,14 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,14 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,14 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-04-27" {
+    description
+      "Add schema for BGP Confederation member-ASN ranges and
+      loose-path-validation.";
+          reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description


### PR DESCRIPTION
### Change Scope

Extend BGP Confederation member-ASN ranges and loose-path-validation.

In large BGP Confederated network it is impractical to explicitly list in configuration all potentially 100's of member-AS. It is also not required for implementaion to be aware of all member-ASN. Implementation only need to know member-ASN it has configured confederation external BGP session.

- The member-as-range structure allows for efficient listing large number of member-ASN if they are allocated in structured way e.g. gotm 4B ASN private space.
- The 'loose-as-validation' boolean allows to explicitly control implementation behaviour regarding AS_PATH attribute validdeation. This is needed since different existing implementaions has disticnt implicit and non-configurable behaviours.

### Platform Implementations

#### AS_PATH validation:
| implementation| implicit behaviour|
|---|---|
|Arista EoS | *loose*. Path is valid if non-listed ASN is in BGP_CONFEDERATION_SEQUENCE object.|
|Cisco IOS | *loose*. Path is valid if non-listed ASN is in BGP_CONFEDERATION_SEQUENCE object.|
|Juniper | *strict*. Path is invalid if non-listed ASN is in BGP_CONFEDERATION_SEQUENCE object. Error handling may reset BGP session.|
|Nokia SR-OS | *strict*. Path is invalid if non-listed ASN is in BGP_CONFEDERATION_SEQUENCE object. Error handling may reset BGP session. (to be confirmed)|
|Quagga/FRR | *loose*. Path is valid if non-listed ASN is in BGP_CONFEDERATION_SEQUENCE object|

#### `member-as-range`
This is a new feature.

### Tree View

```diff
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw bgp
                 +--rw global
                    +--rw confederation
                       +--rw config
                       |  +--rw identifier?              oc-inet:as-number
                       |  +--rw member-as*               oc-inet:as-number
+                      |  +--rw loose-path-validation?   boolean
                       +--ro state
                       |  +--ro identifier?              oc-inet:as-number
                       |  +--ro member-as*               oc-inet:as-number
+                      |  +--ro loose-path-validation?   boolean
+                       +--rw member-as-ranges
+                          +--rw member-as-range* [first-asn last-asn]
+                             +--rw first-asn    -> ../config/first-asn
+                             +--rw last-asn     -> ../config/last-asn
+                             +--rw config
+                             |  +--rw first-asn?   oc-inet:as-number
+                             |  +--rw last-asn?    oc-inet:as-number
+                             +--ro state
+                                +--ro first-asn?   oc-inet:as-number
+                                +--ro last-asn?    oc-inet:as-number
``` 
