### PR TITLE
Add `hierarchical-fec` bool leaf to static nexthop-group

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -22,7 +22,13 @@ module openconfig-network-instance-static {
   description
     "Static configurations associated with a network instance";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2026-05-20" {
+    description
+      "Add hierarchical-fec leaf to static next-hop-group.";
+    reference "0.3.0";
+  }
 
   revision "2025-08-05" {
     description
@@ -148,6 +154,18 @@ module openconfig-network-instance-static {
       type string;
       description
         "A user defined name that uniquely identifies the next-hop-group.";
+    }
+
+    leaf hierarchical-fec {
+      type boolean;
+      description
+        "When set to true, the next-hop-group preserves its hierarchical
+        structure, with each next-hop entry explicitly pointing to the
+        resolving next-hop-group. This enables load-balancing of traffic
+        forwarded through each next-hop-group entry based on the
+        bandwidth of the resolving links. When set to false, the
+        next-hop-group contents are flattened, or a single next-hop is
+        selected from each referenced group.";
     }
   }
 


### PR DESCRIPTION
**Change Scope**
- Add `hierarchical-fec` bool leaf to Static nexthop-group to control hierarchical forwarding equivalence class (FEC) behavior on next-hop groups:
`/network-instances/network-instance/static/next-hop-groups/next-hop-group/config/hierarchical-fec`
`/network-instances/network-instance/static/next-hop-groups/next-hop-group/state/hierarchical-fec`
When True: The nexthop-group  preserves its hierarchical structure, explicitly pointing to the resolving NHG for each next-hop.
When False: The nexthop-group contents are flattened, or a single random next-hop is selected.
- This change is backwards compatible

**Context:** 
[Add hierarchical-fec bool leaf to Static NHG](https://github.com/openconfig/public/issues/1405)

**Tree View**
```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
           +--rw static
           |  +--rw next-hop-groups
           |  |  +--rw next-hop-group* [name]
           |  |     +--rw name         -> ../config/name
           |  |     +--rw config
           |  |     |  +--rw name?   string
  +        |  |     |  +--rw hierarchical-fec?   boolean
           |  |     +--ro state
           |  |     |  +--ro name?   string
  +        |  |     |  +--ro hierarchical-fec?   boolean
           |  |     +--rw next-hops
           |  |        +--rw next-hop* [index]
           |  |           +--rw index     -> ../config/index
           |  |           +--rw config
           |  |           |  +--rw index?   -> ../../../../../../next-hops/next-hop/index
           |  |           +--ro state
           |  |              +--ro index?   -> ../../../../../../next-hops/next-hop/index
```