### PR TITLE
Add MIDPLANE hardware component identity

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -451,7 +451,7 @@ revision "2025-07-09" {
   identity MIDPLANE {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
-      "Midplaneis a central, passive, or active circuit board assembly situated
+      "Midplane is a central, passive, or active circuit board assembly situated
       in the middle of a chassis. It serves as an interconnect, enabling data
       transfer between front-facing and rear-facing components and may also
       distribute power.";

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.11.0";
+  oc-ext:openconfig-version "1.12.0";
+
+revision "2025-09-03" {
+    description
+      "Add MIDPLANE";
+    reference "1.12.0";
+  }
 
 revision "2025-09-03" {
     description
@@ -440,6 +446,15 @@ revision "2025-07-09" {
       "Field-Programmable Gate Array (FPGA) is a type of integrated circuit
       that can be configured after manufacturing. This type should not be
       used to represent a switching ASIC";
+  }
+
+  identity MIDPLANE {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "Midplaneis a central, passive, or active circuit board assembly situated
+      in the middle of a chassis. It serves as an interconnect, enabling data
+      transfer between front-facing and rear-facing components and may also
+      distribute power.";
   }
 
   identity OPERATING_SYSTEM {

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -24,7 +24,7 @@ module openconfig-platform-types {
 
   oc-ext:openconfig-version "1.12.0";
 
-revision "2025-09-03" {
+revision "2026-05-19" {
     description
       "Add MIDPLANE";
     reference "1.12.0";


### PR DESCRIPTION
### Change Scope

* Add a `MIDPLANE` identity to the `OPENCONFIG_HARDWARE_COMPONENT` base identity.
* This change is backwards compatible.

### Platform Implementations

* [Nokia 7750 SR-e Service Router](https://www.nokia.com/asset/189831).
>Its modular, mid-plane design offers MACsec line rate encryption, control plane, fan and power redundancy along with a NEBS-compliant front-to-back thermal design.

* [Nokia 7950 Extensible Routing System](https://www.nokia.com/asset/174425/).
> The XCMs contain a slot-level control plane subsystem and fabric interface to interconnect to the SFMs via the chassis mid-plane.

* [Cisco Nexus 7000 series](https://www.cisco.com/c/en/us/products/collateral/switches/nexus-7000-series-switches/Data_Sheet_C78-437762.html)

* [Juniper MX960 midplane](https://www.juniper.net/documentation/us/en/hardware/mx960/topics/concept/midplane-mx960-description.html)


