### PR TITLE
Introduce recurse action in policy-forwarding

### DIFF
--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -756,6 +756,25 @@ grouping pf-forwarding-policy-action-forwarding-config {
         lookup on the local system.";
     }
 
+    leaf recurse {
+      type enumeration {
+        enum INCLUDE_DEFAULT_RT {
+          description
+            "Default route (0.0.0.0/0 or ::/0) is considered a
+            valid longest prefix.";
+        }
+        enum EXCLUDE_DEFAULT_RT {
+          description
+            "Default route (0.0.0.0/0 or ::/0) is NOT considered a
+            valid longest prefix.";
+        }
+      }
+      description
+        "Determines if the next-hop can be resolved recursively
+        via longest prefix match in FIB. If not enabled, only directly
+        connected routes can resolve the next-hop.";
+    }
+
     leaf next-hop-group {
       // we are at /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group
       type leafref {

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -27,6 +27,12 @@ submodule openconfig-pf-forwarding-policies {
 
   oc-ext:openconfig-version "1.2.0";
 
+  revision "2026-07-20" {
+    description
+      "Add recurse as a policy-forwarding action.";
+    reference "1.3.0";
+  }
+
   revision "2026-03-13" {
     description
       "Add count as a policy-forwarding action.";

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -775,6 +775,10 @@ grouping pf-forwarding-policy-action-forwarding-config {
             valid longest prefix.";
         }
       }
+      must "../next-hop" {
+        description
+          "The recurse leaf is valid only when next-hop is specified.";
+      }
       description
         "Determines if the next-hop can be resolved recursively
         via longest prefix match in FIB. If not enabled, only directly

--- a/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
+++ b/release/models/policy-forwarding/openconfig-pf-forwarding-policies.yang
@@ -781,8 +781,8 @@ grouping pf-forwarding-policy-action-forwarding-config {
       }
       description
         "Determines if the next-hop can be resolved recursively
-        via longest prefix match in FIB. If not enabled, only directly
-        connected routes can resolve the next-hop.";
+        via longest prefix match in FIB. If this leaf is not configured,
+        only directly connected routes can resolve the next-hop.";
     }
 
     leaf next-hop-group {


### PR DESCRIPTION
### Change Scope

* Introduce `recurse` within /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/
* This change is backwards compatible.

### Platform Implementations

Arista implementation document - https://www.arista.com/en/support/toi/eos-4-20-5f/14550#redirect-next-hop

Example config:
```
traffic-policies
   traffic-policy foo
      match m1 ipv4
         source prefix 10.0.0.0/24
         actions
            redirect next-hop recursive 20.0.0.1 <-- EXCLUDE_DEFAULT_RT
      match m2 ipv4
         source prefix 30.0.0.0/24
         actions
            redirect next-hop recursive include default 40.0.0.1 <-- INCLUDE_DEFAULT_RT
```

### Tree View

```diff
         +--rw policy-forwarding
         |  +--rw policies
         |  |  +--rw policy* [policy-id]
         |  |     +--rw rules
         |  |        +--rw rule* [sequence-id]
         |  |           +--rw action
         |  |           |  +--rw config
         |  |              |  +--rw log?                               boolean
         |  |              |  +--rw post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |              |  +--rw network-instance?                  -> /network-instances/network-instance/config/name
         |  |              |  +--rw path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |              |  +--rw next-hop?                          oc-inet:ip-address
+        |  |              |  +--rw recurse?                           enumeration
         |  |              |  +--rw next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |              |  +--rw decapsulate-mpls-in-udp?           boolean
         |  |              |  +--rw decapsulate-gue?                   boolean
         |  |              |  x--rw ip-ttl?                            uint8
         |  |              +--ro state
@@ -1569,10 +1570,11 @@
         |  |              |  +--ro log?                               boolean
         |  |              |  +--ro post-decap-network-instance?       -> /network-instances/network-instance/config/name
         |  |              |  +--ro network-instance?                  -> /network-instances/network-instance/config/name
         |  |              |  +--ro path-selection-group?              -> ../../../../../../../path-selection-groups/path-selection-group/config/group-id
         |  |              |  +--ro next-hop?                          oc-inet:ip-address
+        |  |              |  +--ro recurse?                           enumeration
         |  |              |  +--ro next-hop-group?                    -> ../../../../../../../../static/next-hop-groups/next-hop-group/config/name
         |  |              |  +--ro decapsulate-mpls-in-udp?           boolean
         |  |              |  +--ro decapsulate-gue?                   boolean
         |  |              |  x--ro ip-ttl?                            uint8
         |  |              +--rw encapsulate-gre
```