### PR TITLE
Add operational power state reporting for platform components

### DIFF
--- a/release/models/platform/openconfig-platform-common.yang
+++ b/release/models/platform/openconfig-platform-common.yang
@@ -20,7 +20,14 @@ submodule openconfig-platform-common {
     "This modules contains common groupings that are used in multiple
     components within the platform module.";
 
-  oc-ext:openconfig-version "0.32.0";
+  oc-ext:openconfig-version "0.33.0";
+
+  revision "2026-07-08" {
+    description
+      "Add component-power-management-state grouping with the
+      read-only power-oper-state leaf.";
+    reference "0.33.0";
+  }
 
   revision "2025-07-15" {
     description
@@ -286,6 +293,30 @@ revision "2024-10-13" {
         from becoming active even after a reboot of the system. A component
         (if controller-card) may not honor power-admin-state depending on rules
         defined in the description of the component config container.";
+    }
+  }
+
+  grouping component-power-management-state {
+    description
+      "Common grouping for reporting the operational power state of a
+      component";
+
+    leaf power-oper-state {
+      type oc-platform-types:component-power-oper-type;
+      description
+        "The operational power state of the component.  Whereas
+        power-admin-state reflects the configured (intended) power
+        state, power-oper-state reflects the actual, applied power
+        state as observed by the system.
+
+        While a power change is in progress, for example when a
+        component is being powered down but has not yet fully powered
+        off, this leaf reports POWER_TRANSITIONING and does not report
+        POWER_DISABLED until the component has fully powered off.  This
+        provides a consistent operational view across telemetry and
+        other management interfaces and allows management systems to
+        avoid initiating a subsequent power operation before the
+        current transition has completed.";
     }
   }
 

--- a/release/models/platform/openconfig-platform-controller-card.yang
+++ b/release/models/platform/openconfig-platform-controller-card.yang
@@ -22,7 +22,13 @@ module openconfig-platform-controller-card {
     "This module defines data related to CONTROLLER_CARD components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2026-07-08" {
+    description
+      "Add read-only power-oper-state leaf to controller-card state.";
+    reference "0.3.0";
+  }
 
   revision "2024-04-10" {
     description
@@ -83,6 +89,7 @@ module openconfig-platform-controller-card {
       is only valid when the type of the component is CONTROLLER_CARD.";
 
     uses controller-card-config;
+    uses oc-platform:component-power-management-state;
   }
 
   // rpc statements

--- a/release/models/platform/openconfig-platform-fabric.yang
+++ b/release/models/platform/openconfig-platform-fabric.yang
@@ -22,7 +22,13 @@ module openconfig-platform-fabric {
     "This module defines data related to FABRIC components in
     the openconfig-platform model";
 
-  oc-ext:openconfig-version "0.1.0";
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2026-07-08" {
+    description
+      "Add read-only power-oper-state leaf to fabric state.";
+    reference "0.2.0";
+  }
 
   revision "2022-07-28" {
     description
@@ -71,6 +77,7 @@ module openconfig-platform-fabric {
       is only valid when the type of the component is FABRIC.";
 
     uses fabric-config;
+    uses oc-platform:component-power-management-state;
   }
 
   // rpc statements

--- a/release/models/platform/openconfig-platform-linecard.yang
+++ b/release/models/platform/openconfig-platform-linecard.yang
@@ -22,7 +22,13 @@ module openconfig-platform-linecard {
     "This module defines data related to LINECARD components in
     the openconfig-platform model";
 
-oc-ext:openconfig-version "1.2.0";
+oc-ext:openconfig-version "1.3.0";
+
+   revision "2026-07-08" {
+    description
+      "Add read-only power-oper-state leaf to linecard state.";
+    reference "1.3.0";
+  }
 
    revision "2024-04-12" {
     description
@@ -132,6 +138,7 @@ oc-ext:openconfig-version "1.2.0";
 
         uses linecard-config;
         uses linecard-state;
+        uses oc-platform:component-power-management-state;
       }
       uses oc-platform:platform-resource-utilization-top;
     }

--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,15 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.12.0";
+  oc-ext:openconfig-version "1.13.0";
+
+revision "2026-07-08" {
+    description
+      "Add component-power-oper-type typedef with POWER_TRANSITIONING
+      to reflect the operational power state of a component,
+      including transient transitions.";
+    reference "1.13.0";
+  }
 
 revision "2026-05-19" {
     description
@@ -579,6 +587,32 @@ revision "2025-07-09" {
     description
       "A generic type reflecting whether a hardware component
       is powered on or off";
+  }
+
+  typedef component-power-oper-type {
+    type enumeration {
+      enum POWER_ENABLED {
+        description
+          "The component is powered on.";
+      }
+      enum POWER_DISABLED {
+        description
+          "The component is powered off.";
+      }
+      enum POWER_TRANSITIONING {
+        description
+          "The component is transitioning between the POWER_ENABLED and
+          POWER_DISABLED states, for example while it is being powered
+          down but has not yet fully powered off, or while it is being
+          powered up but is not yet fully powered on.";
+      }
+    }
+    description
+      "A generic type reflecting the operational power state of a
+      hardware component.  This is the operational counterpart to
+      component-power-type (the configured, intended power state) and
+      may include operational-only values that are not valid as
+      configuration.";
   }
 
   identity COMPONENT_REBOOT_REASON {

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,14 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.32.0";
+  oc-ext:openconfig-version "0.33.0";
+
+  revision "2026-07-08" {
+    description
+      "Add component-power-management-state grouping with the
+      read-only power-oper-state leaf.";
+    reference "0.33.0";
+  }
 
   revision "2025-07-15" {
     description


### PR DESCRIPTION
  * (M) release/models/platform/openconfig-platform-types.yang
    - Add component-power-oper-type typedef with an operational-only
      POWER_TRANSITIONING value alongside POWER_ENABLED/POWER_DISABLED
    - Increment version to 1.13.0
  * (M) release/models/platform/openconfig-platform-common.yang
    - Add component-power-management-state grouping with the read-only
      power-oper-state leaf as the operational counterpart to
      power-admin-state
    - Increment version to 0.33.0
  * (M) release/models/platform/openconfig-platform-controller-card.yang
    - Add power-oper-state to controller-card state
    - Increment version to 0.3.0
  * (M) release/models/platform/openconfig-platform-fabric.yang
    - Add power-oper-state to fabric state
    - Increment version to 0.2.0
  * (M) release/models/platform/openconfig-platform-linecard.yang
    - Add power-oper-state to linecard state
    - Increment version to 1.3.0
  * (M) release/models/platform/openconfig-platform.yang
  - Increment version to 0.33.0 to track openconfig-platform-common
    submodule revision

### Change Scope

The `power-admin-state` leaf reflects the configured (intended) power state
of a component and today is the only power state modeled, with values of
`POWER_ENABLED` or `POWER_DISABLED`.  There is no path that reports the
actual, applied power state, so a configured value that is mirrored into
state is the only operational signal available.

This is problematic during a power transition.  When a redundant
controller-card is powered down, a component is neither cleanly enabled nor
disabled while the shutdown is in progress, yet only those two values can be
represented.  Consumers relying on state to gate a subsequent power
operation can therefore act prematurely - e.g. a `POWERUP` issued after
state reports `POWER_DISABLED`, but before the node has fully powered off,
is rejected as already online.

Introduce a read-only `power-oper-state` leaf as the operational
counterpart to `power-admin-state`, following the same intent vs.
operational split modeled by interface `admin-status`/`oper-status`.  A new
`component-power-oper-type` typedef mirrors `component-power-type` and adds
an operational-only `POWER_TRANSITIONING` value that is not valid as
configuration.  A component reports `POWER_TRANSITIONING` while a power
change is in progress and only reports `POWER_DISABLED` once it has fully
powered off, giving a consistent operational view across telemetry and
other management interfaces.

`power-admin-state` is reused across controller-card, fabric and linecard
components, so `power-oper-state` is added as a state-only sibling to the
same set of components.

### Platform Implementations

N/A

### Tree View

```diff
module: openconfig-platform
  +--rw components
     +--rw component* [name]
        +--rw controller-card
        |  +--rw config
        |  |  +--rw oc-ctrl-card:power-admin-state?   oc-platform-types:component-power-type
        |  +--ro state
        |     +--ro oc-ctrl-card:power-admin-state?   oc-platform-types:component-power-type
+       |     +--ro oc-ctrl-card:power-oper-state?    oc-platform-types:component-power-oper-type
        +--rw fabric
        |  +--rw config
        |  |  +--rw oc-fabric:power-admin-state?   oc-platform-types:component-power-type
        |  +--ro state
        |     +--ro oc-fabric:power-admin-state?   oc-platform-types:component-power-type
+       |     +--ro oc-fabric:power-oper-state?    oc-platform-types:component-power-oper-type
        +--rw oc-linecard:linecard
           +--rw oc-linecard:config
           |  +--rw oc-linecard:power-admin-state?   oc-platform-types:component-power-type
           +--ro oc-linecard:state
              +--ro oc-linecard:power-admin-state?   oc-platform-types:component-power-type
+             +--ro oc-linecard:power-oper-state?    oc-platform-types:component-power-oper-type
```
