### PR TITLE
Deprecate cpu-utilization and add cpu-utilization-pct for multi-core support

### DIFF
--- a/release/models/system/openconfig-procmon.yang
+++ b/release/models/system/openconfig-procmon.yang
@@ -25,7 +25,15 @@ module openconfig-procmon {
     "This module provides data definitions for process health
     monitoring of one or more processes running on the system.";
 
-  oc-ext:openconfig-version "0.4.0";
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2026-07-13" {
+    description
+      "Change cpu-utilization type from oc-types:percentage to
+      uint16 to support multi-core systems where CPU utilization
+      can exceed 100 percent.";
+    reference "0.5.0";
+  }
 
   revision "2019-03-15" {
     description
@@ -153,9 +161,11 @@ module openconfig-procmon {
     }
 
     leaf cpu-utilization {
-      type oc-types:percentage;
+      type uint16;
       description
-        "The percentage of CPU that is being used by the process.";
+        "The percentage of CPU that is being used by the process.
+        On multi-core systems, this value may exceed 100 percent,
+        up to 100 percent per core.";
     }
 
     leaf memory-usage {

--- a/release/models/system/openconfig-procmon.yang
+++ b/release/models/system/openconfig-procmon.yang
@@ -27,10 +27,10 @@ module openconfig-procmon {
 
   oc-ext:openconfig-version "0.5.0";
 
-  revision "2026-07-13" {
+  revision "2026-07-14" {
     description
-      "Change cpu-utilization type from oc-types:percentage to
-      uint16 to support multi-core systems where CPU utilization
+      "Deprecate cpu-utilization and add cpu-utilization-pct as
+      uint32 to support multi-core systems where CPU utilization
       can exceed 100 percent.";
     reference "0.5.0";
   }
@@ -161,7 +161,18 @@ module openconfig-procmon {
     }
 
     leaf cpu-utilization {
-      type uint16;
+      status deprecated;
+      type oc-types:percentage;
+      description
+        "The percentage of CPU that is being used by the process.
+        This leaf is deprecated because its type constrains values
+        to 0-100, which is insufficient for multi-core systems.
+        Use cpu-utilization-pct instead.";
+    }
+
+    leaf cpu-utilization-pct {
+      type uint32;
+      units "percent";
       description
         "The percentage of CPU that is being used by the process.
         On multi-core systems, this value may exceed 100 percent,

--- a/release/models/system/openconfig-procmon.yang
+++ b/release/models/system/openconfig-procmon.yang
@@ -27,7 +27,7 @@ module openconfig-procmon {
 
   oc-ext:openconfig-version "0.5.0";
 
-  revision "2026-07-14" {
+  revision "2026-08-13" {
     description
       "Deprecate cpu-utilization and add cpu-utilization-pct as
       uint32 to support multi-core systems where CPU utilization

--- a/release/models/system/openconfig-procmon.yang
+++ b/release/models/system/openconfig-procmon.yang
@@ -171,12 +171,7 @@ module openconfig-procmon {
     }
 
     leaf cpu-utilization-pct {
-      type uint32;
-      units "percent";
-      description
-        "The percentage of CPU that is being used by the process.
-        On multi-core systems, this value may exceed 100 percent,
-        up to 100 percent per core.";
+      type oc-types:multi-core-percentage;
     }
 
     leaf memory-usage {

--- a/release/models/types/openconfig-types.yang
+++ b/release/models/types/openconfig-types.yang
@@ -21,7 +21,13 @@ module openconfig-types {
     are used across OpenConfig models. It can be imported by modules
     that make use of these types.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2026-08-13" {
+    description
+      "Add multi-core-percentage type.";
+    reference "1.1.0";
+  }
 
   revision "2024-01-31" {
     description
@@ -95,6 +101,15 @@ module openconfig-types {
     }
     description
       "Integer indicating a percentage value";
+  }
+
+  typedef multi-core-percentage {
+    type uint32;
+    units "percent";
+    description
+      "The percentage of CPU that is being used by the process.
+      On multi-core systems, this value may exceed 100 percent,
+      up to 100 percent per core.";
   }
 
   typedef std-regexp {


### PR DESCRIPTION
## Summary
- Deprecate the existing `cpu-utilization` leaf (`oc-types:percentage`, uint8 range 0-100)
- Add new `cpu-utilization-pct` leaf with `uint32` type to support multi-core systems where per-process CPU utilization can exceed 100%
- Bump module version from 0.4.0 to 0.5.0

## Background
The `cpu-utilization` leaf under `/system/processes/process/state` is backed by `/proc/PID/stat` in Linux-based implementations. On multi-core systems, a process using multiple cores can report CPU utilization exceeding 100% (up to 100% per core). The previous type `oc-types:percentage` restricts values to 0-100, which is insufficient.

A new leaf is added instead of modifying the existing type to preserve backward compatibility — downstream consumers may have strict type handling or run mixed model versions.

## Test plan
- [ ] Verify YANG model compiles with `pyang`
- [ ] Validate backward compatibility with existing consumers of `cpu-utilization`