### PR TITLE
Add mount-point inode and read-only operational state leaves

### DIFF
--- a/release/models/system/openconfig-system.yang
+++ b/release/models/system/openconfig-system.yang
@@ -48,7 +48,14 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.1.0";
+  oc-ext:openconfig-version "3.2.0";
+
+  revision "2026-07-20" {
+    description
+      "Add inode count, utilization, and read-only operational leaves
+      to mount-point state.";
+    reference "3.2.0";
+  }
 
   revision "2026-03-31" {
     description
@@ -450,6 +457,31 @@ module openconfig-system {
       description
         "This identify indicates the filesystem type used for storage.
         The string type exists to support backwards compatibility.";
+    }
+
+    leaf inodes-available {
+      type uint64;
+      description
+        "The number of free inodes available on the filesystem.";
+    }
+
+    leaf inodes-total {
+      type uint64;
+      description
+        "The total number of inodes on the filesystem.";
+    }
+
+    leaf inodes-utilized {
+      type uint64;
+      description
+        "The number of used inodes on the filesystem.";
+    }
+
+    leaf read-only {
+      type boolean;
+      description
+        "When true, indicates that the filesystem is mounted in read-only
+        mode.";
     }
   }
 


### PR DESCRIPTION
This change introduces new mount-point operational state leaves `inodes-total`, `inodes-available`, `inodes-utilized`, and `read-only` under `/system/mount-points/mount-point/state`. These complement the existing storage space leaves (`size`, `available`, `utilized`) by exposing inode capacity/utilization and mount mode for filesystem monitoring and troubleshooting.
The version has been bumped to `3.2.0` in `openconfig-system.yang`.

Change-Id: Ia25932ff09415b97d0960384579a37a4013d8183

### Change Scope

- **Description:** This PR adds operational state leaves to the `mount-point-state` grouping in `openconfig-system.yang` for inode total/free/used counts and read-only mount status. `inodes-total` refers to total inode capacity; `inodes-available` refers to free/unused inodes; `inodes-utilized` mirrors the existing storage `utilized` leaf for used inode count.
- **Backwards Compatibility:** This change is fully backward compatible as it only adds new operational state leaves to an existing grouping.

### Use case

Filesystem exhaustion is a common cause of control-plane and application failures on network devices. While existing mount-point leaves report block storage (`size`, `available`, `utilized`), operators also need inode utilization to detect cases where free space remains but file creation fails due to inode exhaustion. The `read-only` leaf surfaces mount mode changes that can silently block writes during disk pressure or maintenance events.

### Platform Implementations

- POSIX `statfs(2)` / `df` provide inode total and free counts on Linux-based NOS platforms.
https://man7.org/linux/man-pages/man1/df.1.html
https://man7.org/linux/man-pages/man2/statfs.2.html

https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/command/show-system-inventory-hardware-storage.html
https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/system-management/b-system-management/m-utility-commands.html#wp8767566250
https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-514/Monitoring-and-Troubleshooting/Monitoring-Best-Practices/


### Tree View

```diff
module: openconfig-system
  +--rw system
     ...
     +--rw mount-points
        +--rw mount-point* [name]
           ...
           +--ro state
              ...
              +--ro size?                uint64
              +--ro available?           uint64
              +--ro utilized?            uint64
              +--ro type?                 union
+             +--ro inodes-available?     uint64
+             +--ro inodes-total?         uint64
+             +--ro inodes-utilized?      uint64
+             +--ro read-only?             boolean
```
