### PR TITLE
Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL

### DIFF
--- a/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
+++ b/release/models/bgp/openconfig-bgp-common-multiprotocol.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common-multiprotocol {
     for multiple protocols in BGP. The groupings are common across
     multiple contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common-structure.yang
+++ b/release/models/bgp/openconfig-bgp-common-structure.yang
@@ -21,7 +21,13 @@ submodule openconfig-bgp-common-structure {
     "This sub-module contains groupings that are common across multiple BGP
     contexts and provide structure around other primitive groupings.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -542,9 +542,8 @@ submodule openconfig-bgp-common {
           }
           enum ADDPATH_ALL {
             description
-              "Enable capability negotiation to send multiple paths,
-              and select/advertise the top N best paths to the peer,
-              up to the threshold defined by the send-max leaf.";
+              "Enable capability negotiation to send all RIB/FIB paths
+              to the peer.";
           }
         }
       }

--- a/release/models/bgp/openconfig-bgp-common.yang
+++ b/release/models/bgp/openconfig-bgp-common.yang
@@ -24,7 +24,13 @@ submodule openconfig-bgp-common {
     may be application to a subset of global, peer-group or neighbor
     contexts.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description
@@ -525,11 +531,29 @@ submodule openconfig-bgp-common {
     }
 
     leaf send {
-      type boolean;
+      type union {
+        type boolean;
+        type enumeration {
+          enum ADDPATH_ECMP {
+            description
+              "Enable capability negotiation to send multiple paths,
+              and select/advertise all active ECMP paths
+              for a destination to the peer.";
+          }
+          enum ADDPATH_ALL {
+            description
+              "Enable capability negotiation to send multiple paths,
+              and select/advertise the top N best paths to the peer,
+              up to the threshold defined by the send-max leaf.";
+          }
+        }
+      }
       default false;
       description
         "Enable capability negotiation to send multiple path
-        advertisements for an NLRI from the neighbor or group";
+        advertisements for an NLRI from the neighbor or group.
+        Supports both backward-compatible boolean toggles or explicit
+        selection modes (ADDPATH_ECMP, ADDPATH_ALL).";
       reference
         "RFC 7911 - Advertisement of Multiple Paths in BGP";
     }

--- a/release/models/bgp/openconfig-bgp-global.yang
+++ b/release/models/bgp/openconfig-bgp-global.yang
@@ -27,7 +27,13 @@ submodule openconfig-bgp-global {
     "This sub-module contains groupings that are specific to the
     global context of the OpenConfig BGP module";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-neighbor.yang
+++ b/release/models/bgp/openconfig-bgp-neighbor.yang
@@ -30,7 +30,13 @@ submodule openconfig-bgp-neighbor {
     "This sub-module contains groupings that are specific to the
     neighbor context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp-peer-group.yang
+++ b/release/models/bgp/openconfig-bgp-peer-group.yang
@@ -25,7 +25,13 @@ submodule openconfig-bgp-peer-group {
     "This sub-module contains groupings that are specific to the
     peer-group context of the OpenConfig BGP module.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description

--- a/release/models/bgp/openconfig-bgp.yang
+++ b/release/models/bgp/openconfig-bgp.yang
@@ -68,7 +68,13 @@ module openconfig-bgp {
     whereas leaf not present inherits its value from the leaf present
     at the next higher level in the hierarchy.";
 
-  oc-ext:openconfig-version "9.9.1";
+  oc-ext:openconfig-version "9.9.2";
+
+  revision "2026-07-15" {
+    description
+      "Extend Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL";
+    reference "9.9.2";
+  }
 
   revision "2025-04-18" {
     description


### PR DESCRIPTION
This proposal extends Add-path Send leaf with values ADDPATH-ECMP and ADDPATH-ALL to add support ecmp and send all paths within add-path feature.

### Platform Implementations

1.  Arista Feature Documentation: BGP Additional Paths (Add-Path)

bgp additional-paths send ecmp (Advertises all ECMP multipaths)
bgp additional-paths send any (Advertises all paths)
bgp additional-paths send limit <N> (Limits the best-path advertisement count)
bgp additional-paths receive

2. Cisco (IOS-XR)

additional-paths send / additional-paths receive
additional-paths selection route-policy <POLICY>
RPL policy action: set path-selection multipath advertise or set path-selection all advertise.

**Cisco should natively translate the enum values ADDPATH_ALL and ADDPATH_ECMP to the appropriate route-policy**
Example route-policy:

```
route-policy ADDPATH-ECMP
  set path-selection multipath advertise
end-policy
! 

```
3. Juniper (Junos)
path-count <N>
path-selection-mode equal-cost-paths 
path-selection-mode all-paths 

4. Nokia (SR Linux)

network-instance protocols bgp afi-safi ipv4-unicast add-paths send true
send-max <N>
Coupled with the BGP Multipath configuration (protocols bgp afi-safi ipv4-unicast multipath) to advertise ECMP ranges.

### Tree View

```diff
 module: openconfig-bgp-common
         |     |  |     |     +--rw add-paths
         |     |  |     |     |  +--rw config
         |     |  |     |     |  |  +--rw receive?                  boolean
-        |     |  |     |     |  |  +--rw send?                     boolean
+        |     |  |     |     |  |  +--rw send?                     union
         |     |  |     |     |  |  +--rw send-max?                 uint8
         |     |  |     |     |  |  +--rw eligible-prefix-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
         |     |  |     |     |  +--ro state
         |     |  |     |     |     +--ro receive?                  boolean
-        |     |  |     |     |     +--ro send?                     boolean
+        |     |  |     |     |     +--ro send?                     union
         |     |  |     |     |     +--ro send-max?                 uint8
         |     |  |     |     |     +--ro eligible-prefix-policy?   -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
         |     |  |     |     +--rw use-multiple-paths
         |     |  |     |     |  +--rw config

```
