### PR TITLE
Update documentation for AFT Limited Prefix Streaming and aft-summarry behavior

### DIFF
--- a/release/models/aft/openconfig-aft-summary.yang
+++ b/release/models/aft/openconfig-aft-summary.yang
@@ -20,7 +20,15 @@ module openconfig-aft-summary {
     "This module provides summary of aft entry counts per protocol type for each network
     instance.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.2.2";
+
+  revision "2026-06-15" {
+    description
+      "Clarify that aft-summaries counters reflect total unfiltered
+       entries in the hardware FIB, independent of any global-filter
+       policy.";
+    reference "0.2.2";
+  }
 
   revision "2026-03-11" {
     description
@@ -59,7 +67,10 @@ module openconfig-aft-summary {
 
       leaf aft-entries {
         description
-          "Total number of entries in the aft.";
+          "Total number of entries installed in the hardware FIB for
+           the given protocol. This count reflects all entries
+           regardless of any AFT global-filter policy that may be
+           configured to limit which prefixes are streamed via gNMI.";
         type uint64;
       }
     }
@@ -126,7 +137,11 @@ module openconfig-aft-summary {
       uses aft-summary-ipv6;
 
       description
-        "Aft summary for the network instance.";
+        "Summary of AFT entry counts per protocol type for the network
+         instance. These counts reflect total entries installed in the
+         hardware FIB and are not affected by any AFT global-filter
+         policy that may restrict which prefixes are streamed to gNMI
+         subscribers.";
     }
   }
 


### PR DESCRIPTION
**Change Scope**

- The current description that aft-summaries should reflect the total AFT entries in the HW FIB, not the filtered summary. Specifically, the Route Summary (per protocol route count in the FIB) should remain untouched, meaning it will still contain the counts related to all prefixes. 
- This change is backward compatible.

**Related Issues**
Fixes https://github.com/openconfig/public/issues/1503

**Platform Implementations**
NA

Tree View
No changes to tree view