### PR TITLE
Add ETH_800GBASE_2XLR4 and ETH_800GBASE_2XPLR4 PMD types

### DIFF
--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -22,7 +22,13 @@ module openconfig-transport-types {
     "This module contains general type definitions and identities
     for optical transport models.";
 
-  oc-ext:openconfig-version "1.4.0";
+  oc-ext:openconfig-version "1.5.0";
+
+  revision "2026-06-09" {
+    description
+      "Add ETH_800GBASE_2XLR4 and ETH_800GBASE_2XPLR4 PMD types.";
+    reference "1.5.0";
+  }
 
   revision "2026-04-24" {
     description
@@ -1325,6 +1331,16 @@ module openconfig-transport-types {
     base ETHERNET_PMD_TYPE;
     description "Ethernet compliance code: 800GBASE_2XFR4";
     reference "IEEE 802.3cu";
+  }
+
+  identity ETH_800GBASE_2XLR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 800GBASE_2XLR4";
+  }
+
+  identity ETH_800GBASE_2XPLR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 800GBASE_2XPLR4";
   }
 
   identity ETH_UNDEFINED {

--- a/release/models/optical-transport/openconfig-transport-types.yang
+++ b/release/models/optical-transport/openconfig-transport-types.yang
@@ -1335,12 +1335,12 @@ module openconfig-transport-types {
 
   identity ETH_800GBASE_2XLR4 {
     base ETHERNET_PMD_TYPE;
-    description "Ethernet compliance code: 800GBASE_2XLR4";
+    description "Ethernet compliance code: 800GBASE-2xLR4";
   }
 
   identity ETH_800GBASE_2XPLR4 {
     base ETHERNET_PMD_TYPE;
-    description "Ethernet compliance code: 800GBASE_2XPLR4";
+    description "Ethernet compliance code: 800GBASE-2xPLR4";
   }
 
   identity ETH_UNDEFINED {


### PR DESCRIPTION



## Description
This Pull Request proposes the addition of two new 800G Ethernet Physical Medium Dependent (PMD) types to the `openconfig-transport-types.yang` module. 
These additions are made under the `ETHERNET_PMD_TYPE` base identity to support newer 800G transceiver compliance codes:
*   **`ETH_800GBASE_2XLR4`**: Ethernet compliance code for 800GBASE_2XLR4 (typically 2x400G LR4).
*   **`ETH_800GBASE_2XPLR4`**: Ethernet compliance code for 800GBASE_2XPLR4 (typically 2x400G PLR4).
## Rationale
As 800G optics deploy, these PMD types are increasingly required to model interfaces using dual-carrier/breakout 400G interfaces packaged as a single 800G transceiver (2x400G LR4/PLR4). Adding them to the standard public models ensures vendor-neutral consistency.
## YANG Changes
*   **Module**: `release/models/optical-transport/openconfig-transport-types.yang`
*   Added `identity ETH_800GBASE_2XLR4`
*   Added `identity ETH_800GBASE_2XPLR4`
*   Bumped `openconfig-version` to `1.5.0` (minor version bump for backward-compatible additions).
*   Added `revision "2026-06-09"` with description.
## Compatibility
This change is fully backward-compatible as it only introduces new identities.

### Tree View
No diff