### PR TITLE
Add a global config for encap-header attributes

### DIFF
--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -214,6 +214,8 @@ module openconfig-network-instance-static {
       description
         "Destination UDP port to use when the encapsulated payload is an
         MPLS packet.";
+      reference
+        "RFC 7510: Encapsulating MPLS in UDP";
     }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -170,7 +170,7 @@ module openconfig-network-instance-static {
 
     container encap-header-template {
       description
-        "Surrounding container for groups of encap-header templates.";
+        "Surrounding container for the global encapsulation header template.";
 
       container config {
         description

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -11,6 +11,7 @@ module openconfig-network-instance-static {
   import openconfig-aft { prefix "oc-aft"; }
   import openconfig-aft-types { prefix "oc-aftt"; }
   import openconfig-local-routing { prefix "oc-loc-rt"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
 
   // meta
   organization "OpenConfig working group";
@@ -22,7 +23,13 @@ module openconfig-network-instance-static {
   description
     "Static configurations associated with a network instance";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2026-07-07" {
+    description
+      "Add a global encapsulation header template for static next-hops.";
+    reference "0.3.0";
+  }
 
   revision "2025-08-05" {
     description
@@ -54,6 +61,12 @@ module openconfig-network-instance-static {
         description
           "Configuration and state parameters relating to
           statically configured next hop group";
+      }
+
+      uses static-encap-header-template-top {
+        description
+          "Configuration and state parameters relating to the global
+          encapsulation header template.";
       }
 
       uses static-next-hops-top {
@@ -148,6 +161,59 @@ module openconfig-network-instance-static {
       type string;
       description
         "A user defined name that uniquely identifies the next-hop-group.";
+    }
+  }
+
+  grouping static-encap-header-template-top {
+    description
+      "Logical grouping for the global encapsulation header template.";
+
+    container encap-header-template {
+      description
+        "Surrounding container for groups of encap-header templates.";
+
+      container config {
+        description
+          "Configuration parameters relating to the encapsulation header
+          template.";
+
+        uses static-encap-header-template;
+      }
+
+      container state {
+        config false;
+        description
+          "State parameters relating to the encapsulation header template.";
+
+        uses static-encap-header-template;
+      }
+    }
+  }
+
+  grouping static-encap-header-template {
+    description
+      "Configuration parameters for the global encapsulation header
+      template.";
+
+    leaf ipv4-dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Destination UDP port to use when the encapsulated payload is an
+        IPv4 packet.";
+    }
+
+    leaf ipv6-dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Destination UDP port to use when the encapsulated payload is an
+        IPv6 packet.";
+    }
+
+    leaf mpls-dst-udp-port {
+      type oc-inet:port-number;
+      description
+        "Destination UDP port to use when the encapsulated payload is an
+        MPLS packet.";
     }
   }
 

--- a/release/models/network-instance/openconfig-network-instance-static.yang
+++ b/release/models/network-instance/openconfig-network-instance-static.yang
@@ -27,7 +27,7 @@ module openconfig-network-instance-static {
 
   revision "2026-07-07" {
     description
-      "Add a global encapsulation header template for static next-hops.";
+      "Add a global encapsulation header configurations for static next-hops.";
     reference "0.3.0";
   }
 
@@ -63,10 +63,10 @@ module openconfig-network-instance-static {
           statically configured next hop group";
       }
 
-      uses static-encap-header-template-top {
+      uses static-global-encap-header-top {
         description
           "Configuration and state parameters relating to the global
-          encapsulation header template.";
+          encapsulation header.";
       }
 
       uses static-next-hops-top {
@@ -164,36 +164,34 @@ module openconfig-network-instance-static {
     }
   }
 
-  grouping static-encap-header-template-top {
+  grouping static-global-encap-header-top {
     description
-      "Logical grouping for the global encapsulation header template.";
+      "Logical grouping for the global encapsulation header.";
 
-    container encap-header-template {
+    container encap-header {
       description
-        "Surrounding container for the global encapsulation header template.";
+        "Surrounding container for the global encapsulation header.";
 
       container config {
         description
-          "Configuration parameters relating to the encapsulation header
-          template.";
+          "Configuration parameters relating to the global encapsulation header.";
 
-        uses static-encap-header-template;
+        uses static-global-encap-header;
       }
 
       container state {
         config false;
         description
-          "State parameters relating to the encapsulation header template.";
+          "State parameters relating to the global encapsulation header.";
 
-        uses static-encap-header-template;
+        uses static-global-encap-header;
       }
     }
   }
 
-  grouping static-encap-header-template {
+  grouping static-global-encap-header {
     description
-      "Configuration parameters for the global encapsulation header
-      template.";
+      "Configuration parameters for the global encapsulation header.";
 
     leaf ipv4-dst-udp-port {
       type oc-inet:port-number;


### PR DESCRIPTION
### Change Scope

* Add global configuration for encapsulation headers configured for static next-hops.
* The global configuration mainly contains UDP destination port info.


### Tree View

```diff
  +--rw network-instances
        +--rw static
+       |  +--rw encap-header
+       |  |  +--rw config
+       |  |  |  +--rw ipv4-dst-udp-port?   oc-inet:port-number
+       |  |  |  +--rw ipv6-dst-udp-port?   oc-inet:port-number
+       |  |  |  +--rw mpls-dst-udp-port?   oc-inet:port-number
+       |  |  +--ro state
+       |  |     +--ro ipv4-dst-udp-port?   oc-inet:port-number
+       |  |     +--ro ipv6-dst-udp-port?   oc-inet:port-number
+       |  |     +--ro mpls-dst-udp-port?   oc-inet:port-number
        |  +--rw next-hops
        |     +--rw next-hop* [index]
        |        +--rw index            -> ../config/index
        |        +--rw config
        |        |  +--rw index?          string
        |        |  +--rw next-hop?       union
        |        |  +--rw recurse?        boolean
        |        |  +--rw metric?         uint32
        |        |  +--rw preference?     uint32
        |        |  +--rw wecmp-weight?   union
        |        +--ro state
        |        |  +--ro index?          string
        |        |  +--ro next-hop?       union
        |        |  +--ro recurse?        boolean
        |        |  +--ro metric?         uint32
        |        |  +--ro preference?     uint32
        |        |  +--ro wecmp-weight?   union
        |        +--rw encap-headers
        |           +--rw encap-header* [index]
        |              +--rw index     -> ../config/index
        |              +--rw config
        |              |  +--rw index?   uint8
        |              |  +--rw type?    oc-aftt:encapsulation-header-type
        |              +--ro state
        |              |  +--ro index?   uint8
        |              |  +--ro type?    oc-aftt:encapsulation-header-type
        |              +--rw udp-v4
        |              |  +--rw config
        |              |  |  +--rw src-ip?         oc-inet:ipv4-address
        |              |  |  +--rw dst-ip?         oc-inet:ipv4-address
        |              |  |  +--rw dscp?           oc-inet:dscp
        |              |  |  +--rw src-udp-port?   oc-inet:port-number
        |              |  |  +--rw dst-udp-port?   oc-inet:port-number
        |              |  |  +--rw ip-ttl?         uint8
        |              |  +--ro state
        |              |     +--ro src-ip?         oc-inet:ipv4-address
        |              |     +--ro dst-ip?         oc-inet:ipv4-address
        |              |     +--ro dscp?           oc-inet:dscp
        |              |     +--ro src-udp-port?   oc-inet:port-number
        |              |     +--ro dst-udp-port?   oc-inet:port-number
        |              |     +--ro ip-ttl?         uint8
```
