### PR TITLE
Add fan and temperature operational leaves to platform model

### DIFF
--- a/release/models/platform/openconfig-platform-fan.yang
+++ b/release/models/platform/openconfig-platform-fan.yang
@@ -22,7 +22,13 @@ module openconfig-platform-fan {
     "This module defines data related to FAN components in the
     OpenConfig platform model.";
 
-  oc-ext:openconfig-version "0.2.0";
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2026-07-21" {
+    description
+      "Add fan speed-percentage and direction operational leaves.";
+    reference "0.2.1";
+  }
 
   revision "2025-07-16" {
     description
@@ -125,6 +131,32 @@ module openconfig-platform-fan {
       units rpm;
       description
         "Current (instantaneous) fan speed";
+    }
+
+    leaf speed-percentage {
+      type uint8 {
+        range "0..100";
+      }
+      units "percent";
+      description
+        "Current fan speed as a percentage of maximum rated speed.
+         A value of 0 indicates the fan is stopped, and 100 indicates
+         maximum speed.";
+    }
+
+    leaf direction {
+      type enumeration {
+        enum intake {
+          description
+            "Fan airflow direction is intake (air drawn into the chassis).";
+        }
+        enum exhaust {
+          description
+            "Fan airflow direction is exhaust (air expelled from the chassis).";
+        }
+      }
+      description
+        "Current fan airflow direction.";
     }
   }
 

--- a/release/models/platform/openconfig-platform-fan.yang
+++ b/release/models/platform/openconfig-platform-fan.yang
@@ -22,12 +22,12 @@ module openconfig-platform-fan {
     "This module defines data related to FAN components in the
     OpenConfig platform model.";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "0.3.0";
 
   revision "2026-07-21" {
     description
       "Add fan speed-percentage and direction operational leaves.";
-    reference "0.2.1";
+    reference "0.3.0";
   }
 
   revision "2025-07-16" {

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,7 +65,13 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.32.0";
+  oc-ext:openconfig-version "0.32.1";
+
+  revision "2026-07-21" {
+    description
+      "Add critical high/low temperature threshold leaves.";
+    reference "0.32.1";
+  }
 
   revision "2025-07-15" {
     description
@@ -760,6 +766,24 @@ revision "2024-05-29" {
       }
       description
         "The severity of the current alarm.";
+    }
+
+    leaf critical-high-threshold {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "Critical high temperature threshold for this sensor.";
+    }
+
+    leaf critical-low-threshold {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "Critical low temperature threshold for this sensor.";
     }
   }
 

--- a/release/models/platform/openconfig-platform.yang
+++ b/release/models/platform/openconfig-platform.yang
@@ -65,12 +65,12 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.32.1";
+  oc-ext:openconfig-version "0.33.0";
 
   revision "2026-07-21" {
     description
       "Add critical high/low temperature threshold leaves.";
-    reference "0.32.1";
+    reference "0.33.0";
   }
 
   revision "2025-07-15" {


### PR DESCRIPTION
## Summary

- Add `speed-percentage` and `direction` to `fan-state` in `openconfig-platform-fan.yang` (0.2.1)
- Add `critical-high-threshold` and `critical-low-threshold` to `platform-component-temp-alarm-state` in `openconfig-platform.yang` (0.32.1)

## Motivation

These operational leaves belong in the canonical platform groupings rather than optional extension augments. Fan speed percentage, airflow direction, and temperature critical thresholds are standard platform telemetry.

## References 
https://www.cisco.com/c/en/us/td/docs/server_nw_virtual/2-5_release/command_reference/show.html#wp1121917
https://www.arista.com/en/um-eos/eos-environment-commands#xzx_uSqda3zF3U
https://arubanetworking.hpe.com/techdocs/AOS-CX/10.14/HTML/fundamentals_6200/Content/SysHW_cmds/sho-env-fan-10.htm
https://support.huawei.com/enterprise/en/doc/EDOC1100554480/c2f5c978/display-temperature
https://github.com/sonic-net/SONiC/blob/15e10c2a63a4b0543069bdd309721b83f23368c0/doc/pmon/pmon-chassis-design.md?plain=1#L333


## Test plan

- [x] YANG modules compile with openconfig-platform dependencies
- [x] No breaking changes to existing platform model paths
