### PR TITLE
Add tunnel-processing-mode leaves for dscp and ttl

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,14 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-06-11" {
+    description
+      "Add tunnel header-field processing modes and default TTL/DSCP
+       values for UDP encapsulation.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -840,11 +847,45 @@ submodule openconfig-aft-common {
     description
       "Common fields used for UDP in IPv4/IPv6 encapsulation applied on top of a packet.";
 
+    leaf dscp-processing-mode {
+      type oc-aftt:tunnel-header-field-mode-type;
+      description
+        "Specifies the tunnel processing mode for DSCP / Traffic Class.
+
+        When set to TUNNEL_HEADER_FIELD_MODE_UNIFORM, the DSCP value is
+        propagated from the inner packet header to the outer IP header
+        during encapsulation.
+
+        When set to TUNNEL_HEADER_FIELD_MODE_PIPE, the outer DSCP value
+        is set independently of the inner packet using the configured or
+        default dscp value.";
+      reference
+        "RFC 2474: Definition of the Differentiated Services Field
+         in the IPv4 and IPv6 Headers.
+
+         RFC 2983: Differentiated Services and Tunnels.
+
+         RFC 3270: Multi-Protocol Label Switching (MPLS) Support of
+         Differentiated Services.";
+    }
+
     leaf dscp {
       type oc-inet:dscp;
+      default "0";
       description
-        "DSCP value to use for the UDP header of the encapsulated
-         packet.";
+        "Configured/default DSCP value to use in the outer IP header
+         during packet encapsulation when dscp-processing-mode is set to
+         TUNNEL_HEADER_FIELD_MODE_PIPE.
+
+         If dscp-processing-mode is set to
+         TUNNEL_HEADER_FIELD_MODE_UNIFORM, the DSCP value from the inner
+         packet header is propagated to the outer IP header and this leaf
+         is ignored for encapsulation.";
+      reference
+        "RFC 2474: Definition of the Differentiated Services Field
+         in the IPv4 and IPv6 Headers.
+
+         RFC 2983: Differentiated Services and Tunnels.";
     }
 
     leaf src-udp-port {
@@ -872,13 +913,40 @@ submodule openconfig-aft-common {
         system is expected to utilize the appropriate port.";
     }
 
+    leaf ttl-processing-mode {
+      type oc-aftt:tunnel-header-field-mode-type;
+      description
+        "Specifies the tunnel processing mode for IPv4 TTL.
+
+        When set to TUNNEL_HEADER_FIELD_MODE_UNIFORM, the IPv4 TTL value
+        is propagated from the inner packet header to the outer IP header
+        during encapsulation.
+
+        When set to TUNNEL_HEADER_FIELD_MODE_PIPE, the outer IPv4 TTL
+        value is set independently of the inner packet using the
+        configured or default ip-ttl value.";
+      reference
+        "RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+         Label Switching (MPLS) Networks.";
+    }
+
     leaf ip-ttl {
       type uint8;
+      default "255";
       description
-        "This leaf reflects the configured/default IP TTL value that is used
-         in the outer header during packet encapsulation. When this leaf is
-         not set, the TTL value of the inner packet is copied over as the
-         outer packet's IP TTL value during encapsulation.";
+        "Configured/default IPv4 TTL value used in the outer IP header
+         during packet encapsulation when ttl-processing-mode is set to
+         TUNNEL_HEADER_FIELD_MODE_PIPE.
+
+         If ttl-processing-mode is set to
+         TUNNEL_HEADER_FIELD_MODE_UNIFORM, the TTL value from the inner
+         packet header is propagated to the outer IP header and this leaf
+         is ignored for encapsulation.";
+      reference
+        "RFC 791: Internet Protocol.
+
+         RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+         Label Switching (MPLS) Networks.";
     }
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -849,6 +849,7 @@ submodule openconfig-aft-common {
 
     leaf dscp-processing-mode {
       type oc-aftt:tunnel-header-field-mode-type;
+      default "oc-aftt:TUNNEL_HEADER_FIELD_MODE_UNIFORM";
       description
         "Specifies the tunnel processing mode for DSCP / Traffic Class.
 
@@ -915,14 +916,15 @@ submodule openconfig-aft-common {
 
     leaf ttl-processing-mode {
       type oc-aftt:tunnel-header-field-mode-type;
+      default "oc-aftt:TUNNEL_HEADER_FIELD_MODE_PIPE";
       description
-        "Specifies the tunnel processing mode for IPv4 TTL.
+        "Specifies the tunnel processing mode for IP TTL / Hop Limit.
 
-        When set to TUNNEL_HEADER_FIELD_MODE_UNIFORM, the IPv4 TTL value
-        is propagated from the inner packet header to the outer IP header
+        When set to TUNNEL_HEADER_FIELD_MODE_UNIFORM, the IP TTL / Hop Limit
+        value is propagated from the inner packet header to the outer IP header
         during encapsulation.
 
-        When set to TUNNEL_HEADER_FIELD_MODE_PIPE, the outer IPv4 TTL
+        When set to TUNNEL_HEADER_FIELD_MODE_PIPE, the outer IP TTL / Hop Limit
         value is set independently of the inner packet using the
         configured or default ip-ttl value.";
       reference
@@ -934,12 +936,12 @@ submodule openconfig-aft-common {
       type uint8;
       default "255";
       description
-        "Configured/default IPv4 TTL value used in the outer IP header
+        "Configured/default IP TTL / Hop Limit value used in the outer IP header
          during packet encapsulation when ttl-processing-mode is set to
          TUNNEL_HEADER_FIELD_MODE_PIPE.
 
          If ttl-processing-mode is set to
-         TUNNEL_HEADER_FIELD_MODE_UNIFORM, the TTL value from the inner
+         TUNNEL_HEADER_FIELD_MODE_UNIFORM, the TTL / Hop Limit value from the inner
          packet header is propagated to the outer IP header and this leaf
          is ignored for encapsulation.";
       reference

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -16,7 +16,13 @@ module openconfig-aft-types {
     "Types related to the OpenConfig Abstract Forwarding
     Table (AFT) model";
 
-  oc-ext:openconfig-version "1.3.0";
+  oc-ext:openconfig-version "1.4.0";
+
+  revision "2026-06-11" {
+    description
+      "Add reusable tunnel header-field processing mode identities and typedef.";
+    reference "1.4.0";
+  }
 
   revision "2025-01-28" {
     description
@@ -76,6 +82,87 @@ module openconfig-aft-types {
   oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
+
+  identity TUNNEL_HEADER_FIELD_MODE {
+    description
+      "Base identity for tunnel header-field processing modes.
+
+      Tunnel header-field processing modes describe how a packet header
+      field is handled across a tunnel encapsulation boundary. Examples
+      include IPv4 TTL and DSCP / Traffic Class.
+
+      The selected mode determines whether the tunnel header field is
+      propagated from the inner packet header or uses an independently
+      configured/default value.";
+    reference
+      "RFC 3270: Multi-Protocol Label Switching (MPLS) Support of
+       Differentiated Services.
+
+       RFC 2983: Differentiated Services and Tunnels.
+
+       RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+       Label Switching (MPLS) Networks.";
+  }
+
+  identity TUNNEL_HEADER_FIELD_MODE_UNIFORM {
+    base TUNNEL_HEADER_FIELD_MODE;
+    description
+      "Uniform tunnel header-field processing mode.
+
+      In uniform mode, the selected tunnel header field is propagated
+      from the corresponding inner packet header field during
+      encapsulation.
+
+      This mode is also commonly described as propagation.";
+    reference
+      "RFC 3270: Multi-Protocol Label Switching (MPLS) Support of
+       Differentiated Services.
+
+       RFC 2983: Differentiated Services and Tunnels.
+
+       RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+       Label Switching (MPLS) Networks.";
+  }
+
+  identity TUNNEL_HEADER_FIELD_MODE_PIPE {
+    base TUNNEL_HEADER_FIELD_MODE;
+    description
+      "Pipe tunnel header-field processing mode.
+
+      In pipe mode, the selected outer tunnel header field is
+      independent of the corresponding inner packet header field during
+      encapsulation. The outer field is set using an explicitly
+      configured value, a default value, or another field-specific
+      policy.";
+    reference
+      "RFC 3270: Multi-Protocol Label Switching (MPLS) Support of
+       Differentiated Services.
+
+       RFC 2983: Differentiated Services and Tunnels.
+
+       RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+       Label Switching (MPLS) Networks.";
+  }
+
+  typedef tunnel-header-field-mode-type {
+    type identityref {
+      base TUNNEL_HEADER_FIELD_MODE;
+    }
+    description
+      "Type definition for tunnel header-field processing modes.
+
+      This type is intended for leaves that control whether a packet
+      header field is propagated across a tunnel encapsulation boundary
+      or independently set by the tunnel header policy.";
+    reference
+      "RFC 3270: Multi-Protocol Label Switching (MPLS) Support of
+       Differentiated Services.
+
+       RFC 2983: Differentiated Services and Tunnels.
+
+       RFC 3443: Time To Live (TTL) Processing in Multi-Protocol
+       Label Switching (MPLS) Networks.";
+  }
 
   typedef encapsulation-header-type {
     type enumeration {

--- a/release/models/aft/openconfig-aft-types.yang
+++ b/release/models/aft/openconfig-aft-types.yang
@@ -89,7 +89,7 @@ module openconfig-aft-types {
 
       Tunnel header-field processing modes describe how a packet header
       field is handled across a tunnel encapsulation boundary. Examples
-      include IPv4 TTL and DSCP / Traffic Class.
+      include IP TTL / Hop Limit and DSCP / Traffic Class.
 
       The selected mode determines whether the tunnel header field is
       propagated from the inner packet header or uses an independently

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,14 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-06-11" {
+    description
+      "Add tunnel header-field processing modes and default TTL/DSCP
+       values for UDP encapsulation.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description


### PR DESCRIPTION
## Change Scope

TTL, Hop Limit, and DSCP/Traffic Class can be viewed as tunnel header fields whose values are processed according to defined tunnel conceptual models, most notably Uniform and Pipe modes.

These changes have been discussed as part of PR review https://github.com/openconfig/public/pull/1492
### Overview of tunnel header processing modes

* **Uniform mode (Propagation):** The corresponding field from the inner packet is propagated into the outer tunnel header during encapsulation. Where field-specific de-capsulation behavior is defined, the tunnel header field may also influence the forwarded packet at tunnel egress.
* **Pipe mode:** The outer tunnel header field is processed independently from the corresponding inner packet field. The outer field is set using an explicitly configured value, a default value, or another field-specific policy, and changes within the tunnel are not propagated back to the inner packet at tunnel egress.

These conceptual tunnel models are used across multiple specifications and header fields. Since the same tunnel processing concept applies to multiple header fields (IPv4 TTL, IPv6 Hop Limit, and DSCP/Traffic Class), it is preferable to model this as a generic reusable identity that can be set explicitly by configuration leaves rather than encoding it implicitly.

### Proposed Configuration Leaves
We suggest explicit configurable leaves to set the tunnel processing models:
* `ttl-processing-mode`
* `dscp-processing-mode`

These leaves are of type `tunnel-header-field-mode-type`, defined as follows:

typedef tunnel-header-field-mode-type {
  type identityref {
    base TUNNEL_HEADER_FIELD_MODE;
  }
}

#### Derived Identities
* `TUNNEL_HEADER_FIELD_MODE_UNIFORM`
* `TUNNEL_HEADER_FIELD_MODE_PIPE`

We also suggest setting a default value for the `ip-ttl` and `dscp` leaves. This terminology is aligned with RFC 3270, RFC 2983, RFC 3443, and RFC 2473.

### Generic Behavior Table

| processing-mode | Field-specific value configured? | Outer tunnel header-field behavior |
| :--- | :--- | :--- |
| TUNNEL_HEADER_FIELD_MODE_UNIFORM | Yes or no | Propagate the corresponding value from the inner packet header to the outer tunnel header. The field-specific configured value is ignored for encapsulation. |
| TUNNEL_HEADER_FIELD_MODE_PIPE | Yes | Use the explicitly configured field-specific value in the outer tunnel header. |
| TUNNEL_HEADER_FIELD_MODE_PIPE | No | Use the field-specific default value or policy-defined value in the outer tunnel header. |

### References

| RFC | Context |
| :--- | :--- |
| RFC 3270 | Defines the Uniform, Pipe, and Short Pipe tunnel models in the context of MPLS DiffServ/QoS treatment. |
| RFC 2983 | Discusses DiffServ behavior across tunnels, including how DSCP/DS field values may be copied, preserved, or independently set across tunnel boundaries. |
| RFC 3443 | Applies the Uniform and Pipe tunnel model concepts to TTL processing in MPLS networks. |
| RFC 2473 | Defines generic IPv6 tunneling behavior, including outer IPv6 Hop Limit handling. |
| RFC 2474 | Defines the DS field/DSCP semantics used by the DiffServ tunneling behavior described in RFC 2983 and RFC 3270. |


## Tree View

```diff
       |     +--ro udp-v4
       |     |  +--ro state
       |     |     +--ro src-ip?         oc-inet:ipv4-address
       |     |     +--ro dst-ip?         oc-inet:ipv4-address
+      |     |     +--ro dscp-processing-mode?   oc-aftt:tunnel-header-field-mode-type
       |     |     +--ro dscp?           oc-inet:dscp
       |     |     +--ro src-udp-port?   oc-inet:port-number
       |     |     +--ro dst-udp-port?   oc-inet:port-number
+      |     |     +--ro ttl-processing-mode?    oc-aftt:tunnel-header-field-mode-type
       |     |     +--ro ip-ttl?         uint8
       |     +--ro udp-v6
       |     |  +--ro state
       |     |     +--ro src-ip?         oc-inet:ipv6-address
       |     |     +--ro dst-ip?         oc-inet:ipv6-address
+      |     |     +--ro dscp-processing-mode?   oc-aftt:tunnel-header-field-mode-type
       |     |     +--ro dscp?           oc-inet:dscp
       |     |     +--ro src-udp-port?   oc-inet:port-number
       |     |     +--ro dst-udp-port?   oc-inet:port-number
+      |     |     +--ro ttl-processing-mode?    oc-aftt:tunnel-header-field-mode-type
       |     |     +--ro ip-ttl?         uint8
```
