### PR TITLE
Add DSCP leaf to GRE encapsulation config

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-06-22" {
+    description
+      "Add DSCP leaf to GRE encapsulation config.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -732,6 +738,13 @@ submodule openconfig-aft-common {
         "If specified, this TTL value is used on the GRE header during
         encapsulation. If unspecified, the TTL value of the inner packet is
         copied to the GRE header TTL value during encapsulation.";
+    }
+
+    leaf dscp {
+      type oc-inet:dscp;
+      description
+        "DSCP value to use for the outer IP header of the GRE-encapsulated
+         packet.";
     }
   }
 

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-06-22" {
+    description
+      "Add DSCP leaf to GRE encapsulation config.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description


### PR DESCRIPTION
### Change Scope

* Add a DSCP leaf to the GRE encapsulation config grouping in openconfig-aft-common.yang.
* This change is backwards compatible, it adds a new leaf with no impact on existing leaves.

### Platform Implementations

 * Implementation Arista: [Nexthop Groups](https://www.arista.com/en/um-eos/eos-nexthop-groups) MPLS over GRE nexthop group supports TOS configuration. TOS maps directly to/from DSCP.
 * Implementation B: [link to documentation](http://foo.com) and/or implementation output.

### Tree View

```diff
 module: openconfig-network-instance
         +--rw static
         |  +--rw next-hops
         |     +--rw next-hop* [index]
         |        +--rw index            -> ../config/index
         |        +--rw encap-headers
         |           +--rw encap-header* [index]
         |              +--rw index     -> ../config/index
         |              +--rw gre
         |              |  +--rw config
         |              |  |  +--rw src-ip?   oc-inet:ip-address
         |              |  |  +--rw dst-ip?   oc-inet:ip-address
         |              |  |  +--rw ttl?      uint8
+        |              |  |  +--rw dscp?     oc-inet:dscp
         |              |  +--ro state
         |              |     +--ro src-ip?   oc-inet:ip-address
         |              |     +--ro dst-ip?   oc-inet:ip-address
         |              |     +--ro ttl?      uint8
+        |              |     +--ro dscp?     oc-inet:dscp
         |              +--rw mpls
         +--rw afts
         |  +--ro next-hops
         |     +--ro next-hop* [index]
         |        +--ro index            -> ../state/index
         |        +--ro gre
         |        |  +--ro state
         |        |     +--ro src-ip?   oc-inet:ip-address
         |        |     +--ro dst-ip?   oc-inet:ip-address
         |        |     +--ro ttl?      uint8
+        |        |     +--ro dscp?     oc-inet:dscp
         |        +--ro encap-headers
         |        |  +--ro encap-header* [index]
         |        |     +--ro index     -> ../state/index
         |        |     +--ro state
         |        |     |  +--ro index?   uint8
         |        |     |  +--ro type?    oc-aftt:encapsulation-header-type
         |        |     +--ro gre
         |        |     |  +--ro state
         |        |     |     +--ro src-ip?   oc-inet:ip-address
         |        |     |     +--ro dst-ip?   oc-inet:ip-address
         |        |     |     +--ro ttl?      uint8
+        |        |     |     +--ro dscp?     oc-inet:dscp
         +--rw protocols
```