### PR TITLE
Add openconfig-snmp YANG model for SNMP configuration and monitoring

### DIFF
--- a/release/models/system/.spec.yml
+++ b/release/models/system/.spec.yml
@@ -10,6 +10,7 @@
     - yang/system/openconfig-hashing.yang
     - yang/system/openconfig-license.yang
     - yang/system/openconfig-procmon.yang
+    - yang/system/openconfig-snmp.yang
     - yang/system/openconfig-system.yang
     - yang/system/openconfig-system-bootz.yang
     - yang/system/openconfig-system-controlplane.yang

--- a/release/models/system/openconfig-snmp.yang
+++ b/release/models/system/openconfig-snmp.yang
@@ -1,0 +1,475 @@
+module openconfig-snmp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/system/snmp";
+
+  prefix "oc-snmp";
+
+  // import some basic types
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  import openconfig-inet-types {
+    prefix oc-inet;
+  }
+
+  import openconfig-acl {
+    prefix oc-acl;
+  }
+
+  import openconfig-extensions {
+    prefix oc-ext;
+  }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state
+    data for SNMP services on network systems.
+
+    This module is limited to community-based SNMP.
+    SNMPv3 is out of scope.";
+
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2026-05-04" {
+    description
+      "Remove SNMPv3, fix receiver identity, resolve
+      dual access-restriction paths, document filter
+      precedence, remove unneeded source-address.";
+    reference
+      "0.3.0";
+  }
+
+  revision "2026-04-15" {
+    description
+      "Initial revision.";
+    reference
+      "0.1.0";
+  }
+
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  identity SNMP_NOTIFICATION_EVENT {
+    description
+      "Base identity for SNMP notification event types.";
+  }
+
+  identity ALL {
+    base SNMP_NOTIFICATION_EVENT;
+    description
+      "Enable all SNMP notification event types.";
+  }
+
+  identity AUTHENTICATION {
+    base SNMP_NOTIFICATION_EVENT;
+    description
+      "Enable authentication failure notifications.";
+  }
+
+  identity LINE_STATUS {
+    base SNMP_NOTIFICATION_EVENT;
+    description
+      "Enable line/session status change notifications
+      (e.g., console or VTY login/logout events).";
+  }
+
+  typedef snmp-access-mode {
+    type enumeration {
+      enum READ_ONLY {
+        description
+          "Read-only community access.";
+      }
+      enum READ_WRITE {
+        description
+          "Read-write community access.";
+      }
+    }
+    description
+      "SNMP access mode for a community.";
+  }
+
+  typedef snmp-version {
+    type enumeration {
+      enum V1 {
+        description
+          "SNMP version 1.";
+      }
+      enum V2C {
+        description
+          "SNMP version 2c.";
+      }
+    }
+    description
+      "SNMP protocol version for a receiver or community
+      in this module.";
+  }
+
+  grouping snmp-global-config {
+    description
+      "Configuration data for global SNMP settings.";
+
+    leaf contact {
+      type string;
+      description
+        "Configured SNMP contact string.";
+    }
+
+    leaf location {
+      type string;
+      description
+        "Configured SNMP location string.";
+    }
+  }
+
+  grouping snmp-global-state {
+    description
+      "Operational state data for global SNMP settings.
+      Reserved for future operational counters such as
+      total requests received or invalid community
+      attempts.";
+  }
+
+  grouping snmp-community-client-config {
+    description
+      "Configuration data for allowed SNMP manager prefixes.";
+
+    leaf prefix {
+      type oc-inet:ip-prefix;
+      description
+        "Allowed manager prefix for this community.";
+    }
+  }
+
+  grouping snmp-community-client-state {
+    description
+      "Operational state data for community manager
+      prefixes. Reserved for future per-client
+      counters.";
+  }
+
+  grouping snmp-community-client-top {
+    description
+      "Top-level grouping for community manager prefixes.";
+
+    container clients {
+      description
+        "List of allowed manager prefixes for a community.";
+
+      list client {
+        key "prefix";
+        description
+          "List of prefixes allowed to use this community.";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+          description
+            "Reference to community client prefix.";
+        }
+
+        container config {
+          description
+            "Configuration data for a community client.";
+          uses snmp-community-client-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for a community client.";
+          uses snmp-community-client-config;
+          uses snmp-community-client-state;
+        }
+      }
+    }
+  }
+
+  grouping snmp-community-config {
+    description
+      "Configuration data for SNMP communities.";
+
+    leaf name {
+      type string;
+      description
+        "SNMP community name.";
+    }
+
+    leaf access-mode {
+      type snmp-access-mode;
+      description
+        "Access mode for this community.";
+    }
+
+    leaf version {
+      type snmp-version;
+      description
+        "SNMP version associated with this community.
+        Only V1 and V2C are supported by this module.";
+    }
+
+    leaf access-list {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set"
+          + "/oc-acl:config/oc-acl:name";
+      }
+      description
+        "Reference to an ACL restricting which managers
+        may use this community. When set, the clients
+        list is ignored and access is governed solely
+        by this ACL. If omitted, the clients list is
+        consulted; if both are absent, access is
+        unrestricted.";
+    }
+  }
+
+  grouping snmp-community-state {
+    description
+      "Operational state data for SNMP communities.
+      Reserved for future per-community counters.";
+  }
+
+  grouping snmp-community-top {
+    description
+      "Top-level grouping for SNMP community configuration.";
+
+    container communities {
+      description
+        "List of SNMP communities.";
+
+      list community {
+        key "name";
+        description
+          "List of configured SNMP communities.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the community list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for an SNMP community.";
+          uses snmp-community-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for an SNMP community.";
+          uses snmp-community-config;
+          uses snmp-community-state;
+        }
+
+        uses snmp-community-client-top;
+      }
+    }
+  }
+
+  grouping snmp-receiver-config {
+    description
+      "Configuration data for SNMP notification receivers.";
+
+    leaf name {
+      type string;
+      description
+        "Unique name identifying this receiver entry.";
+    }
+
+    leaf address {
+      type oc-inet:ip-address;
+      description
+        "Receiver address for notifications.";
+    }
+
+    leaf port {
+      type inet:port-number;
+      description
+        "UDP port used for notifications. If omitted,
+        the standard SNMP trap port (162) is used.";
+    }
+
+    leaf version {
+      type snmp-version;
+      description
+        "SNMP version used for this receiver. Only V1
+        and V2C are supported by this module.";
+    }
+
+    leaf community {
+      type string;
+      description
+        "Community string used for v1/v2c notifications.";
+    }
+
+    leaf-list event-type {
+      type identityref {
+        base SNMP_NOTIFICATION_EVENT;
+      }
+      description
+        "Event types enabled for this specific receiver.
+        If empty, the receiver inherits the globally
+        configured event-type list under
+        notifications/config. If both are empty, no
+        notifications are sent. If the global list
+        contains ALL, all event types are sent unless
+        this receiver-level list restricts them to a
+        subset.";
+    }
+  }
+
+  grouping snmp-receiver-state {
+    description
+      "Operational state data for SNMP receivers.";
+
+    leaf notifications-sent {
+      type yang:counter64;
+      description
+        "Total notifications sent to this receiver.";
+    }
+
+    leaf notifications-dropped {
+      type yang:counter64;
+      description
+        "Total notifications dropped for this
+        receiver.";
+    }
+  }
+
+  grouping snmp-receiver-top {
+    description
+      "Top-level grouping for SNMP notification receivers.";
+
+    container receivers {
+      description
+        "List of configured notification receivers.";
+
+      list receiver {
+        key "name";
+        description
+          "List of SNMP notification receivers.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to receiver name list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for a notification receiver.";
+          uses snmp-receiver-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for a notification receiver.";
+          uses snmp-receiver-config;
+          uses snmp-receiver-state;
+        }
+      }
+    }
+  }
+
+  grouping snmp-notifications-config {
+    description
+      "Configuration data for SNMP notifications.";
+
+    leaf-list event-type {
+      type identityref {
+        base SNMP_NOTIFICATION_EVENT;
+      }
+      description
+        "Globally enabled notification event types.
+        This list provides a default set of events for
+        all receivers. Individual receivers may override
+        this by specifying their own event-type list.
+        If ALL is included, all event types are enabled
+        globally; specific identities should not be
+        combined with ALL.";
+    }
+  }
+
+  grouping snmp-notifications-state {
+    description
+      "Operational state data for SNMP notifications.
+      Reserved for future global notification
+      counters.";
+  }
+
+  grouping snmp-notifications-top {
+    description
+      "Top-level grouping for SNMP notifications.";
+
+    container notifications {
+      description
+        "Configuration and state for SNMP notifications.";
+
+      container config {
+        description
+          "Configuration data for SNMP notifications.";
+        uses snmp-notifications-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for SNMP notifications.";
+        uses snmp-notifications-config;
+        uses snmp-notifications-state;
+      }
+
+      uses snmp-receiver-top;
+    }
+  }
+
+  grouping snmp-top {
+    description
+      "Top-level grouping for SNMP configuration and state.";
+
+    container snmp {
+      description
+        "Configuration and operational state for
+        SNMP community access, notifications, and
+        trap receivers on a network device.";
+
+      container config {
+        description
+          "Configuration data for SNMP.";
+        uses snmp-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for SNMP.";
+        uses snmp-global-config;
+        uses snmp-global-state;
+      }
+
+      uses snmp-community-top;
+      uses snmp-notifications-top;
+    }
+  }
+}

--- a/release/models/system/openconfig-snmp.yang
+++ b/release/models/system/openconfig-snmp.yang
@@ -8,10 +8,6 @@ module openconfig-snmp {
   prefix "oc-snmp";
 
   // import some basic types
-  import ietf-inet-types {
-    prefix inet;
-  }
-
   import ietf-yang-types {
     prefix yang;
   }
@@ -110,6 +106,23 @@ module openconfig-snmp {
       in this module.";
   }
 
+  typedef snmp-notification-type {
+    type enumeration {
+      enum TRAP {
+        description
+          "Unacknowledged notification (SNMPv1 trap or
+          SNMPv2c trap PDU).";
+      }
+      enum INFORM {
+        description
+          "Acknowledged notification (SNMPv2c inform
+          request). Only valid when version is V2C.";
+      }
+    }
+    description
+      "SNMP notification delivery mechanism.";
+  }
+
   grouping snmp-global-config {
     description
       "Configuration data for global SNMP settings.";
@@ -135,9 +148,10 @@ module openconfig-snmp {
       attempts.";
   }
 
-  grouping snmp-community-client-config {
+  grouping snmp-community-manager-config {
     description
-      "Configuration data for allowed SNMP manager prefixes.";
+      "Configuration data for allowed SNMP manager
+      prefixes.";
 
     leaf prefix {
       type oc-inet:ip-prefix;
@@ -146,46 +160,51 @@ module openconfig-snmp {
     }
   }
 
-  grouping snmp-community-client-state {
+  grouping snmp-community-manager-state {
     description
       "Operational state data for community manager
-      prefixes. Reserved for future per-client
+      prefixes. Reserved for future per-manager
       counters.";
   }
 
-  grouping snmp-community-client-top {
+  grouping snmp-community-manager-top {
     description
-      "Top-level grouping for community manager prefixes.";
+      "Top-level grouping for community manager
+      prefixes.";
 
-    container clients {
+    container managers {
       description
-        "List of allowed manager prefixes for a community.";
+        "List of allowed manager prefixes for a
+        community.";
 
-      list client {
+      list manager {
         key "prefix";
         description
-          "List of prefixes allowed to use this community.";
+          "List of SNMP manager prefixes allowed to use
+          this community.";
 
         leaf prefix {
           type leafref {
             path "../config/prefix";
           }
           description
-            "Reference to community client prefix.";
+            "Reference to community manager prefix.";
         }
 
         container config {
           description
-            "Configuration data for a community client.";
-          uses snmp-community-client-config;
+            "Configuration data for a community
+            manager.";
+          uses snmp-community-manager-config;
         }
 
         container state {
           config false;
           description
-            "Operational state data for a community client.";
-          uses snmp-community-client-config;
-          uses snmp-community-client-state;
+            "Operational state data for a community
+            manager.";
+          uses snmp-community-manager-config;
+          uses snmp-community-manager-state;
         }
       }
     }
@@ -221,11 +240,24 @@ module openconfig-snmp {
       }
       description
         "Reference to an ACL restricting which managers
-        may use this community. When set, the clients
-        list is ignored and access is governed solely
-        by this ACL. If omitted, the clients list is
-        consulted; if both are absent, access is
-        unrestricted.";
+        may use this community. Used together with
+        access-list-type to uniquely identify the ACL
+        set. When set, the managers list is ignored and
+        access is governed solely by this ACL. If
+        omitted, the managers list is consulted; if
+        both are absent, access is unrestricted.";
+    }
+
+    leaf access-list-type {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set"
+          + "/oc-acl:config/oc-acl:type";
+      }
+      description
+        "Type of the ACL set referenced by access-list.
+        Required to uniquely identify the ACL set when
+        multiple sets share the same name with different
+        types (e.g., IPv4 and IPv6).";
     }
   }
 
@@ -270,7 +302,7 @@ module openconfig-snmp {
           uses snmp-community-state;
         }
 
-        uses snmp-community-client-top;
+        uses snmp-community-manager-top;
       }
     }
   }
@@ -293,7 +325,6 @@ module openconfig-snmp {
 
     leaf port {
       type oc-inet:port-number;
-      default 162;
       description
         "UDP port used for notifications. If omitted,
         the standard SNMP trap port (162) is used.";
@@ -309,7 +340,18 @@ module openconfig-snmp {
     leaf community {
       type string;
       description
-        "Community string used for v1/v2c notifications.";
+        "Community string used for v1/v2c
+        notifications.";
+    }
+
+    leaf notification-type {
+      type snmp-notification-type;
+      description
+        "Notification delivery mechanism for this
+        receiver. TRAP sends unacknowledged
+        notifications; INFORM sends acknowledged
+        notifications (V2C only). If omitted, TRAP
+        is assumed.";
     }
 
     leaf-list event-type {

--- a/release/models/system/openconfig-snmp.yang
+++ b/release/models/system/openconfig-snmp.yang
@@ -42,18 +42,9 @@ module openconfig-snmp {
     This module is limited to community-based SNMP.
     SNMPv3 is out of scope.";
 
-  oc-ext:openconfig-version "0.3.0";
+  oc-ext:openconfig-version "0.1.0";
 
-  revision "2026-05-04" {
-    description
-      "Remove SNMPv3, fix receiver identity, resolve
-      dual access-restriction paths, document filter
-      precedence, remove unneeded source-address.";
-    reference
-      "0.3.0";
-  }
-
-  revision "2026-04-15" {
+  revision "2026-05-05" {
     description
       "Initial revision.";
     reference

--- a/release/models/system/openconfig-snmp.yang
+++ b/release/models/system/openconfig-snmp.yang
@@ -292,7 +292,8 @@ module openconfig-snmp {
     }
 
     leaf port {
-      type inet:port-number;
+      type oc-inet:port-number;
+      default 162;
       description
         "UDP port used for notifications. If omitted,
         the standard SNMP trap port (162) is used.";

--- a/release/models/system/openconfig-snmp.yang
+++ b/release/models/system/openconfig-snmp.yang
@@ -210,6 +210,98 @@ module openconfig-snmp {
     }
   }
 
+  grouping snmp-community-acl-config {
+    description
+      "Configuration data for SNMP community ACL
+      bindings.";
+
+    leaf name {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets"
+          + "/oc-acl:acl-set/oc-acl:config/oc-acl:name";
+      }
+      description
+        "Name of the ACL set applied to this SNMP
+        community.";
+    }
+
+    leaf type {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set"
+          + "[oc-acl:name=current()/../name]"
+          + "/oc-acl:config/oc-acl:type";
+      }
+      description
+        "Type of the ACL set referenced by name. The
+        pair (name, type) uniquely identifies an ACL
+        set.";
+    }
+  }
+
+  grouping snmp-community-acl-state {
+    description
+      "Operational state data for SNMP community ACL
+      bindings. Reserved for future per-binding
+      counters.";
+  }
+
+  grouping snmp-community-acl-top {
+    description
+      "Top-level grouping for SNMP community ACL
+      bindings.";
+
+    container access-lists {
+      description
+        "List of ACL bindings for this SNMP community.
+        Multiple tuples may be configured (for example,
+        IPv4 ACL, IPv6 ACL, or both). When any ACL
+        bindings are present, the managers list is
+        ignored and access is governed by these ACL
+        tuples. If no ACL bindings are present, the
+        managers list is consulted; if both are absent,
+        access is unrestricted.";
+
+      list access-list {
+        key "name type";
+        description
+          "List of ACL tuples applied to this SNMP
+          community.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the ACL name list key.";
+        }
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "Reference to the ACL type list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for an ACL tuple
+            applied to this SNMP community.";
+          uses snmp-community-acl-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for an ACL tuple
+            applied to this SNMP community.";
+          uses snmp-community-acl-config;
+          uses snmp-community-acl-state;
+        }
+      }
+    }
+  }
+
   grouping snmp-community-config {
     description
       "Configuration data for SNMP communities.";
@@ -223,41 +315,18 @@ module openconfig-snmp {
     leaf access-mode {
       type snmp-access-mode;
       description
-        "Access mode for this community.";
+        "Access mode for this community. If omitted,
+        the implementation-defined access mode is
+        used.";
     }
 
     leaf version {
       type snmp-version;
       description
         "SNMP version associated with this community.
-        Only V1 and V2C are supported by this module.";
-    }
-
-    leaf access-list {
-      type leafref {
-        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set"
-          + "/oc-acl:config/oc-acl:name";
-      }
-      description
-        "Reference to an ACL restricting which managers
-        may use this community. Used together with
-        access-list-type to uniquely identify the ACL
-        set. When set, the managers list is ignored and
-        access is governed solely by this ACL. If
-        omitted, the managers list is consulted; if
-        both are absent, access is unrestricted.";
-    }
-
-    leaf access-list-type {
-      type leafref {
-        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set"
-          + "/oc-acl:config/oc-acl:type";
-      }
-      description
-        "Type of the ACL set referenced by access-list.
-        Required to uniquely identify the ACL set when
-        multiple sets share the same name with different
-        types (e.g., IPv4 and IPv6).";
+        Only V1 and V2C are supported by this module.
+        If omitted, the implementation-defined
+        community version is used.";
     }
   }
 
@@ -303,6 +372,7 @@ module openconfig-snmp {
         }
 
         uses snmp-community-manager-top;
+        uses snmp-community-acl-top;
       }
     }
   }
@@ -320,7 +390,9 @@ module openconfig-snmp {
     leaf address {
       type oc-inet:ip-address;
       description
-        "Receiver address for notifications.";
+        "Receiver address for notifications. If
+        omitted, no notification destination is
+        configured for this receiver.";
     }
 
     leaf port {
@@ -334,14 +406,17 @@ module openconfig-snmp {
       type snmp-version;
       description
         "SNMP version used for this receiver. Only V1
-        and V2C are supported by this module.";
+        and V2C are supported by this module. If
+        omitted, the implementation-defined receiver
+        version is used.";
     }
 
     leaf community {
       type string;
       description
         "Community string used for v1/v2c
-        notifications.";
+        notifications. If omitted, no v1/v2c
+        notifications are sent for this receiver.";
     }
 
     leaf notification-type {
@@ -363,10 +438,13 @@ module openconfig-snmp {
         If empty, the receiver inherits the globally
         configured event-type list under
         notifications/config. If both are empty, no
-        notifications are sent. If the global list
-        contains ALL, all event types are sent unless
-        this receiver-level list restricts them to a
-        subset.";
+        notifications are sent. If this receiver-level
+        list contains ALL, all event types are enabled
+        for the receiver; any additional identities are
+        redundant and have no additional effect. If the
+        global list contains ALL, all event types are
+        sent unless this receiver-level list restricts
+        them to a subset.";
     }
   }
 
@@ -440,8 +518,8 @@ module openconfig-snmp {
         all receivers. Individual receivers may override
         this by specifying their own event-type list.
         If ALL is included, all event types are enabled
-        globally; specific identities should not be
-        combined with ALL.";
+        globally; any additional identities are
+        redundant and have no additional effect.";
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -1391,6 +1391,7 @@ module openconfig-system {
       uses system-macaddr-top;
       uses system-memory-top;
       uses system-ntp-top;
+      uses oc-snmp:snmp-top;
     }
   }
 

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -13,6 +13,7 @@ module openconfig-system {
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-aaa { prefix oc-aaa; }
+  import openconfig-snmp { prefix oc-snmp; }
   import openconfig-system-logging { prefix oc-log; }
   import openconfig-system-terminal { prefix oc-sys-term; }
   import openconfig-procmon { prefix oc-proc; }

--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -49,7 +49,15 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.1.0";
+  oc-ext:openconfig-version "3.2.0";
+
+  revision "2026-06-02" {
+    description
+      "Add SNMP community, notification, and receiver
+      configuration via openconfig-snmp.";
+    reference "3.2.0";
+  }
+
 
   revision "2026-03-31" {
     description


### PR DESCRIPTION
### Change Scope

This PR adds a new YANG module `openconfig-snmp` under `release/models/system/`
for managing SNMP services on network devices. The model covers community-based
SNMPv1/v2c configuration including:

- Global SNMP settings (contact, location)
- Community definitions with access modes (read-only, read-write)
- Client prefix restrictions per community
- Trap/notification receivers
- Notification event filtering (authentication, line-status, etc.)

SNMPv3 is explicitly out of scope for this module.

The module is imported by `openconfig-system.yang` under the system hierarchy.

### Platform Implementations

 * Implementation A: [SNMPv1/v2c Configuration](https://arista.my.site.com/AristaCommunity/s/article/snmpv1-v2c-configuration)
 * Implementation C: [SNMP Configuration Guide, Cisco IOS XE 17](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/snmp/configuration/xe-17-x/snmp-xe-17-book/nm-snmp-cfg-snmp-support.html)


### Tree View

```
module: openconfig-system
  +--rw system
     ...
     +--rw snmp
        +--rw config
        |  +--rw contact?    string
        |  +--rw location?   string
        +--ro state
        |  +--ro contact?    string
        |  +--ro location?   string
        +--rw communities
        |  +--rw community* [name]
        |     +--rw name            -> ../config/name
        |     +--rw config
        |     |  +--rw name?          string
        |     |  +--rw access-mode?   snmp-access-mode
        |     |  +--rw version?       snmp-version
        |     +--ro state
        |     |  +--ro name?          string
        |     |  +--ro access-mode?   snmp-access-mode
        |     |  +--ro version?       snmp-version
        |     +--rw managers
        |     |  +--rw manager* [prefix]
        |     |     +--rw prefix    -> ../config/prefix
        |     |     +--rw config
        |     |     |  +--rw prefix?   oc-inet:ip-prefix
        |     |     +--ro state
        |     |        +--ro prefix?   oc-inet:ip-prefix
        |     +--rw access-lists
        |        +--rw access-list* [name type]
        |           +--rw name      -> ../config/name
        |           +--rw type      -> ../config/type
        |           +--rw config
        |           |  +--rw name?   -> /oc-acl:acl/acl-sets/acl-set/config/name
        |           |  +--rw type?   -> /oc-acl:acl/acl-sets/acl-set[oc-acl:name=current()/../name]/config/type
        |           +--ro state
        |              +--ro name?   -> /oc-acl:acl/acl-sets/acl-set/config/name
        |              +--ro type?   -> /oc-acl:acl/acl-sets/acl-set[oc-acl:name=current()/../name]/config/type
        +--rw notifications
           +--rw config
           |  +--rw event-type*   identityref
           +--ro state
           |  +--ro event-type*   identityref
           +--rw receivers
              +--rw receiver* [name]
                 +--rw name      -> ../config/name
                 +--rw config
                 |  +--rw name?                string
                 |  +--rw address?             oc-inet:ip-address
                 |  +--rw port?                oc-inet:port-number
                 |  +--rw version?             snmp-version
                 |  +--rw community?           string
                 |  +--rw notification-type?   snmp-notification-type
                 |  +--rw event-type*          identityref
                 +--ro state
                    +--ro name?                    string
                    +--ro address?                 oc-inet:ip-address
                    +--ro port?                    oc-inet:port-number
                    +--ro version?                 snmp-version
                    +--ro community?               string
                    +--ro notification-type?       snmp-notification-type
                    +--ro event-type*              identityref
                    +--ro notifications-sent?      yang:counter64
                    +--ro notifications-dropped?   yang:counter64
```


