### PR TITLE
Add support for PASSTHROUGH vlan stack action, outer and innter tag s…

### DIFF
--- a/release/models/vlan/openconfig-vlan-types.yang
+++ b/release/models/vlan/openconfig-vlan-types.yang
@@ -21,7 +21,23 @@ module openconfig-vlan-types {
     "This module defines configuration and state variables for VLANs,
     in addition to VLAN parameters associated with interfaces";
 
-  oc-ext:openconfig-version "3.2.0";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-07-23" {
+    description
+      "Pass the matched VLAN tag(s) through unmodified. No tag
+      push, pop, or swap operation is performed. The original
+      VLAN ID and priority (PCP/DEI) bits from the matched
+      client frame are preserved as-is on the network side.
+
+      This action is used when the subinterface encapsulation
+      requires that the original customer VLAN tag be carried
+      transparently through the network — for example, in
+      pseudowire services where the remote PE uses the VLAN
+      tag within the tunneled payload for service demultiplexing
+      or egress VLAN translation.";
+    reference "3.3.0";
+  }
 
   revision "2022-05-24" {
     description
@@ -272,6 +288,14 @@ module openconfig-vlan-types {
       enum SWAP {
         description
           "Swap the VLAN at the top of the VLAN stack.";
+      }
+      enum PASSTHROUGH {
+        description
+          "Pass the packet through without modifying the VLAN stack.
+           Used when a client-side dot1q VLAN is transparently carried
+           across the network unchanged, for both single-tagged
+           (client dot1q <id> network client) and double-tagged
+           (client dot1q outer <id> inner <id> network client) cases.";
       }
       // TODO: add push-push, pop-pop, push-swap etc
     }

--- a/release/models/vlan/openconfig-vlan.yang
+++ b/release/models/vlan/openconfig-vlan.yang
@@ -26,7 +26,14 @@ module openconfig-vlan {
     "This module defines configuration and state variables for VLANs,
     in addition to VLAN parameters associated with interfaces";
 
-  oc-ext:openconfig-version "3.2.2";
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2026-07-23" {
+    description
+      "Add optional outer-tag and inner-tag containers to ingress-mapping
+       and egress-mapping to support double-tagged network VLAN operations.";
+    reference "3.3.0";
+  }
 
   revision "2023-02-07" {
     description
@@ -690,6 +697,36 @@ module openconfig-vlan {
     }
   }
 
+  grouping vlan-logical-tag-mapping-config {
+    description
+      "Configuration for a single VLAN tag action used within ingress
+       or egress mapping (outer-tag or inner-tag).";
+
+    leaf vlan-stack-action {
+      type oc-vlan-types:vlan-stack-action;
+      description
+        "The action to take on this VLAN tag of a packet.";
+    }
+
+    leaf vlan-id {
+      type oc-vlan-types:vlan-id;
+      description
+        "Optionally specifies a fixed VLAN identifier used by the action
+         configured in 'vlan-stack-action'. This value must be non-zero
+         if the 'vlan-stack-action' is 'PUSH' or 'SWAP'.";
+    }
+
+    leaf tpid {
+      type identityref {
+        base oc-vlan-types:TPID_TYPES;
+      }
+      description
+        "Optionally override the tag protocol identifier field (TPID)
+         that is used by the action configured by 'vlan-stack-action'
+         when modifying the VLAN stack.";
+    }
+  }
+
   grouping vlan-logical-ingress-mapping-config {
     description
       "Configuration for ingress VLAN stack behaviors for
@@ -752,6 +789,44 @@ module openconfig-vlan {
 
         uses vlan-logical-ingress-mapping-config;
       }
+
+      container outer-tag {
+        description
+          "VLAN stack action applied to the outer VLAN tag of ingress
+           packets. Used for double-tagged operations where independent
+           per-tag actions are required.";
+
+        container config {
+          description
+            "Configuration for the outer tag ingress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+        container state {
+          config false;
+          description
+            "State for the outer tag ingress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+      }
+
+      container inner-tag {
+        description
+          "VLAN stack action applied to the inner VLAN tag of ingress
+           packets. Used for double-tagged operations where independent
+           per-tag actions are required.";
+
+        container config {
+          description
+            "Configuration for the inner tag ingress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+        container state {
+          config false;
+          description
+            "State for the inner tag ingress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+      }
     }
   }
 
@@ -811,6 +886,44 @@ module openconfig-vlan {
            that are destined for output via this subinterface.";
 
         uses vlan-logical-egress-mapping-config;
+      }
+
+      container outer-tag {
+        description
+          "VLAN stack action applied to the outer VLAN tag of egress
+           packets. Used for double-tagged operations where independent
+           per-tag actions are required.";
+
+        container config {
+          description
+            "Configuration for the outer tag egress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+        container state {
+          config false;
+          description
+            "State for the outer tag egress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+      }
+
+      container inner-tag {
+        description
+          "VLAN stack action applied to the inner VLAN tag of egress
+           packets. Used for double-tagged operations where independent
+           per-tag actions are required.";
+
+        container config {
+          description
+            "Configuration for the inner tag egress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
+        container state {
+          config false;
+          description
+            "State for the inner tag egress VLAN action.";
+          uses vlan-logical-tag-mapping-config;
+        }
       }
     }
   }


### PR DESCRIPTION
…upport in ingress and egress mapping

[Note: Please fill out the following template for your pull request. Replace
all the text in `[]` with your own content.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* [Please briefly describe the change that is being made to the models.]
* [Please indicate whether this change is backwards compatible.]

### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].

### Tree View

* [Please provide a view of the tree being modified.  It's preferred if a `diff` format is used for ease of review.]
* [Here are recommended steps to generate the tree view as a diff]

```
git checkout mychangebranch
pyang -f tree -p release/models/*/* > ~/new-tree.txt 
git checkout master
git pull
pyang -f tree -p release/models/*/* > ~/old-tree.txt
diff -bU 100 ~/old-tree.txt ~/new-tree.txt   | less
```

[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         +--ro state
         |  +--ro counters
         |  |  +--ro in-octets?               oc-yang:counter64
         |  |  +--ro in-pkts?                 oc-yang:counter64
         |  |  +--ro in-unicast-pkts?         oc-yang:counter64
         |  |  +--ro in-broadcast-pkts?       oc-yang:counter64
         |  |  +--ro in-multicast-pkts?       oc-yang:counter64
         |  |  +--ro in-errors?               oc-yang:counter64
         |  |  +--ro in-discards?             oc-yang:counter64
         |  |  +--ro out-octets?              oc-yang:counter64
         |  |  +--ro out-pkts?                oc-yang:counter64
         |  |  +--ro out-unicast-pkts?        oc-yang:counter64
         |  |  +--ro out-broadcast-pkts?      oc-yang:counter64
         |  |  +--ro out-multicast-pkts?      oc-yang:counter64
         |  |  +--ro out-discards?            oc-yang:counter64
         |  |  +--ro out-errors?              oc-yang:counter64
         |  |  +--ro last-clear?              oc-types:timeticks64
         |  |  +--ro in-unknown-protos?       oc-yang:counter64
         |  |  +--ro in-fcs-errors?           oc-yang:counter64
+        |  |  x--ro carrier-transitions?     oc-yang:counter64
-        |  |  +--ro carrier-transitions?     oc-yang:counter64
+        |  |  +--ro interface-transitions?   oc-yang:counter64
+        |  |  +--ro link-transitions?        oc-yang:counter64
         |  |  +--ro resets?                oc-yang:counter64
```
