### PR TITLE
Specify unit as Mbps for IS-IS reference-bandwidth

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.7.1";
+
+  revision "2026-05-13" {
+    description
+      "Specify the unit as Mbps for reference-bandwidth.";
+    reference "1.7.1";
+  }
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.7.1";
+
+  revision "2026-05-13" {
+    description
+      "Specify the unit as Mbps for reference-bandwidth.";
+    reference "1.7.1";
+  }
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.7.1";
+
+  revision "2026-05-13" {
+    description
+      "Specify the unit as Mbps for reference-bandwidth.";
+    reference "1.7.1";
+  }
 
   revision "2024-02-28" {
     description
@@ -543,8 +549,10 @@ module openconfig-isis {
 
     leaf reference-bandwidth {
       type uint32;
+      units "Mbps";
       description
-        "ISIS Reference Bandwidth value";
+        "ISIS Reference Bandwidth value expressed in megabits per
+        second.";
     }
   }
 


### PR DESCRIPTION
  * (M) release/models/isis/openconfig-isis-lsp.yang
  * (M) release/models/isis/openconfig-isis-routing.yang
  * (M) release/models/isis/openconfig-isis.yang
    - Add unit to reference-bandwidth
    - Increment to version 1.8.1

### Change Scope

Specify unit as Mbps for IS-IS reference-bandwidth.  Current definition can lead
to implementation divergence.

### Platform Implementations

_NOTE: Based off current public model publishes only_

Arista:
- Not supported feature, deviated in OC not supported
- No native leaf

Refs:
- https://github.com/aristanetworks/yang/blob/master/EOS-4.36.0F/release/openconfig/models/isis/arista-isis-deviations.yang#L259-L263

Cisco IOS-XR:
- OC leafs not supported
- Native leafs are uint64 but kbps

Refs:
- https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/2611/Cisco-IOS-XR-um-router-isis-cfg.yang#L3865-L3871
- https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/2611/cisco-xr-openconfig-network-instance-deviations.yang#L3533-L3539

Nokia SROS:
- OC leafs deviated to scope reduced range of uint32
- Native leafs are uint64 but bps

Refs:
- https://github.com/nokia/7x50_YangModels/blob/master/latest_sros_26.3/nokia-types-sros.yang#L1477-L1499
- https://github.com/nokia/7x50_YangModels/blob/master/latest_sros_26.3/openconfig/nokia-sr-openconfig-isis-deviations.yang#L90-L104

Nokia SRLinux:
- OC leafs deviated to scope reduced range of uint32 (assumes Mbps)
- Native leafs are uint64 but kbps

Refs:
- https://github.com/nokia/srlinux-yang-models/blob/v26.3/srlinux-yang-models/srl_nokia/models/network-instance/srl_nokia-isis.yang#L1460-L1477
- https://github.com/nokia/srlinux-yang-models/blob/v26.3/srlinux-yang-models/openconfig/openconfig-srl-deviations.yang#L1116-L1130

### Tree View

No tree updates were made as part of this patchset.
