### PR TITLE
Adding list leaf for SSH public keys

### DIFF
--- a/release/models/system/openconfig-aaa-radius.yang
+++ b/release/models/system/openconfig-aaa-radius.yang
@@ -26,7 +26,7 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision 2025-10-31 {
     description

--- a/release/models/system/openconfig-aaa-tacacs.yang
+++ b/release/models/system/openconfig-aaa-tacacs.yang
@@ -25,7 +25,7 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
 
   revision 2025-10-31 {
     description

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -400,6 +400,25 @@ module openconfig-aaa {
       description
         "SSH public key for the user (RSA or DSA)";
     }
+    
+    list authorized-ssh-keys {
+      key "key-name";
+      max-elements 10;
+      description
+        "Authorized SSH public keys for the user";
+        
+      leaf key-name {
+        type string;
+        description
+          "The name with which to reference the authorized SSH public key";
+      }
+      
+      leaf authorized-ssh-key {
+        type string;
+        description
+          "Authorized SSH public key for the user";
+      }
+    }
 
     leaf role {
       type union {

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -434,7 +434,7 @@ module openconfig-aaa {
      leaf authorized-ssh-key {
        type string;
        description
-         "Authorized SSH public key for the user";
+         "Authorized SSH public key for the user (RSA or ECDSA)";
      }
   }
 
@@ -483,7 +483,7 @@ module openconfig-aaa {
 		  list authorized-ssh-key {
 			key "key-name";
 			description
-			  "Authorized SSH public keys for the user";
+			  "Authorized SSH public keys for the user (RSA or ECDSA)";
 
 			leaf key-name {
 			  type leafref {

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -397,6 +397,7 @@ module openconfig-aaa {
 
     leaf ssh-key {
       type string;
+      status deprecated;
       description
         "SSH public key for the user (RSA or DSA)";
     }
@@ -425,7 +426,7 @@ module openconfig-aaa {
     description
       "Configuration data for user SSH keys";
     
-     leaf key-name {
+     leaf name {
        type string;
        description
          "The name with which to reference the authorized SSH public key";
@@ -434,7 +435,7 @@ module openconfig-aaa {
      leaf authorized-ssh-key {
        type string;
        description
-         "Authorized SSH public key for the user (RSA or ECDSA)";
+         "Authorized SSH public key for the user";
      }
   }
 
@@ -481,11 +482,11 @@ module openconfig-aaa {
 			"Top-level container for authorized SSH keys";
 		
 		  list authorized-ssh-key {
-			key "key-name";
+			key "name";
 			description
 			  "Authorized SSH public keys for the user (RSA or ECDSA)";
 
-			leaf key-name {
+			leaf name {
 			  type leafref {
 				path "../config/key-name";
 			  }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -400,25 +400,6 @@ module openconfig-aaa {
       description
         "SSH public key for the user (RSA or DSA)";
     }
-    
-    list authorized-ssh-keys {
-      key "key-name";
-      max-elements 10;
-      description
-        "Authorized SSH public keys for the user";
-        
-      leaf key-name {
-        type string;
-        description
-          "The name with which to reference the authorized SSH public key";
-      }
-      
-      leaf authorized-ssh-key {
-        type string;
-        description
-          "Authorized SSH public key for the user";
-      }
-    }
 
     leaf role {
       type union {
@@ -438,6 +419,23 @@ module openconfig-aaa {
   grouping aaa-authentication-user-state {
     description
       "Operational state data for local users";
+  }
+  
+  grouping authorized-ssh-key-config {
+    description
+      "Configuration data for user SSH keys";
+    
+     leaf key-name {
+       type string;
+       description
+         "The name with which to reference the authorized SSH public key";
+     }
+    
+     leaf authorized-ssh-key {
+       type string;
+       description
+         "Authorized SSH public key for the user";
+     }
   }
 
   grouping aaa-authentication-user-top {
@@ -477,6 +475,38 @@ module openconfig-aaa {
           uses aaa-authentication-user-config;
           uses aaa-authentication-user-state;
         }
+        
+        container authorized-ssh-keys {
+		  description
+			"Top-level container for authorized SSH keys";
+		
+		  list authorized-ssh-key {
+			key "key-name";
+			description
+			  "Authorized SSH public keys for the user";
+
+			leaf key-name {
+			  type leafref {
+				path "../config/key-name";
+			  }
+			  description
+				"References the key name in the configuration block";
+			}
+		
+			container config {
+			  description
+				"Configuration data for the authorized SSH key";
+			  uses authorized-ssh-key-config;
+			}
+		
+			container state {
+			  config false;
+			  description
+				"Operational state data for the authorized SSH key";
+			  uses authorized-ssh-key-config;
+			}
+		  }
+		}
       }
 
     }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -39,7 +39,7 @@ module openconfig-aaa {
          "Deprecating ssh-key leaf in favour of public-keys list.";
       reference "1.2.0";
   }
-  
+
   revision 2025-10-31 {
       description
           "Added GLOME path.";
@@ -405,7 +405,7 @@ module openconfig-aaa {
       type string;
       status deprecated;
       description
-        "SSH public key for the user. Deprecated in favour of the 
+        "SSH public key for the user. Deprecated in favour of the
         public-keys list, which supports mutiple keys per user.";
     }
 
@@ -446,7 +446,7 @@ module openconfig-aaa {
          entry of an OpenSSH authorized_keys file:
 
            [options] <algorithm> <base64-key> [comment]
-           
+
          Encoding the full entry as one string preserves any key options
          and algorithm names not known to the system.";
 
@@ -454,7 +454,7 @@ module openconfig-aaa {
           "OpenSSH sshd(8), AUTHORIZED_KEYS FILE FORMAT";
      }
   }
-  
+
   grouping public-keys {
     description
       "SSH keys";

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -32,8 +32,14 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "1.1.0";
+  oc-ext:openconfig-version "1.2.0";
 
+  revision 2026-08-07 {
+      description
+         "Deprecating ssh-key leaf in favour of public-keys list.";
+      reference "1.2.0";
+  }
+  
   revision 2025-10-31 {
       description
           "Added GLOME path.";
@@ -399,7 +405,8 @@ module openconfig-aaa {
       type string;
       status deprecated;
       description
-        "SSH public key for the user (RSA or DSA)";
+        "SSH public key for the user. Deprecated in favour of the 
+        public-keys list, which supports mutiple keys per user.";
     }
 
     leaf role {
@@ -421,22 +428,63 @@ module openconfig-aaa {
     description
       "Operational state data for local users";
   }
-  
-  grouping authorized-ssh-key-config {
+
+  grouping public-key-config {
     description
       "Configuration data for user SSH keys";
-    
+
      leaf name {
        type string;
        description
          "The name with which to reference the authorized SSH public key";
      }
-    
-     leaf authorized-ssh-key {
+
+     leaf public-key {
        type string;
        description
-         "Authorized SSH public key for the user";
+         "An authorized SSH public key for the user, formatted as a single
+         entry of an OpenSSH authorized_keys file:
+
+           [options] <algorithm> <base64-key> [comment]
+           
+         Encoding the full entry as one string preserves any key options
+         and algorithm names not known to the system.";
+
+       reference
+          "OpenSSH sshd(8), AUTHORIZED_KEYS FILE FORMAT";
      }
+  }
+  
+  grouping public-keys {
+    description
+      "SSH keys";
+
+    list public-key {
+      key "name";
+      description
+        "Authorized SSH public keys for the user.";
+
+      leaf name {
+        type leafref {
+          path "../config/name";
+        }
+        description
+          "References the key name in the configuration block";
+      }
+
+      container config {
+        description
+          "Configuration data for the authorized SSH key";
+        uses public-key-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for the authorized SSH key";
+        uses public-key-config;
+      }
+    }
   }
 
   grouping aaa-authentication-user-top {
@@ -476,38 +524,8 @@ module openconfig-aaa {
           uses aaa-authentication-user-config;
           uses aaa-authentication-user-state;
         }
-        
-        container authorized-ssh-keys {
-		  description
-			"Top-level container for authorized SSH keys";
-		
-		  list authorized-ssh-key {
-			key "name";
-			description
-			  "Authorized SSH public keys for the user (RSA or ECDSA)";
 
-			leaf name {
-			  type leafref {
-				path "../config/key-name";
-			  }
-			  description
-				"References the key name in the configuration block";
-			}
-		
-			container config {
-			  description
-				"Configuration data for the authorized SSH key";
-			  uses authorized-ssh-key-config;
-			}
-		
-			container state {
-			  config false;
-			  description
-				"Operational state data for the authorized SSH key";
-			  uses authorized-ssh-key-config;
-			}
-		  }
-		}
+        uses public-keys;
       }
 
     }

--- a/release/models/system/openconfig-aaa.yang
+++ b/release/models/system/openconfig-aaa.yang
@@ -459,30 +459,35 @@ module openconfig-aaa {
     description
       "SSH keys";
 
-    list public-key {
-      key "name";
+    container public-keys {
       description
-        "Authorized SSH public keys for the user.";
+        "Enclosing container for authorized SSH public keys.";
 
-      leaf name {
-        type leafref {
-          path "../config/name";
+      list public-key {
+        key "name";
+        description
+          "Authorized SSH public keys for the user.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "References the key name in the configuration block";
         }
-        description
-          "References the key name in the configuration block";
-      }
 
-      container config {
-        description
-          "Configuration data for the authorized SSH key";
-        uses public-key-config;
-      }
+        container config {
+          description
+            "Configuration data for the authorized SSH key";
+          uses public-key-config;
+        }
 
-      container state {
-        config false;
-        description
-          "Operational state data for the authorized SSH key";
-        uses public-key-config;
+        container state {
+          config false;
+          description
+            "Operational state data for the authorized SSH key";
+          uses public-key-config;
+        }
       }
     }
   }


### PR DESCRIPTION
### Change Scope

* Adding a leaf list for user ssh keys to add the ability to add more than one SSH key per user.
* This change is backwards compatible. We are proposing a new list leaf rather than changing the existing single leaf for ssh-key as to not break backwards compatibility. 

### Platform Implementations

 * Implementation A: gNSI model requires support for multiple ssh keys per user: 
    https://github.com/openconfig/gnsi/tree/main/credentialz#update-the-clients-authorized-key
 * Implementation B: Ciena 6500
    The platform supports adding more than one public key per user

### Tree View

```diff
 module: openconfig-aaa
           +--rw aaa
        |  +--rw config
        |  +--ro state
        |  +--rw authentication
        |  |  +--rw glome
        |  |  |  +--ro state
        |  |  +--rw config
        |  |  |  +--rw authentication-method*   union
        |  |  +--ro state
        |  |  |  +--ro authentication-method*   union
        |  |  +--rw admin-user
        |  |  |  +--rw config
        |  |  |  |  +--rw admin-password?          string
        |  |  |  |  +--rw admin-password-hashed?   oc-aaa-types:crypt-password-type
        |  |  |  +--ro state
        |  |  |     +--ro admin-password?          string
        |  |  |     +--ro admin-password-hashed?   oc-aaa-types:crypt-password-type
        |  |  |     +--ro admin-username?          string
        |  |  +--rw users
        |  |     +--rw user* [username]
        |  |        +--rw username    -> ../config/username
        |  |        +--rw config
        |  |        |  +--rw username?          string
        |  |        |  +--rw password?          string
        |  |        |  +--rw password-hashed?   oc-aaa-types:crypt-password-type
        |  |        |  +--rw ssh-key?           string
        |  |        |  +--rw role               union
        |  |        +--ro state
        |  |           +--ro username?          string
        |  |           +--ro password?          string
        |  |           +--ro password-hashed?   oc-aaa-types:crypt-password-type
        |  |           +--ro ssh-key?           string
        |  |           +--ro role               union
+       |  |        +---- authorized-ssh-keys
+       |  |           +---- authorized-ssh-key* [key-name]
+       |  |              +---- key-name?   -> ../config/key-name
+       |  |              +---- config
+       |  |              |  +---- key-name?             string
+       |  |              |  +---- authorized-ssh-key?   string
+       |  |              +--ro state
+       |  |                 +--ro key-name?             string
+       |  |                 +--ro authorized-ssh-key?   string

```
