### PR TITLE
Introduce non-AFI-SAFI aggregate prefix limit at global, neighbor, and peer-group levels

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,15 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2025-05-07" {
+    description
+      "Rename bgp-common-mp-all-afi-safi-common-prefix-limit-config to
+      bgp-common-prefix-limit-config to reflect its use beyond the
+      AFI-SAFI context.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -539,7 +547,7 @@ submodule openconfig-bgp-common-multiprotocol {
         description
           "Configuration parameters relating to the prefix
           limit for the AFI-SAFI";
-        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-prefix-limit-config;
       }
 
       container state {
@@ -547,7 +555,7 @@ submodule openconfig-bgp-common-multiprotocol {
         description
           "State information relating to the prefix-limit for the
           AFI-SAFI";
-        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-prefix-limit-config;
         uses bgp-common-mp-all-afi-safi-common-prefix-limit-state;
       }
     }
@@ -561,7 +569,7 @@ submodule openconfig-bgp-common-multiprotocol {
         description
           "Configuration parameters relating to the prefix
           limit for the AFI-SAFI";
-        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-prefix-limit-config;
       }
 
       container state {
@@ -569,7 +577,7 @@ submodule openconfig-bgp-common-multiprotocol {
         description
           "State information relating to the prefix-limit for the
           AFI-SAFI";
-        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-prefix-limit-config;
         uses bgp-common-mp-all-afi-safi-common-prefix-limit-state;
       }
     }
@@ -696,10 +704,10 @@ submodule openconfig-bgp-common-multiprotocol {
   }
 
   // Config groupings for common groups
-  grouping bgp-common-mp-all-afi-safi-common-prefix-limit-config {
+  grouping bgp-common-prefix-limit-config {
     description
-      "Configuration parameters relating to prefix-limits for an
-      AFI-SAFI";
+      "Configuration parameters relating to prefix-limits for a BGP
+      neighbor, peer-group, or global instance.";
 
     leaf max-prefixes {
       type uint32;

--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -26,7 +26,7 @@ submodule openconfig-bgp-common-multiprotocol {
 
   oc-ext:openconfig-version "9.10.0";
 
-  revision "2025-05-07" {
+  revision "2025-05-08" {
     description
       "Rename bgp-common-mp-all-afi-safi-common-prefix-limit-config to
       bgp-common-prefix-limit-config to reflect its use beyond the
@@ -713,7 +713,7 @@ submodule openconfig-bgp-common-multiprotocol {
       type uint32;
       description
         "Maximum number of prefixes that will be accepted
-        from the neighbor";
+        or received from the neighbor";
     }
 
     leaf prevent-teardown {
@@ -730,10 +730,10 @@ submodule openconfig-bgp-common-multiprotocol {
     leaf warning-threshold-pct {
       type oc-types:percentage;
       description
-        "Threshold on number of prefixes that can be received
-        from a neighbor before generation of warning messages
-        or log entries. Expressed as a percentage of
-        max-prefixes";
+        "Threshold on number of prefixes that can be accepted
+        or received from a neighbor before generation of
+        warning messages or log entries. Expressed as a
+        percentage of max-prefixes";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,14 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2025-05-07" {
+    description
+      "Add structural groupings for non-AFI-SAFI prefix-limit at neighbor,
+      peer-group, and global levels.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -396,6 +403,31 @@ submodule openconfig-bgp-common-structure {
         "Parameters related to automatic generation link-bandwidth
         extended community base on underlaying interface speed.";
       uses bgp-common-structure-neighbor-group-auto-gen-link-bandwidth;
+    }
+  }
+
+  grouping bgp-common-structure-prefix-limit {
+    description
+      "Structural grouping for a non-AFI-SAFI prefix-limit applicable at
+      the neighbor, peer-group, or global BGP level.";
+
+    container prefix-limit {
+      description
+        "Configure the maximum number of prefixes that will be received
+        across all address families.";
+
+      container config {
+        description
+          "Configuration parameters relating to the prefix-limit.";
+        uses bgp-common-prefix-limit-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information relating to the prefix-limit.";
+        uses bgp-common-prefix-limit-config;
+      }
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -23,10 +23,10 @@ submodule openconfig-bgp-common-structure {
 
   oc-ext:openconfig-version "9.10.0";
 
-  revision "2025-05-07" {
+  revision "2025-05-08" {
     description
-      "Add structural groupings for non-AFI-SAFI prefix-limit at neighbor,
-      peer-group, and global levels.";
+      "Add structural groupings for non-AFI-SAFI prefix-limit and
+      prefix-limit-received at neighbor, peer-group, and global levels.";
     reference "9.10.0";
   }
 
@@ -413,7 +413,7 @@ submodule openconfig-bgp-common-structure {
 
     container prefix-limit {
       description
-        "Configure the maximum number of prefixes that will be received
+        "Configure the maximum number of prefixes that will be accepted
         across all address families.";
 
       container config {
@@ -426,6 +426,25 @@ submodule openconfig-bgp-common-structure {
         config false;
         description
           "State information relating to the prefix-limit.";
+        uses bgp-common-prefix-limit-config;
+      }
+    }
+
+    container prefix-limit-received {
+      description
+        "Configure the maximum number of prefixes that will be received
+        across all address families.";
+
+      container config {
+        description
+          "Configuration parameters relating to the prefix-limit-received.";
+        uses bgp-common-prefix-limit-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information relating to the prefix-limit-received.";
         uses bgp-common-prefix-limit-config;
       }
     }

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2025-05-07" {
+    description
+      "Add global default prefix-limit at BGP global level.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -522,6 +528,7 @@ submodule openconfig-bgp-global {
       }
     }
 
+    uses bgp-common-structure-prefix-limit;
     uses bgp-common-global-group-use-multiple-paths;
     uses bgp-common-route-selection-options;
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -29,9 +29,9 @@ submodule openconfig-bgp-global {
 
   oc-ext:openconfig-version "9.10.0";
 
-  revision "2025-05-07" {
+  revision "2025-05-08" {
     description
-      "Add global default prefix-limit at BGP global level.";
+      "Add global default prefix-limit and prefix-limit-received at BGP global level.";
     reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2025-05-07" {
+    description
+      "Add non-AFI-SAFI prefix-limit at neighbor level.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -868,6 +874,7 @@ submodule openconfig-bgp-neighbor {
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
     uses bgp-common-structure-neighbor-group-auto-link-bandwidth;
+    uses bgp-common-structure-prefix-limit;
     uses bgp-neighbor-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -32,9 +32,9 @@ submodule openconfig-bgp-neighbor {
 
   oc-ext:openconfig-version "9.10.0";
 
-  revision "2025-05-07" {
+  revision "2025-05-08" {
     description
-      "Add non-AFI-SAFI prefix-limit at neighbor level.";
+      "Add non-AFI-SAFI prefix-limit and prefix-limit-received at neighbor level.";
     reference "9.10.0";
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2025-05-07" {
+    description
+      "Add non-AFI-SAFI prefix-limit at peer-group level.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -376,6 +382,7 @@ submodule openconfig-bgp-peer-group {
     uses bgp-common-structure-neighbor-group-route-reflector;
     uses bgp-common-structure-neighbor-group-as-path-options;
     uses bgp-common-structure-neighbor-group-auto-link-bandwidth;
+    uses bgp-common-structure-prefix-limit;
     uses bgp-common-global-group-use-multiple-paths;
     uses oc-rpol:apply-policy-group;
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -27,9 +27,9 @@ submodule openconfig-bgp-peer-group {
 
   oc-ext:openconfig-version "9.10.0";
 
-  revision "2025-05-07" {
+  revision "2025-05-08" {
     description
-      "Add non-AFI-SAFI prefix-limit at peer-group level.";
+      "Add non-AFI-SAFI prefix-limit and prefix-limit-received at peer-group level.";
     reference "9.10.0";
   }
 


### PR DESCRIPTION
**Files changed:**

- (M) release/models/bgp/openconfig-bgp-common-multiprotocol.yang
- (M) release/models/bgp/openconfig-bgp-common-structure.yang
- (M) release/models/bgp/openconfig-bgp-global.yang
- (M) release/models/bgp/openconfig-bgp-neighbor.yang
- (M) release/models/bgp/openconfig-bgp-peer-group.yang


**Change Scope:**

This change introduces a non-AFI-SAFI aggregate prefix-limit for accepted routes and prefix-limit-received for received routes at the BGP global, neighbor, and peer-group levels, and renames one internal grouping to reflect its broadened scope.

1. Grouping rename (`openconfig-bgp-common-multiprotocol.yang`):

- bgp-common-mp-all-afi-safi-common-prefix-limit-config → bgp-common-prefix-limit-config

The original name implied this grouping was scoped exclusively to AFI-SAFI contexts. Since it is now reused outside that context, the name has been shortened accordingly. bgp-common-mp-all-afi-safi-common-prefix-limit-state is unchanged as it remains AFI-SAFI specific. All existing uses statements within the AFI-SAFI prefix-limit containers are updated accordingly. There is no functional change to the existing per-AFI-SAFI prefix-limit behaviour.

2. New structural grouping (`openconfig-bgp-common-structure.yang)`:

A new grouping bgp-common-structure-prefix-limit is added, following the existing OpenConfig config/state container pattern. It is applied at the global, neighbor, and peer-group levels via openconfig-bgp-global.yang, openconfig-bgp-neighbor.yang, and openconfig-bgp-peer-group.yang respectively.

This allows operators to set a single aggregate prefix-limit across all address families for a session, complementing the existing per-AFI-SAFI prefix-limit. Note that prefix-limit-exceeded is intentionally not included in the state container at these levels, as exceeded-state tracking is only modelled at the AFI-SAFI granularity.

Relevant pyang tree output:

```
module: openconfig-bgp
    +--rw bgp
       +--rw global
       |  +--rw prefix-limit-received
       |     +--rw config
       |     |  +--rw max-prefixes?            uint32
       |     |  +--rw prevent-teardown?        boolean
       |     |  +--rw warning-threshold-pct?   oc-types:percentage
       |     +--ro state
       |        +--ro max-prefixes?            uint32
       |        +--ro prevent-teardown?        boolean
       |        +--ro warning-threshold-pct?   oc-types:percentage
       +--rw neighbors
       |  +--rw neighbor* [neighbor-address]
       |     +--rw prefix-limit
       |        +--rw config
       |        |  +--rw max-prefixes?            uint32
       |        |  +--rw prevent-teardown?        boolean
       |        |  +--rw warning-threshold-pct?   oc-types:percentage
       |        +--ro state
       |           +--ro max-prefixes?            uint32
       |           +--ro prevent-teardown?        boolean
       |           +--ro warning-threshold-pct?   oc-types:percentage
       +--rw peer-groups
          +--rw peer-group* [peer-group-name]
             +--rw prefix-limit
                +--rw config
                |  +--rw max-prefixes?            uint32
                |  +--rw prevent-teardown?        boolean
                |  +--rw warning-threshold-pct?   oc-types:percentage
                +--ro state
                   +--ro max-prefixes?            uint32
                   +--ro prevent-teardown?        boolean
                   +--ro warning-threshold-pct?   oc-types:percentage
```


**Platform Implementations**

[Arista EOS User Guide](https://www.arista.com/en/um-eos/eos-border-gateway-protocol-bgp) implements BGP prefix-limit-received using the `neighbor maximum-routes command`, which enforces a per-session prefix threshold and may terminate the BGP session upon exceedance.