### PR TITLE
Local-as refactoring and extension

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,15 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,15 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -349,7 +349,7 @@ submodule openconfig-bgp-common {
 
     leaf local-as {
       type oc-inet:as-number;
-      deprecated;
+      status deprecated;
       description
         "The local autonomous system number that is to be used
         when establishing sessions with the remote peer or peer

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,13 +24,21 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
       "Clarification to usage of link-bandwidth-ext-community
       container under BGP use-multiple-paths`.";
-          reference "9.9.1";
+    reference "9.9.1";
   }
 
   revision "2025-03-30" {
@@ -279,6 +287,56 @@ submodule openconfig-bgp-common {
     }
   }
 
+  grouping bgp-local-as-group-config {
+    description
+      "Local-as configuration items.
+      Local-as is migration tool described in RFC7705";
+
+    leaf local-as {
+      type oc-inet:as-number;
+      mandatory true;
+      description
+        "The local autonomous system number that is to be used
+        when establishing sessions with the remote peer or peer
+        group, if this differs from the global BGP router
+        autonomous system number. Value is set in My Autonomous
+         Sytem of the OPEN messagege send to establish session.";
+      reference
+        "RFC7705: Autonomous System Migration Mechanisms
+        and Their Effects on the BGP AS_PATH Attribute.
+        Section 3.1 - Modify Inbound BGP AS_PATH Attribute";
+    }
+
+    leaf no-prepend {
+      type boolean;
+      description
+        "When set to TRUE, the value configured as local-as is
+        not prepended to AS-PATH on recived routes.";
+      reference
+        "RFC7705: Autonomous System Migration Mechanisms
+        and Their Effects on the BGP AS_PATH Attribute.
+        Section 3.1 - Modify Inbound BGP AS_PATH Attribute";
+    }
+
+    leaf replace-as {
+      type boolean;
+      description
+        "When set to TRUE, the global AS is not added to AS-PATH
+        when route is advertised to peer. Only local-as is prepended.";
+      reference
+        "RFC7705: Autonomous System Migration Mechanisms
+        and Their Effects on the BGP AS_PATH Attribute.
+        Section 3.2 - Modify Outbound BGP AS_PATH Attribute";
+    }
+
+    leaf dual-as {
+      type boolean;
+      description
+        "When set to TRUE, the speaker alternate between local-ASN
+        and global ASN in every other OPEN messages.";
+    }
+  }
+
   grouping bgp-common-neighbor-group-config {
     description
       "Neighbor level configuration items.";
@@ -291,6 +349,7 @@ submodule openconfig-bgp-common {
 
     leaf local-as {
       type oc-inet:as-number;
+      deprecated;
       description
         "The local autonomous system number that is to be used
         when establishing sessions with the remote peer or peer

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -289,18 +289,17 @@ submodule openconfig-bgp-common {
 
   grouping bgp-local-as-group-config {
     description
-      "Local-as configuration items.
-      Local-as is migration tool described in RFC7705";
+      "Local-AS configuration items.
+      Local-AS is a migration tool described in RFC7705";
 
     leaf local-as {
       type oc-inet:as-number;
-      mandatory true;
       description
         "The local autonomous system number that is to be used
         when establishing sessions with the remote peer or peer
         group, if this differs from the global BGP router
         autonomous system number. Value is set in My Autonomous
-         Sytem of the OPEN messagege send to establish session.";
+        System of the OPEN message sent to establish session.";
       reference
         "RFC7705: Autonomous System Migration Mechanisms
         and Their Effects on the BGP AS_PATH Attribute.
@@ -311,7 +310,7 @@ submodule openconfig-bgp-common {
       type boolean;
       description
         "When set to TRUE, the value configured as local-as is
-        not prepended to AS-PATH on recived routes.";
+        not prepended to AS-PATH on received routes.";
       reference
         "RFC7705: Autonomous System Migration Mechanisms
         and Their Effects on the BGP AS_PATH Attribute.
@@ -332,7 +331,7 @@ submodule openconfig-bgp-common {
     leaf dual-as {
       type boolean;
       description
-        "When set to TRUE, the speaker alternate between local-ASN
+        "When set to TRUE, the speaker alternates between local-ASN
         and global ASN in every other OPEN messages.";
     }
   }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -332,7 +332,10 @@ submodule openconfig-bgp-common {
       type boolean;
       description
         "When set to TRUE, the speaker alternates between local-ASN
-        and global ASN in every other OPEN messages.";
+        and global ASN in every other OPEN messages. Implemetation
+        may but not have to strictly follow procedure documented in
+        section 4.2 of RFC7705, that allows of use of local-ASN
+        only upporn reception of BAD_PEER_AS error.";
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,15 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -888,21 +888,21 @@ submodule openconfig-bgp-neighbor {
 
     container local-as-options {
       description
-        "Local-as options.
-        Local-as is migration tool described in RFC7705";
+        "Local-AS options.
+        Local-AS is a migration tool described in RFC7705.";
 
       container config {
         description
-          "Local-as options configuration.
-          Local-as is migration tool described in RFC7705";
+          "Local-AS options configuration.
+          Local-AS is a migration tool described in RFC7705.";
         uses bgp-local-as-group-config;
       }
 
       container state {
         config false;
         description
-          "Local-as options state.
-          Local-as is migration tool described in RFC7705";
+          "Local-AS options state.
+          Local-AS is a migration tool described in RFC7705.";
         uses bgp-local-as-group-config;
       }
     }

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,15 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -876,6 +884,27 @@ submodule openconfig-bgp-neighbor {
         "Per-address-family configuration parameters associated with
         the neighbor";
       uses bgp-neighbor-afi-safi-list;
+    }
+
+    container local-as-options {
+      description
+        "Local-as options.
+        Local-as is migration tool described in RFC7705";
+
+      container config {
+        description
+          "Local-as options configuration.
+          Local-as is migration tool described in RFC7705";
+        uses bgp-local-as-group-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Local-as options state.
+          Local-as is migration tool described in RFC7705";
+        uses bgp-local-as-group-config;
+      }
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,15 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description
@@ -384,6 +392,27 @@ submodule openconfig-bgp-peer-group {
         "Per-address-family configuration parameters associated with
         thegroup";
       uses bgp-peer-group-afi-safi-list;
+    }
+
+    container local-as-options {
+      description
+        "Local-as options.
+        Local-as is migration tool described in RFC7705";
+
+      container config {
+        description
+          "Local-as options configuration.
+          Local-as is migration tool described in RFC7705";
+        uses bgp-local-as-group-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Local-as options state.
+          Local-as is migration tool described in RFC7705";
+        uses bgp-local-as-group-config;
+      }
     }
   }
 

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -396,21 +396,21 @@ submodule openconfig-bgp-peer-group {
 
     container local-as-options {
       description
-        "Local-as options.
-        Local-as is migration tool described in RFC7705";
+        "Local-AS options.
+        Local-AS is a migration tool described in RFC7705.";
 
       container config {
         description
-          "Local-as options configuration.
-          Local-as is migration tool described in RFC7705";
+          "Local-AS options configuration.
+          Local-AS is a migration tool described in RFC7705.";
         uses bgp-local-as-group-config;
       }
 
       container state {
         config false;
         description
-          "Local-as options state.
-          Local-as is migration tool described in RFC7705";
+          "Local-AS options state.
+          Local-AS is a migration tool described in RFC7705.";
         uses bgp-local-as-group-config;
       }
     }

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,15 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.10.0";
+
+  revision "2026-06-16" {
+    description
+      "Deprecation of ../config/local-as leaf and replacement with
+      local-as-options container. Extending with RFC7705 no-prepend
+      and replace-as explicit flags and dual-as option.";
+    reference "9.10.0";
+  }
 
   revision "2025-04-18" {
     description


### PR DESCRIPTION
local-as-options container. Extending with RFC7705 `no-prepend` and `replace-as` explicit flags and with non specified in RFC but common in industry implementations `dual-as` option.

### Change Scope

* Deprecate below leafs as current schema do not allow for adding flags
  * `/openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/local-as`
  *`/openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/local-as`
  *`/openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/config/local-as`
  *`/openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/state/local-as`
* Add new container ` local-as-options` and define local-as and flags for flexibility and RFC7705 compliance.

### Platform Implementations

## Cross-Vendor Translation Matrix

| RFC 7705 Concept | Arista EOS | Cisco IOS-XR | Juniper Junos | Nokia SR Linux (SRL) |
| --- | --- | --- | --- | --- |
| **Basic Local-AS** | `local-as <AS>` | `local-as <AS>` | `local-as <AS>` | `local-as as-number <AS>` |
| **No-Prepend (Mech 2)** | `local-as <AS> no-prepend`  | `local-as <AS> no-prepend`| `local-as <AS> no-prepend-global-as` | Controlled via BGP Policy framework |
| **Replace-AS (Mech 3)** | `local-as <AS> no-prepend replace-as`  | `local-as <AS> no-prepend replace-as`| `local-as <AS> private` | `as-path replace <AS>` policy action |
| **Dual-AS Session** | `fallback` | `dual-as`| `alias` | Supported natively per-session |


### Tree View

```diff
module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw bgp
                  +--rw peer-groups
                     +--rw peer-group* [peer-group-name]
@@ -953,32 +964,43 @@
                        |        +--rw prefix-limit
                        |        |  +--rw config
                        |        |  |  +--rw max-prefixes?            uint32
                        |        |  |  +--rw prevent-teardown?        boolean
                        |        |  |  +--rw warning-threshold-pct?   oc-types:percentage
                        |        |  +--ro state
                        |        |     +--ro max-prefixes?            uint32
                        |        |     +--ro prevent-teardown?        boolean
                        |        |     +--ro warning-threshold-pct?   oc-types:percentage
                        |        |     +--ro prefix-limit-exceeded?   boolean
                        |        +--rw prefix-limit-received
                        |           +--rw config
                        |           |  +--rw max-prefixes?            uint32
                        |           |  +--rw prevent-teardown?        boolean
                        |           |  +--rw warning-threshold-pct?   oc-types:percentage
                        |           +--ro state
                        |              +--ro max-prefixes?            uint32
                        |              +--ro prevent-teardown?        boolean
                        |              +--ro warning-threshold-pct?   oc-types:percentage
                        |              +--ro prefix-limit-exceeded?   boolean
+                       +--rw local-as-options
+                       |  +--rw config
+                       |  |  +--rw local-as      oc-inet:as-number
+                       |  |  +--rw no-prepend?   boolean
+                       |  |  +--rw replace-as?   boolean
+                       |  |  +--rw dual-as?      boolean
+                       |  +--ro state
+                       |     +--ro local-as      oc-inet:as-number
+                       |     +--ro no-prepend?   boolean
+                       |     +--ro replace-as?   boolean
+                       |     +--ro dual-as?      boolean
                        +--rw enable-bfd
                           +--rw config
                           |  +--rw enabled?                       boolean
                           |  +--rw desired-minimum-tx-interval?   uint32
                           |  +--rw required-minimum-receive?      uint32
                           |  +--rw detection-multiplier?          uint8
                           +--ro state
                              +--ro enabled?                       boolean
                              +--ro desired-minimum-tx-interval?   uint32
                              +--ro required-minimum-receive?      uint32
                              +--ro detection-multiplier?          uint8
```
```diff
 module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw bgp
                  +--rw neighbors
                     +--rw neighbor* [neighbor-address]
@@ -971,32 +982,43 @@
                        |     |  +--rw prefix-limit-received
                        |     |     +--rw config
                        |     |     |  +--rw max-prefixes?            uint32
                        |     |     |  +--rw prevent-teardown?        boolean
                        |     |     |  +--rw warning-threshold-pct?   oc-types:percentage
                        |     |     +--ro state
                        |     |        +--ro max-prefixes?            uint32
                        |     |        +--ro prevent-teardown?        boolean
                        |     |        +--ro warning-threshold-pct?   oc-types:percentage
                        |     |        +--ro prefix-limit-exceeded?   boolean
                        |     +--rw use-multiple-paths
                        |        +--rw config
                        |        |  +--rw enabled?   boolean
                        |        +--ro state
                        |        |  +--ro enabled?   boolean
                        |        +--rw ebgp
                        |           +--rw config
                        |           |  +--rw allow-multiple-as?   boolean
                        |           +--ro state
                        |              +--ro allow-multiple-as?   boolean
+                       +--rw local-as-options
+                       |  +--rw config
+                       |  |  +--rw local-as      oc-inet:as-number
+                       |  |  +--rw no-prepend?   boolean
+                       |  |  +--rw replace-as?   boolean
+                       |  |  +--rw dual-as?      boolean
+                       |  +--ro state
+                       |     +--ro local-as      oc-inet:as-number
+                       |     +--ro no-prepend?   boolean
+                       |     +--ro replace-as?   boolean
+                       |     +--ro dual-as?      boolean
                        +--rw enable-bfd
                           +--rw config
                           |  +--rw enabled?                       boolean
                           |  +--rw desired-minimum-tx-interval?   uint32
                           |  +--rw required-minimum-receive?      uint32
                           |  +--rw detection-multiplier?          uint8
                           +--ro state
                              +--ro enabled?                       boolean
                              +--ro desired-minimum-tx-interval?   uint32
                              +--ro required-minimum-receive?      uint32
                              +--ro detection-multiplier?          uint8
```