### PR TITLE
Add build section and ci checks to spec yml files

### DIFF
--- a/release/models/catalog/.spec.yml
+++ b/release/models/catalog/.spec.yml
@@ -4,4 +4,4 @@
   docs:
     - yang/catalog/openconfig-catalog-types.yang
     - yang/catalog/openconfig-module-catalog.yang
-  run-ci: false
+  run-ci: true

--- a/release/models/catalog/.spec.yml
+++ b/release/models/catalog/.spec.yml
@@ -1,8 +1,7 @@
 - name: openconfig-module-catalog
   build:
-    - yang/catalog/openconfig-catalog-types.yang
     - yang/catalog/openconfig-module-catalog.yang
   docs:
     - yang/catalog/openconfig-catalog-types.yang
     - yang/catalog/openconfig-module-catalog.yang
-  run-ci: true
+  run-ci: false

--- a/release/models/catalog/.spec.yml
+++ b/release/models/catalog/.spec.yml
@@ -1,5 +1,6 @@
 - name: openconfig-module-catalog
   build:
+    - yang/catalog/openconfig-catalog-types.yang
     - yang/catalog/openconfig-module-catalog.yang
   docs:
     - yang/catalog/openconfig-catalog-types.yang

--- a/release/models/gnpsi/.spec.yml
+++ b/release/models/gnpsi/.spec.yml
@@ -3,4 +3,4 @@
     - yang/gnpsi/openconfig-gnpsi-types.yang
   build:
     - yang/gnpsi/openconfig-gnpsi-types.yang
-  run-ci: false
+  run-ci: true

--- a/release/models/grpc/.spec.yml
+++ b/release/models/grpc/.spec.yml
@@ -3,4 +3,4 @@
     - yang/grpc/openconfig-grpc-types.yang
   build:
     - yang/grpc/openconfig-grpc-types.yang
-  run-ci: false
+  run-ci: true

--- a/release/models/local-routing/.spec.yml
+++ b/release/models/local-routing/.spec.yml
@@ -8,3 +8,7 @@
   docs:
     - yang/network-instance/openconfig-network-instance.yang
     - yang/local-routing/openconfig-local-routing-network-instance.yang
+  build:
+    - yang/network-instance/openconfig-network-instance.yang
+    - yang/local-routing/openconfig-local-routing-network-instance.yang
+  run-ci: true

--- a/release/models/types/.spec.yml
+++ b/release/models/types/.spec.yml
@@ -7,4 +7,4 @@
     - yang/types/openconfig-types.yang
     - yang/types/openconfig-yang-types.yang
     - yang/types/openconfig-inet-types.yang
-  run-ci: false
+  run-ci: true


### PR DESCRIPTION
This pull request updates several `.spec.yml` files for different models to enable continuous integration (CI) and, in one case, adds missing build steps. The main goal is to ensure that CI runs for these models and that all necessary build steps are defined.

**CI enablement:**

* Set `run-ci: true` for the following models, so CI will now run for them:
  - `gnpsi` (`release/models/gnpsi/.spec.yml`)
  - `grpc` (`release/models/grpc/.spec.yml`)
  - `types` (`release/models/types/.spec.yml`)

**Build configuration:**

* Added a missing `build` section for the `local-routing` model and enabled CI by setting `run-ci: true` (`release/models/local-routing/.spec.yml`)