### PR TITLE
Add ingress low-TTL discard counter to interface and subinterface counters

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.8.1";
+  oc-ext:openconfig-version "3.9.0";
+
+  revision "2026-07-15" {
+      description
+        "Add ingress low-TTL discard counter to subinterface counters.";
+      reference
+        "3.9.0";
+  }
 
   revision "2026-01-06" {
       description
@@ -1158,6 +1165,18 @@ module openconfig-interfaces {
         between up and down since the time the device restarted
         or the last-clear time, whichever is most recent.";
       oc-ext:telemetry-on-change;
+    }
+
+    leaf in-low-ttl-discards {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets received on the subinterface that
+        were dropped due to an expired Time-To-Live (TTL) or Hop Limit upon
+        routing lookup, indicating TTL expiration or routing loops.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
 
   }

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -1171,8 +1171,8 @@ module openconfig-interfaces {
       type oc-yang:counter64;
       description
         "The number of inbound packets received on the subinterface that
-        were dropped due to an expired Time-To-Live (TTL) or Hop Limit upon
-        routing lookup, indicating TTL expiration or routing loops.
+        were dropped due to an expired Time-To-Live (TTL) or Hop Limit during
+        transit forwarding, indicating TTL expiration or routing loops.
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -55,7 +55,8 @@ module openconfig-interfaces {
 
   revision "2026-07-15" {
       description
-        "Add ingress low-TTL discard counter to subinterface counters.";
+        "Add ingress low-TTL discard counter to interface and
+        subinterface counters.";
       reference
         "3.9.0";
   }
@@ -1013,6 +1014,19 @@ module openconfig-interfaces {
         the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
       oc-ext:telemetry-on-change;
     }
+
+    leaf in-low-ttl-discards {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets received on the interface or
+        subinterface that were dropped due to an expired Time-To-Live
+        (TTL) or Hop Limit during transit forwarding, indicating TTL
+        expiration or routing loops.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
+    }
   }
 
   grouping interface-counters-state {
@@ -1165,18 +1179,6 @@ module openconfig-interfaces {
         between up and down since the time the device restarted
         or the last-clear time, whichever is most recent.";
       oc-ext:telemetry-on-change;
-    }
-
-    leaf in-low-ttl-discards {
-      type oc-yang:counter64;
-      description
-        "The number of inbound packets received on the subinterface that
-        were dropped due to an expired Time-To-Live (TTL) or Hop Limit during
-        transit forwarding, indicating TTL expiration or routing loops.
-
-        Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of 'last-clear'.";
     }
 
   }


### PR DESCRIPTION
# Add ingress low-TTL discard counter to interface and subinterface counters

This change introduces a new operational state counter `in-low-ttl-discards` under common interface counters (`/interfaces/interface/state/counters/in-low-ttl-discards` and `/interfaces/interface/subinterfaces/subinterface/state/counters/in-low-ttl-discards`) to track ingress packets dropped due to Time-To-Live (TTL) or Hop Limit expiration during transit forwarding.
The version has been bumped to `3.9.0` in `openconfig-interfaces.yang`.

Change-Id: I2eb15fbed7f42d17dbca3e6a789befd41993f6f9

### Change Scope
* **Description:** This PR introduces `in-low-ttl-discards` to `openconfig-interfaces.yang` (under `interface-common-counters-state`) to count ingress packets discarded on a routed interface or subinterface due to TTL or Hop Limit expiration.
* **Backwards Compatibility:** This change is fully backward compatible as it only adds a new read-only operational state leaf counter to the existing `interface-common-counters-state` grouping.

### Use case
This counter is designed for production network debugging and automated failure pinpointing. Silent packet discards in routed fabrics are difficult to diagnose using generic discard counters alone. Providing an explicit counter for TTL expiration drops (`in-low-ttl-discards`) allows network operators and SRE tools to quickly identify routing loops and TTL-expired discards at both interface and subinterface granularity.

### Platform Implementations
- **SAI Specification:** SAI specification defines an explicit debug drop reason for TTL expiration: `SAI_IN_DROP_REASON_TTL` ([SAI Debug Counters Proposal](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-Debug-Counters.md#L107)).
- **Google Switch Telemetry:** Google network switches export granular ingress TTL drop telemetry via UMF and SAI debug counters.
- **[Cisco IOS IP Application Services Command Reference](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipapp/iap-cr-book.pdf) P202:** Exposes bad hop count traffic statistics (`show ip traffic interface ethernet 0/0` shows `hop count exceeded`).
- **[Nvidia / Mellanox (WJH)](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-513/Monitoring-and-Troubleshooting/Network-Troubleshooting/Mellanox-WJH/#router-drops):** Tracks router drops due to TTL expiration (`Router Drops -> TTL value is too small`).
- **SONiC / Broadcom Telemetry:** Pipeline counters support per-port ingress drop counting for TTL expiration events.

### Tree View
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         ...
         +--ro state
         |  +--ro counters
         |     +--ro out-discards?            oc-yang:counter64
         |     +--ro out-errors?              oc-yang:counter64
         |     +--ro last-clear?              oc-types:timeticks64
+        |     +--ro in-low-ttl-discards?     oc-yang:counter64
         ...
         +--rw subinterfaces
            +--rw subinterface* [index]
               ...
               +--ro state
                  +--ro counters
                     +--ro out-discards?           oc-yang:counter64
                     +--ro out-errors?             oc-yang:counter64
                     +--ro last-clear?             oc-types:timeticks64
+                    +--ro in-low-ttl-discards?    oc-yang:counter64
