### PR TITLE
Isis ip reachability removal

### DIFF
--- a/release/models/isis/openconfig-isis-lsp.yang
+++ b/release/models/isis/openconfig-isis-lsp.yang
@@ -34,7 +34,13 @@ submodule openconfig-isis-lsp {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.8.0";
+
+  revision "2026-05-23" {
+    description
+      "Add IP reachability suppression per global, level, and interface-level address family with inheritance.";
+    reference "1.8.0";
+  }
 
   revision "2024-02-28" {
     description

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -548,11 +548,11 @@ submodule openconfig-isis-routing {
     description
       "Grouping defining reachability options for ISIS at the global context.";
 
-    leaf suppress-interface-ip {
+    leaf suppress-interface-reachability {
       type oc-isis-types:suppress-interface-ip-mode;
       default "NONE";
       description
-        "Controls IP reachability (TLVs 135/235) advertisement for all
+        "Controls IP reachability (TLVs 135/236) advertisement for all
         interfaces enabled for this address-family.";
     }
   }
@@ -561,10 +561,10 @@ submodule openconfig-isis-routing {
     description
       "Grouping defining reachability options for ISIS at the level context.";
 
-    leaf suppress-interface-ip {
+    leaf suppress-interface-reachability {
       type oc-isis-types:suppress-interface-ip-mode;
       description
-        "Controls IP reachability (TLVs 135/235) advertisement for interfaces
+        "Controls IP reachability (TLVs 135/236) advertisement for interfaces
         enabled in this level.
         If not specified, the value is inherited from the global level configuration.";
     }
@@ -574,10 +574,10 @@ submodule openconfig-isis-routing {
     description
       "Grouping defining reachability options for ISIS at the interface level context.";
 
-    leaf suppress {
+    leaf suppress-reachability {
       type boolean;
       description
-        "Controls IP reachability (TLVs 135/235) advertisement for this interface.
+        "Controls IP reachability (TLVs 135/236) advertisement for this interface.
         When set to true, advertisement of the interface's IP prefix is suppressed.
         When set to false, advertisement of the interface's IP prefix is not suppressed.
         If not specified, the behavior is inherited from the level or global configuration.";

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -24,7 +24,7 @@ submodule openconfig-isis-routing {
 
   revision "2026-05-10" {
     description
-      "Add IP reachability suppression on P2P links per level and per interface-level address family with inheritance.";
+      "Add IP reachability suppression per level and per interface-level address family with inheritance.";
     reference "1.8.0";
   }
 
@@ -546,12 +546,12 @@ submodule openconfig-isis-routing {
     description
       "Grouping defining reachability options for ISIS at the level context.";
 
-    leaf ip-reachability-suppress {
-      type boolean;
-      default false;
+    leaf suppress-interface-ip {
+      type oc-isis-types:suppress-interface-ip-mode;
+      default "NONE";
       description
-        "When set to true, IP reachability (TLVs 135/235) on P2P links is suppressed,
-        advertising only passive interfaces.";
+        "Controls IP reachability (TLVs 135/235/236/237) advertisement for interfaces
+        enabled in this level.";
     }
   }
 
@@ -561,12 +561,11 @@ submodule openconfig-isis-routing {
       When left unconfigured, the implementation inherits the value configured at the
       protocol level.";
 
-    leaf ip-reachability-suppress {
-      type boolean;
+    leaf suppress-interface-ip {
+      type oc-isis-types:suppress-interface-ip-mode;
       description
-        "When set to true, IP reachability (TLVs 135/235) on P2P links is suppressed,
-        advertising only passive interfaces. If not specified, the value is inherited
-        from the protocol level configuration.";
+        "Controls IP reachability (TLVs 135/235/236/237) advertisement for this interface.
+        If not specified, the value is inherited from the protocol level configuration.";
     }
   }
 

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -22,9 +22,9 @@ submodule openconfig-isis-routing {
 
   oc-ext:openconfig-version "1.8.0";
 
-  revision "2026-05-10" {
+  revision "2026-05-23" {
     description
-      "Add IP reachability suppression per level and per interface-level address family with inheritance.";
+      "Add IP reachability suppression per global, level, and interface-level address family with inheritance.";
     reference "1.8.0";
   }
 
@@ -367,6 +367,7 @@ submodule openconfig-isis-routing {
         uses isis-metric-config;
         uses rt-admin-config;
         uses isis-ecmp-config;
+        uses isis-reachability-global-config;
       }
 
       container state {
@@ -378,6 +379,7 @@ submodule openconfig-isis-routing {
         uses isis-metric-config;
         uses rt-admin-config;
         uses isis-ecmp-config;
+        uses isis-reachability-global-config;
       }
 
       uses isis-mt-list;
@@ -542,30 +544,43 @@ submodule openconfig-isis-routing {
     }
   }
 
+  grouping isis-reachability-global-config {
+    description
+      "Grouping defining reachability options for ISIS at the global context.";
+
+    leaf suppress-interface-ip {
+      type oc-isis-types:suppress-interface-ip-mode;
+      default "NONE";
+      description
+        "Controls IP reachability (TLVs 135/235) advertisement for all
+        interfaces enabled for this address-family.";
+    }
+  }
+
   grouping isis-reachability-level-config {
     description
       "Grouping defining reachability options for ISIS at the level context.";
 
     leaf suppress-interface-ip {
       type oc-isis-types:suppress-interface-ip-mode;
-      default "NONE";
       description
-        "Controls IP reachability (TLVs 135/235/236/237) advertisement for interfaces
-        enabled in this level.";
+        "Controls IP reachability (TLVs 135/235) advertisement for interfaces
+        enabled in this level.
+        If not specified, the value is inherited from the global level configuration.";
     }
   }
 
   grouping isis-reachability-interface-config {
     description
-      "Grouping defining reachability options for ISIS at the interface level context.
-      When left unconfigured, the implementation inherits the value configured at the
-      protocol level.";
+      "Grouping defining reachability options for ISIS at the interface level context.";
 
-    leaf suppress-interface-ip {
-      type oc-isis-types:suppress-interface-ip-mode;
+    leaf suppress {
+      type boolean;
       description
-        "Controls IP reachability (TLVs 135/235/236/237) advertisement for this interface.
-        If not specified, the value is inherited from the protocol level configuration.";
+        "Controls IP reachability (TLVs 135/235) advertisement for this interface.
+        When set to true, advertisement of the interface's IP prefix is suppressed.
+        When set to false, advertisement of the interface's IP prefix is not suppressed.
+        If not specified, the behavior is inherited from the level or global configuration.";
     }
   }
 

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -566,7 +566,7 @@ submodule openconfig-isis-routing {
       description
         "Controls IP reachability (TLVs 135/236) advertisement for interfaces
         enabled in this level.
-        If not specified, the value is inherited from the global level configuration.";
+        If not specified, the value is inherited from the global address-family configuration.";
     }
   }
 

--- a/release/models/isis/openconfig-isis-routing.yang
+++ b/release/models/isis/openconfig-isis-routing.yang
@@ -20,7 +20,13 @@ submodule openconfig-isis-routing {
   description
     "This module describes YANG model for ISIS Routing";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.8.0";
+
+  revision "2026-05-10" {
+    description
+      "Add IP reachability suppression on P2P links per level and per interface-level address family with inheritance.";
+    reference "1.8.0";
+  }
 
   revision "2024-02-28" {
     description
@@ -412,6 +418,7 @@ submodule openconfig-isis-routing {
         uses isis-afi-safi-config;
         uses isis-metric-config;
         uses rt-admin-config;
+        uses isis-reachability-interface-config;
       }
 
       container state {
@@ -421,6 +428,7 @@ submodule openconfig-isis-routing {
         uses isis-afi-safi-config;
         uses isis-metric-config;
         uses rt-admin-config;
+        uses isis-reachability-interface-config;
       }
 
       uses oc-sr:sr-igp-interface-top;
@@ -530,6 +538,80 @@ submodule openconfig-isis-routing {
         "This container defines AFI-SAFI multi-topology state information";
       uses isis-mt-config;
       uses rt-admin-config;
+      }
+    }
+  }
+
+  grouping isis-reachability-level-config {
+    description
+      "Grouping defining reachability options for ISIS at the level context.";
+
+    leaf ip-reachability-suppress {
+      type boolean;
+      default false;
+      description
+        "When set to true, IP reachability (TLVs 135/235) on P2P links is suppressed,
+        advertising only passive interfaces.";
+    }
+  }
+
+  grouping isis-reachability-interface-config {
+    description
+      "Grouping defining reachability options for ISIS at the interface level context.
+      When left unconfigured, the implementation inherits the value configured at the
+      protocol level.";
+
+    leaf ip-reachability-suppress {
+      type boolean;
+      description
+        "When set to true, IP reachability (TLVs 135/235) on P2P links is suppressed,
+        advertising only passive interfaces. If not specified, the value is inherited
+        from the protocol level configuration.";
+    }
+  }
+
+  grouping isis-level-afi-safi-list {
+    description
+      "This grouping defines address-family configuration and state
+      information per level.";
+
+    list af {
+      key "afi-name safi-name";
+
+      description
+        "Address-family/Subsequent Address-family list per level.";
+
+      leaf afi-name {
+        type leafref {
+          path "../config/afi-name";
+        }
+        description
+          "Reference to address-family type";
+      }
+
+      leaf safi-name {
+        type leafref {
+          path "../config/safi-name";
+        }
+        description
+          "Reference to subsequent address-family type";
+      }
+
+      container config {
+        description
+          "This container defines AFI-SAFI configuration parameters per level.";
+
+        uses isis-afi-safi-config;
+        uses isis-reachability-level-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines AFI-SAFI state information per level.";
+
+        uses isis-afi-safi-config;
+        uses isis-reachability-level-config;
       }
     }
   }

--- a/release/models/isis/openconfig-isis-types.yang
+++ b/release/models/isis/openconfig-isis-types.yang
@@ -22,7 +22,7 @@ module openconfig-isis-types {
 
   oc-ext:openconfig-version "0.7.0";
 
-  revision "2026-05-10" {
+  revision "2026-05-23" {
     description
       "Add IP reachability suppression mode enumeration.";
     reference "0.7.0";

--- a/release/models/isis/openconfig-isis-types.yang
+++ b/release/models/isis/openconfig-isis-types.yang
@@ -20,7 +20,13 @@ module openconfig-isis-types {
     "This module contains general data definitions for use in ISIS YANG
     model.";
 
-  oc-ext:openconfig-version "0.6.0";
+  oc-ext:openconfig-version "0.7.0";
+
+  revision "2026-05-10" {
+    description
+      "Add IP reachability suppression mode enumeration.";
+    reference "0.7.0";
+  }
 
   revision "2022-02-11" {
     description
@@ -205,6 +211,29 @@ module openconfig-isis-types {
   }
 
   // typedef statements
+  typedef suppress-interface-ip-mode {
+    type enumeration {
+      enum NONE {
+        description
+          "Do not suppress IP reachability on any interface.";
+      }
+      enum ALL {
+        description
+          "Suppress IP reachability on all interfaces in this level/address-family.";
+      }
+      enum NON_PASSIVE {
+        description
+          "Suppress IP reachability on all non-passive (active) interfaces.";
+      }
+      enum NON_PASSIVE_POINT_TO_POINT {
+        description
+          "Suppress IP reachability on non-passive (active) point-to-point interfaces only.";
+      }
+    }
+    description
+      "Mode for interface IP reachability suppression.";
+  }
+
   typedef level-type {
     type enumeration {
       enum LEVEL_1 {

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -56,9 +56,9 @@ module openconfig-isis {
 
   oc-ext:openconfig-version "1.8.0";
 
-  revision "2026-05-10" {
+  revision "2026-05-23" {
     description
-      "Add IP reachability suppression per level and per interface-level address family with inheritance.";
+      "Add IP reachability suppression per global, level, and interface-level address family with inheritance.";
     reference "1.8.0";
   }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -54,7 +54,13 @@ module openconfig-isis {
             +-> { levels config }
             +-> { level adjacencies }";
 
-  oc-ext:openconfig-version "1.7.0";
+  oc-ext:openconfig-version "1.8.0";
+
+  revision "2026-05-10" {
+    description
+      "Add IP reachability suppression on P2P links per level and per interface-level address family with inheritance.";
+    reference "1.8.0";
+  }
 
   revision "2024-02-28" {
     description
@@ -1664,6 +1670,13 @@ module openconfig-isis {
       description
         "This container defines ISIS authentication.";
       uses isis-level-authentication-group;
+    }
+
+    container afi-safi {
+      description
+        "This container defines address-family specific configuration
+        and state information per level.";
+      uses isis-level-afi-safi-list;
     }
   }
 

--- a/release/models/isis/openconfig-isis.yang
+++ b/release/models/isis/openconfig-isis.yang
@@ -58,7 +58,7 @@ module openconfig-isis {
 
   revision "2026-05-10" {
     description
-      "Add IP reachability suppression on P2P links per level and per interface-level address family with inheritance.";
+      "Add IP reachability suppression per level and per interface-level address family with inheritance.";
     reference "1.8.0";
   }
 


### PR DESCRIPTION
### Change Scope
**Add Hierarchical IP Reachability Suppression to IS-IS.**

In large-scale IP networks, advertising transit link IP addresses (TLVs 135/236 into the IGP (IS-IS) dramatically increases the routing table size without adding functional value, as only loopback interfaces (configured as passive interfaces) require global reachability for BGP next-hop resolution. 

This PR introduces a highly flexible, hierarchical IP reachability suppression scheme within the OpenConfig IS-IS model supporting Global, Level, and Interface level contexts with clean inheritance rules:

*   **Global Context**: Introduces `suppress-interface-ip` under `/isis/global/afi-safi/af/config/` (Type: `suppress-interface-ip-mode` with `default "NONE"`), offering instance-wide default suppression control.
*   **Level Context**: Introduces `suppress-interface-ip` under `/isis/levels/level/afi-safi/af/config/` to allow level-specific overrides, inheriting directly from the global configuration when left unconfigured.
*   **Interface Override**: Adds a clean boolean `suppress` leaf under `/isis/interfaces/interface/afi-safi/af/config/` allowing operators to explicitly suppress (`true`) or force advertisement (`false`) of a single interface's prefix, falling back to level/global policies if unconfigured.

---

### Platform Implementations

#### IP Reachability Suppression Support:

| Implementation | Command Syntax / Configuration Capability |
| :--- | :--- |
| **Arista EOS** | Supports global prefix suppression via  [advertise ip-reachability passive-only](https://www.arista.com/en/support/toi/eos-4-32-1f/19861-is-is-advertise-passive-only) command under `router isis` to suppress TLVs 135/236. |
| **Cisco IOS-XR** | Supports prefix suppression globally and per-AFI/SAFI via the [advertise passive-only](https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/ip-routing/b-ip-routing/m_ip6-route-isis-adv-pass-onl.pdf) address-family command under `router isis`, along with the [suppressed](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/routing/24xx/configuration/guide/b-routing-cg-cisco8000-24xx/implement-is-is.html) keyword for per-interface overrides. |
| **Juniper Junos**| Achieves prefix suppression dynamically using a standard  export policy applied under `protocols isis` that accepts passive loopback prefixes while rejecting active transit link direct routes. |
| **Nokia SR-OS** | Supports global prefix suppression using the [advertise-passive-only](https://infocenter.nokia.com/public/7750SR150R1A/index.jsp?topic=%2Fcom.sr.unicast%2Fhtml%2Fisis-cli.html) command under the `config>router>isis` context. |

---

### Tree View

#### 1. Global Context (`/isis/global/afi-safi`)
```diff
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw global
                    +--rw afi-safi
                       +--rw af* [afi-name safi-name]
                          +--rw afi-name    -> ../config/afi-name
                          +--rw safi-name   -> ../config/safi-name
                          +--rw config
                          |  +--rw afi-name?                identityref
                          |  +--rw safi-name?               identityref
                          |  +--rw metric?                  uint32
                          |  +--rw enabled?                 boolean
                          |  +--rw max-ecmp-paths?          uint8
+                         |  +--rw suppress-interface-reachability?   oc-isis-types:suppress-interface-ip-mode
                          +--ro state
                             +--ro afi-name?                identityref
                             +--ro safi-name?               identityref
                             +--ro metric?                  uint32
                             +--ro enabled?                 boolean
                             +--ro max-ecmp-paths?          uint8
+                            +--ro suppress-interface-reachability?   oc-isis-types:suppress-interface-ip-mode
```

#### 2. Protocol Level Context (`/isis/levels/level`)
```diff
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw levels
                    +--rw level* [level-number]
+                      +--rw afi-safi
+                         +--rw af* [afi-name safi-name]
+                            +--rw afi-name    -> ../config/afi-name
+                            +--rw safi-name   -> ../config/safi-name
+                            +--rw config
+                            |  +--rw afi-name?                identityref
+                            |  +--rw safi-name?               identityref
+                            |  +--rw suppress-interface-reachability?   oc-isis-types:suppress-interface-ip-mode
+                            +--ro state
+                               +--ro afi-name?                identityref
+                               +--ro safi-name?               identityref
+                               +--ro suppress-interface-reachability?   oc-isis-types:suppress-interface-ip-mode
```


#### 3. Interface Context (`/isis/interfaces/interface/afi-safi`)
```diff
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw isis
                 +--rw interfaces
                    +--rw interface* [interface-id]
                       +--rw afi-safi
                          +--rw af* [afi-name safi-name]
                             +--rw afi-name    -> ../config/afi-name
                             +--rw safi-name   -> ../config/safi-name
                             +--rw config
                             |  +--rw afi-name?                identityref
                             |  +--rw safi-name?               identityref
                             |  +--rw metric?                  uint32
                             |  +--rw enabled?                 boolean
+                            |  +--rw suppress-reachability?                boolean
                             +--ro state
                                +--ro afi-name?                identityref
                                +--ro safi-name?               identityref
                                +--ro metric?                  uint32
                                +--ro enabled?                 boolean
+                               +--ro suppress-reachability?                boolean
```

#### 4. Enumeration Definition Reference
```yang
typedef suppress-interface-ip-mode {
  type enumeration {
    enum NONE {
      description
        "Do not suppress IP reachability on any interface.";
    }
    enum ALL {
      description
        "Suppress IP reachability on all interfaces in this level/address-family.";
    }
    enum NON_PASSIVE {
      description
        "Suppress IP reachability on all non-passive (active) interfaces.";
    }
    enum NON_PASSIVE_POINT_TO_POINT {
      description
        "Suppress IP reachability on non-passive (active) point-to-point interfaces only.";
    }
  }
  description
    "Mode for interface IP reachability suppression.";
}
```