### PR TITLE
Add prefix-set description and prefix entry sequence/action

### DIFF
--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -92,7 +92,14 @@ module openconfig-routing-policy {
     default value for the default-(import|export)-policy leaf must be
     applied.  See RFC6020 7.6.1 which applies to this model.";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2026-07-22" {
+    description
+      "Add prefix-set description and prefix entry sequence-number and
+       action leaves to support ordered BGP-style prefix lists.";
+    reference "3.6.0";
+  }
 
   revision "2024-11-26" {
     description
@@ -224,6 +231,22 @@ module openconfig-routing-policy {
 
   // grouping statements
 
+  typedef prefix-set-prefix-action-type {
+    type enumeration {
+      enum PERMIT {
+        description
+          "Permit routes that match the prefix entry.";
+      }
+      enum DENY {
+        description
+          "Deny routes that match the prefix entry.";
+      }
+    }
+    default PERMIT;
+    description
+      "Action to take for routes matching a prefix list entry.";
+  }
+
   grouping prefix-set-config {
     description
       "Configuration data for prefix sets used in policy
@@ -259,6 +282,12 @@ module openconfig-routing-policy {
         reject the configuration if there is a discrepancy.  The
         MIXED mode may not be supported on devices that require
         prefix sets to be of only one address family.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Optional human-readable description of the prefix set.";
     }
 
   }
@@ -344,6 +373,26 @@ module openconfig-routing-policy {
         Example: 10.3.192.0/21 would be expressed as
         prefix: 10.3.192.0/21,
         masklength-range: exact";
+    }
+
+    leaf sequence-number {
+      type uint32 {
+        range "1..4294967295";
+      }
+      description
+        "Sequence number for the prefix entry within the prefix set.
+         Prefix list implementations evaluate entries in ascending
+         sequence order.  The list key for prefix entries remains
+         ip-prefix and masklength-range; sequence-number is an
+         additional attribute used by implementations that require
+         explicit ordering or permit/deny semantics per entry.";
+    }
+
+    leaf action {
+      type prefix-set-prefix-action-type;
+      description
+        "Action applied to routes matching this prefix entry within
+         the prefix set.";
     }
   }
 


### PR DESCRIPTION
Extend openconfig-routing-policy for BGP-style prefix lists: optional prefix-set description and per-entry sequence-number and permit/deny action while retaining ip-prefix and masklength-range as list keys.

[Note: Please fill out the following template for your pull request. Replace
all the text in `[]` with your own content.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* [Please briefly describe the change that is being made to the models.]
* [Please indicate whether this change is backwards compatible.]

### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].

### Tree View

* [Please provide a view of the tree being modified.  It's preferred if a `diff` format is used for ease of review.]
* [Here are recommended steps to generate the tree view as a diff]

```
git checkout mychangebranch
pyang -f tree -p release/models/*/* > ~/new-tree.txt 
git checkout master
git pull
pyang -f tree -p release/models/*/* > ~/old-tree.txt
diff -bU 100 ~/old-tree.txt ~/new-tree.txt   | less
```

[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         +--ro state
         |  +--ro counters
         |  |  +--ro in-octets?               oc-yang:counter64
         |  |  +--ro in-pkts?                 oc-yang:counter64
         |  |  +--ro in-unicast-pkts?         oc-yang:counter64
         |  |  +--ro in-broadcast-pkts?       oc-yang:counter64
         |  |  +--ro in-multicast-pkts?       oc-yang:counter64
         |  |  +--ro in-errors?               oc-yang:counter64
         |  |  +--ro in-discards?             oc-yang:counter64
         |  |  +--ro out-octets?              oc-yang:counter64
         |  |  +--ro out-pkts?                oc-yang:counter64
         |  |  +--ro out-unicast-pkts?        oc-yang:counter64
         |  |  +--ro out-broadcast-pkts?      oc-yang:counter64
         |  |  +--ro out-multicast-pkts?      oc-yang:counter64
         |  |  +--ro out-discards?            oc-yang:counter64
         |  |  +--ro out-errors?              oc-yang:counter64
         |  |  +--ro last-clear?              oc-types:timeticks64
         |  |  +--ro in-unknown-protos?       oc-yang:counter64
         |  |  +--ro in-fcs-errors?           oc-yang:counter64
+        |  |  x--ro carrier-transitions?     oc-yang:counter64
-        |  |  +--ro carrier-transitions?     oc-yang:counter64
+        |  |  +--ro interface-transitions?   oc-yang:counter64
+        |  |  +--ro link-transitions?        oc-yang:counter64
         |  |  +--ro resets?                oc-yang:counter64
```
