### PR TITLE
Reapply "Add BGP group/neighbor level and policy support for AIGP (#1…

### DIFF
--- a/release/models/bgp/openconfig-bgp-errors.yang
+++ b/release/models/bgp/openconfig-bgp-errors.yang
@@ -18,7 +18,13 @@ submodule openconfig-bgp-errors {
     "This module defines BGP NOTIFICATION message error codes
     and subcodes";
 
-  oc-ext:openconfig-version "6.1.0";
+  oc-ext:openconfig-version "6.2.0";
+
+  revision "2026-03-24" {
+    description
+      "Add bgp-aigp-metric typedef.";
+    reference "6.2.0";
+  }
 
   revision "2024-09-06" {
     description

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -28,7 +28,13 @@ module openconfig-bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  oc-ext:openconfig-version "8.2.0";
+  oc-ext:openconfig-version "8.3.0";
+
+  revision "2026-03-17" {
+    description
+      "Add set-aigp to BGP policy actions.";
+    reference "8.3.0";
+  }
 
   revision "2025-05-23" {
     description
@@ -263,6 +269,17 @@ module openconfig-bgp-policy {
     description
       "Specifies which action to take on the value specified by the
       bgp-set-med-type.";
+  }
+
+  typedef bgp-set-aigp-action {
+    type enumeration {
+      enum SET {
+        description "Action to set the AIGP to a specific value.";
+      }
+    }
+    description
+      "Specifies which action to take on the value specified by the
+      set-aigp leaf.";
   }
 
   // grouping statements
@@ -1405,6 +1422,20 @@ module openconfig-bgp-policy {
         valid options.  When set to 'IGP', this action must be set to
         'SET'.";
     }
+
+    leaf set-aigp {
+      type oc-bgp-types:bgp-aigp-metric;
+      description
+        "Set the AIGP metric attribute in the route update (RFC 7311,
+        Section 3.4)";
+    }
+
+    leaf set-aigp-action {
+      type bgp-set-aigp-action;
+      description
+        "This leaf is mandatory when `set-aigp` is specified.  When
+        `set-aigp` is specified, the action must be set to 'SET'.";
+    }
   }
 
   grouping bgp-actions-state {
@@ -1433,6 +1464,10 @@ module openconfig-bgp-policy {
             "otherwise any action must be specified if set-med is an " +
             "integer value.";
         }
+
+        must "(not(set-aigp) or set-aigp-action)" {
+          error-message "set-aigp-action must be specified when set-aigp is set";
+        }
       }
 
       container state {
@@ -1451,6 +1486,10 @@ module openconfig-bgp-policy {
             "set-med-action must be set to 'SET' when set-med = 'IGP', " +
             "otherwise any action must be specified if set-med is an " +
             "integer value.";
+        }
+
+        must "(not(set-aigp) or set-aigp-action)" {
+          error-message "set-aigp-action must be specified when set-aigp is set";
         }
       }
       uses as-path-prepend-top;

--- a/release/models/bgp/openconfig-bgp-policy.yang
+++ b/release/models/bgp/openconfig-bgp-policy.yang
@@ -279,7 +279,7 @@ module openconfig-bgp-policy {
     }
     description
       "Specifies which action to take on the value specified by the
-      set-aigp leaf.";
+      set-aigp-action leaf.";
   }
 
   // grouping statements
@@ -1433,8 +1433,7 @@ module openconfig-bgp-policy {
     leaf set-aigp-action {
       type bgp-set-aigp-action;
       description
-        "This leaf is mandatory when `set-aigp` is specified.  When
-        `set-aigp` is specified, the action must be set to 'SET'.";
+        "This leaf is mandatory when `set-aigp-action` is specified.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-types.yang
+++ b/release/models/bgp/openconfig-bgp-types.yang
@@ -24,7 +24,13 @@ module openconfig-bgp-types {
     policy. It can be imported by modules that make use of BGP
     attributes";
 
-  oc-ext:openconfig-version "6.1.0";
+  oc-ext:openconfig-version "6.2.0";
+
+  revision "2026-03-24" {
+    description
+      "Add bgp-aigp-metric typedef.";
+    reference "6.2.0";
+  }
 
   revision "2024-09-06" {
     description
@@ -840,5 +846,14 @@ module openconfig-bgp-types {
     }
     description
       "Defines the types of BGP AS path segments.";
+  }
+
+  typedef bgp-aigp-metric {
+    type uint64;
+    description
+      "Higher-precision metric, also known as Accumulated IGP
+      Metric [RFC7311].";
+    reference
+      "RFC 7311 - The Accumulated IGP Metric Attribute for BGP";
   }
 }

--- a/release/models/network-instance/openconfig-network-instance-l2.yang
+++ b/release/models/network-instance/openconfig-network-instance-l2.yang
@@ -25,7 +25,13 @@ submodule openconfig-network-instance-l2 {
     parameters.";
 
 
-  oc-ext:openconfig-version "4.6.0";
+  oc-ext:openconfig-version "4.7.0";
+
+  revision "2026-03-17" {
+    description
+      "Add enable-aigp to BGP address families in neighbors and peer-groups.";
+    reference "4.7.0";
+  }
 
   revision "2025-03-26" {
     description

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -50,7 +50,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.6.0";
+  oc-ext:openconfig-version "4.7.0";
+
+  revision "2026-03-17" {
+    description
+      "Add enable-aigp to BGP address families in neighbors and peer-groups.";
+    reference "4.7.0";
+  }
 
   revision "2025-03-26" {
     description
@@ -1453,5 +1459,98 @@ module openconfig-network-instance {
         in the network instance";
     }
   }
+
+  grouping ni-bgp-afi-aigp-config {
+    description
+      "Grouping for enable-aigp leaf";
+    leaf enable-aigp {
+      type boolean;
+      description
+        "Flag to enable sending / receiving accumulated IGP
+        attribute in routing updates for the address family as
+        stipulated by RFC 7311 Section 3.3";
+    }
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:neighbors/oc-netinst:neighbor/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv4-unicast/oc-netinst:config" {
+    description
+      "Add enable-aigp to BGP neighbor IPv4 unicast config";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:neighbors/oc-netinst:neighbor/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv4-unicast/oc-netinst:state" {
+    description
+      "Add enable-aigp to BGP neighbor IPv4 unicast state";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:neighbors/oc-netinst:neighbor/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv6-unicast/oc-netinst:config" {
+    description
+      "Add enable-aigp to BGP neighbor IPv6 unicast config";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:neighbors/oc-netinst:neighbor/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv6-unicast/oc-netinst:state" {
+    description
+      "Add enable-aigp to BGP neighbor IPv6 unicast state";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:peer-groups/oc-netinst:peer-group/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv4-unicast/oc-netinst:config" {
+    description
+      "Add enable-aigp to BGP peer-group IPv4 unicast config";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:peer-groups/oc-netinst:peer-group/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv4-unicast/oc-netinst:state" {
+    description
+      "Add enable-aigp to BGP peer-group IPv4 unicast state";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:peer-groups/oc-netinst:peer-group/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv6-unicast/oc-netinst:config" {
+    description
+      "Add enable-aigp to BGP peer-group IPv6 unicast config";
+    uses ni-bgp-afi-aigp-config;
+  }
+
+  augment "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+          "oc-netinst:protocols/oc-netinst:protocol/oc-netinst:bgp/" +
+          "oc-netinst:peer-groups/oc-netinst:peer-group/" +
+          "oc-netinst:afi-safis/oc-netinst:afi-safi/" +
+          "oc-netinst:ipv6-unicast/oc-netinst:state" {
+    description
+      "Add enable-aigp to BGP peer-group IPv6 unicast state";
+    uses ni-bgp-afi-aigp-config;
+  }
+
   uses network-instance-top;
 }

--- a/release/models/rib/openconfig-rib-bgp-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-attributes.yang
@@ -24,7 +24,13 @@ submodule openconfig-rib-bgp-attributes {
     attributes for use in BGP RIB tables.";
 
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2026-03-24" {
+    description
+      "Update aigp to use common AIGP metric typedef.";
+    reference "0.10.0";
+  }
 
   revision "2022-12-20" {
     description
@@ -350,12 +356,10 @@ submodule openconfig-rib-bgp-attributes {
     }
 
     leaf aigp {
-      type uint64;
+      type oc-bgpt:bgp-aigp-metric;
       description
         "BGP path attribute representing the accumulated IGP metric
         for the path";
-      reference
-        "RFC 7311 - The Accumulated IGP Metric Attribute for BGP";
     }
   }
 

--- a/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-shared-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-shared-attributes {
     "This submodule contains structural data definitions for
     attribute sets shared across routes.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2026-03-24" {
+    description
+      "Add BGP AIGP support.";
+    reference "0.10.0";
+  }
 
   revision "2022-12-20" {
     description

--- a/release/models/rib/openconfig-rib-bgp-table-attributes.yang
+++ b/release/models/rib/openconfig-rib-bgp-table-attributes.yang
@@ -21,7 +21,13 @@ submodule openconfig-rib-bgp-table-attributes {
     "This submodule contains common data definitions for data
     related to a RIB entry, or RIB table.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2026-03-24" {
+    description
+      "Add BGP AIGP support.";
+    reference "0.10.0";
+  }
 
   revision "2022-12-20" {
     description

--- a/release/models/rib/openconfig-rib-bgp-tables.yang
+++ b/release/models/rib/openconfig-rib-bgp-tables.yang
@@ -30,7 +30,13 @@ submodule openconfig-rib-bgp-tables {
     "This submodule contains structural data definitions for
     BGP routing tables.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2026-03-24" {
+    description
+      "Add BGP AIGP support.";
+    reference "0.10.0";
+  }
 
   revision "2022-12-20" {
     description

--- a/release/models/rib/openconfig-rib-bgp.yang
+++ b/release/models/rib/openconfig-rib-bgp.yang
@@ -67,7 +67,13 @@ module openconfig-rib-bgp {
     eligible for sending (advertising) to the neighbor after output
     policy rules have been applied.";
 
-  oc-ext:openconfig-version "0.9.0";
+  oc-ext:openconfig-version "0.10.0";
+
+  revision "2026-03-24" {
+    description
+      "Add BGP AIGP support.";
+    reference "0.10.0";
+  }
 
   revision "2022-12-20" {
     description


### PR DESCRIPTION
**Please note: this PR includes changes made in https://github.com/openconfig/public/pull/1451, which was accidentally submitted too early and was subsequently reverted. Please see original pull request for earlier comments and discussion on this change**

### Change Scope

* This change adds the ability to enable BGP AIGP exchange between peers at
the group and neighbor level for IPv4 and IPv6 unicast address families.
It also adds the ability to set an arbitrary AIGP value in a BGP policy.
* This change is backwards compatible.

### Platform Implementations

 * Implementation A: [link to documentation](https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/119001-configure-aigp-00.html#anc10)
 * Implementation B: [link to documentation](https://www.arista.com/en/support/toi/eos-4-24-1f/14532-accumulated-igp-metric-aigp)
 * Implementation C: [link to documentation](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/aigp-edit-protocols-bgp.html)
 * Implementation D: [link to documentation (see pages 28-29)](https://documentation.nokia.com/srlinux/25-7/books/pdf/Routing_Protocols_Guide_25.7.pdf)

 Note: Implementation A and Implementation B align well with the paths added
 here. Implementation C does not allow setting an arbitrary AIGP value in
 policy. AIGP value can instead be originated and adjusted via addition,
 subtraction, multiplication, or division. Implementation D supports AIGP
 enablement only in the base router BGP instance (not per group or
 neighbor) and does not support AIGP manipulation in route policies. 

### Tree View

```diff
 module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
         |  +--rw protocol* [identifier name]
         |     +--rw bgp
         |     |  +--rw neighbors
         |     |  |  +--rw neighbor* [neighbor-address]
         |     |  |     +--rw afi-safis
         |     |  |     |  +--rw afi-safi* [afi-safi-name]
         |     |  |     |     +--rw ipv4-unicast
         |     |  |     |     |  +--rw prefix-limit
         |     |  |     |     |  +--rw prefix-limit-received
         |     |  |     |     |  +--rw config
         |     |  |     |     |  |  +--rw send-default-route?           boolean
         |     |  |     |     |  |  +--rw extended-next-hop-encoding?   boolean
+        |     |  |     |     |  |  +--rw enable-aigp?                  boolean
         |     |  |     |     |  +--ro state
         |     |  |     |     |     +--ro send-default-route?           boolean
         |     |  |     |     |     +--ro extended-next-hop-encoding?   boolean
+        |     |  |     |     |     +--ro enable-aigp?                  boolean
         |     |  |     |     +--rw ipv6-unicast
         |     |  |     |     |  +--rw prefix-limit
         |     |  |     |     |  +--rw prefix-limit-received
         |     |  |     |     |  +--rw config
         |     |  |     |     |  |  +--rw send-default-route?   boolean
+        |     |  |     |     |  |  +--rw enable-aigp?          boolean
         |     |  |     |     |  +--ro state
         |     |  |     |     |     +--ro send-default-route?   boolean
+        |     |  |     |     |     +--ro enable-aigp?          boolean
         |     |  |     |     +--rw ipv4-labeled-unicast
         |     |  +--rw peer-groups
         |     |  |  +--rw peer-group* [peer-group-name]
         |     |  |     +--rw afi-safis
         |     |  |     |  +--rw afi-safi* [afi-safi-name]
         |     |  |     |     +--rw ipv4-unicast
         |     |  |     |     |  +--rw prefix-limit
         |     |  |     |     |  +--rw prefix-limit-received
         |     |  |     |     |  +--rw config
         |     |  |     |     |  |  +--rw send-default-route?           boolean
         |     |  |     |     |  |  +--rw extended-next-hop-encoding?   boolean
+        |     |  |     |     |  |  +--rw enable-aigp?                  boolean
         |     |  |     |     |  +--ro state
         |     |  |     |     |     +--ro send-default-route?           boolean
         |     |  |     |     |     +--ro extended-next-hop-encoding?   boolean
+        |     |  |     |     |     +--ro enable-aigp?                  boolean
         |     |  |     |     +--rw ipv6-unicast
         |     |  |     |     |  +--rw prefix-limit
         |     |  |     |     +--rw ipv4-labeled-unicast
         |     |  +--ro rib
         |     |     +--ro attr-sets
         |     |     |  +--ro attr-set* [index]
         |     |     |     +--ro index                   -> ../state/index
         |     |     |     +--ro state
         |     |     |     |  +--ro index?              uint64
         |     |     |     |  +--ro origin?             oc-bgpt:bgp-origin-attr-type
         |     |     |     |  +--ro atomic-aggregate?   boolean
         |     |     |     |  +--ro next-hop?           oc-inet:ip-address
         |     |     |     |  +--ro med?                uint32
         |     |     |     |  +--ro local-pref?         uint32
         |     |     |     |  +--ro originator-id?      oc-inet:ipv4-address
         |     |     |     |  +--ro cluster-list*       oc-inet:ipv4-address
-        |     |     |     |  +--ro aigp?               uint64
+        |     |     |     |  +--ro aigp?               oc-bgpt:bgp-aigp-metric
         |     |     |     +--ro aggregator

module: openconfig-routing-policy
  +--rw routing-policy
     +--rw policy-definitions
        +--rw policy-definition* [name]
           +--rw statements
              +--rw statement* [name]
                  +--rw actions
                     +--rw oc-bgp-pol:bgp-actions
                     |  +--rw oc-bgp-pol:config
                     |  |  +--rw oc-bgp-pol:set-route-origin?   oc-bgp-types:bgp-origin-attr-type
                     |  |  +--rw oc-bgp-pol:set-local-pref?     uint64
                     |  |  +--rw oc-bgp-pol:set-next-hop?       bgp-next-hop-type
                     |  |  +--rw oc-bgp-pol:set-med?            bgp-set-med-type
                     |  |  +--rw oc-bgp-pol:set-med-action?     bgp-set-med-action
+                    |  |  +--rw oc-bgp-pol:set-aigp?           oc-bgp-types:bgp-aigp-metric
+                    |  |  +--rw oc-bgp-pol:set-aigp-action?    bgp-set-aigp-action
                     |  +--ro oc-bgp-pol:state
                     |  |  +--ro oc-bgp-pol:set-route-origin?   oc-bgp-types:bgp-origin-attr-type
                     |  |  +--ro oc-bgp-pol:set-local-pref?     uint64
                     |  |  +--ro oc-bgp-pol:set-next-hop?       bgp-next-hop-type
                     |  |  +--ro oc-bgp-pol:set-med?            bgp-set-med-type
                     |  |  +--ro oc-bgp-pol:set-med-action?     bgp-set-med-action
+                    |  |  +--rw oc-bgp-pol:set-aigp?           oc-bgp-types:bgp-aigp-metric
+                    |  |  +--rw oc-bgp-pol:set-aigp-action?    bgp-set-aigp-action

```