### PR TITLE
Add interface egress VLAN filter drop counter

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -26,7 +26,13 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.17.0";
+  oc-ext:openconfig-version "2.18.0";
+
+  revision "2026-06-22" {
+    description
+      "Add egress VLAN filter drop counter to Ethernet counters.";
+    reference "2.18.0";
+  }
 
   revision "2026-03-12" {
     description
@@ -684,6 +690,18 @@ module openconfig-if-ethernet {
       reference
         "RFC 1643 Definitions of Managed
         Objects for the Ethernet-like Interface Types.";
+     }
+
+     leaf out-vlan-filter-discards {
+       type oc-yang:counter64;
+       description
+         "The number of outbound packets that were dropped due to
+         VLAN egress filtering being enabled on the interface, where
+         the packet's VLAN tag did not match the allowed VLANs.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of 'last-clear'.";
      }
 
   }


### PR DESCRIPTION
This change introduces a new interface-level operational state counter `out-vlan-filter-discards` to track packet drops caused by egress VLAN filtering mismatch. This is related to VLAN config under ethernet config - /interfaces/interface/ethernet/switched-vlan/config/access-vlan will be used to configure the VLAN.
The version has been bumped to `2.18.0` in `openconfig-if-ethernet.yang`.

Change-Id: I9a11ff67688e8aec8f3d8eb08ef05220bff44040

### Change Scope

* **Description:** This PR introduces a new interface-level operational state counter `out-vlan-filter-discards` to `openconfig-if-ethernet.yang` to track packets dropped due to VLAN egress filtering being enabled on the interface where the packet's VLAN tag did not match the allowed VLANs.
* **Backwards Compatibility:** This change is fully backward compatible as it only adds a new operational state leaf counter to an existing grouping.

### Use case

This counter is designed for production network debugging. Silent packet drops are difficult to diagnose in live networks, so introducing granular drop counters like this one helps network operators to pinpoint and root cause issues. Unlike other counters (e.g. general packet drops), this counter indicates a configuration or programming error, so it would not be seen increasing during normal operation and would indicate that the system is not functioning as intended.

### Platform Implementations

- This counter is part of the [Generic SAI Debug Counters spec](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-Debug-Counters.md), see also [header file](https://github.com/opencomputeproject/SAI/blob/master/inc/saidebugcounter.h#L359). 
- [Nvidia/Mellanox](https://docs.nvidia.com/nvidia-mellanox-neo-documentation.pdf#page=282)
- [Cisco SONiC](https://www.cisco.com/c/dam/en/us/solutions/collateral/silicon-one/Cisco-S1-SONiC-CLI-Reference-Guide.pdf#page=780)
- Google network switches implement egress VLAN filter drop counters to track packet dispatches that violate allowed VLAN criteria. 

### Tree View

```diff
module: openconfig-interfaces
  +--rw interfaces
     +--rw interface* [name]
        ...
        +--rw oc-eth:ethernet
           +--rw oc-eth:config
           ...
           +--ro oc-eth:state
              ...
              +--ro oc-eth:counters
                 +--ro oc-eth:fec-uncorrectable-blocks?   oc-yang:counter64
                 ...
                 +--ro oc-eth:out-mac-errors-tx?          oc-yang:counter64
+                +--ro oc-eth:out-vlan-filter-discards?   oc-yang:counter64
```

