### PR TITLE
Add ingress link-down discard counter to Ethernet interface counters

### DIFF
--- a/release/models/interfaces/openconfig-if-ethernet.yang
+++ b/release/models/interfaces/openconfig-if-ethernet.yang
@@ -26,7 +26,13 @@ module openconfig-if-ethernet {
     "Model for managing Ethernet interfaces -- augments the OpenConfig
     model for interface configuration and state.";
 
-  oc-ext:openconfig-version "2.18.0";
+  oc-ext:openconfig-version "2.19.0";
+
+  revision "2026-07-15" {
+    description
+      "Add ingress link-down discard counter to Ethernet interface counters.";
+    reference "2.19.0";
+  }
 
   revision "2026-06-22" {
     description
@@ -658,6 +664,18 @@ module openconfig-if-ethernet {
         "The total number frames received that are well-formed but
         dropped due to exceeding the maximum frame size on the interface
         (e.g., MTU or MRU)";
+    }
+
+    leaf in-link-down-discards {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets received on the interface that
+        were dropped because the egress interface or next-hop link
+        selected by forwarding or routing was down.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
 
     // egress counters


### PR DESCRIPTION
This change introduces a new operational state counter in-link-down-discards under Ethernet interface counters (/interfaces/interface/ethernet/state/counters/in-link-down-discards) to track ingress packets dropped due to egress link-down forwarding conditions. The version has been bumped to `2.19.0` in `openconfig-if-ethernet.yang`.

Change-Id: I38c19a483b18e47f583c81a0b98597888405892f

### Change Scope
* **Description:** This PR introduces `in-link-down-discards` to `openconfig-if-ethernet.yang` to count ingress packets discarded because the resolved egress interface or next-hop link selected by forwarding or routing was down.
* **Backwards Compatibility:** This change is fully backward compatible as it only adds a new read-only operational state leaf counter to the existing `ethernet-interface-state-counters` grouping.

### Use case
This counter is designed for production network debugging and automated failure pinpointing. Silent packet discards in large-scale fabrics are difficult to diagnose using generic discard counters alone. Providing an explicit counter for inbound packet drops due to egress link-down forwarding failures (`in-link-down-discards`) allows network operators and SRE tools to distinguish forwarding blackholes caused by downstream link failures from normal traffic discards.

### Platform Implementations
- SAI specification defines an explicit debug drop reason for egress link down conditions: `SAI_IN_DROP_REASON_EGRESS_LINK_DOWN` ([SAI Debug Counters Proposal](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-Debug-Counters.md)).
- Google network switches export granular ingress link-down drop telemetry via UMF and SAI debug counters.
- Broadcom / SONiC ASIC telemetry pipelines support per-port ingress drop counting for egress link-down events.

### Tree View
```diff
module: openconfig-if-ethernet
  +--rw interfaces
     +--rw interface* [name]
        +--rw oc-eth:ethernet
           +--ro oc-eth:state
              +--ro oc-eth:counters
                 +--ro oc-eth:in-maxsize-exceeded?      oc-yang:counter64
+                +--ro oc-eth:in-link-down-discards?    oc-yang:counter64

