### PR TITLE
Add ingress link-down discard counter to interface and subinterface counters

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.8.1";
+  oc-ext:openconfig-version "3.9.0";
+
+  revision "2026-07-15" {
+      description
+        "Add ingress link-down discard counter to interface counters.";
+      reference
+        "3.9.0";
+  }
 
   revision "2026-01-06" {
       description
@@ -878,6 +885,18 @@ module openconfig-interfaces {
         "RFC 2863: The Interfaces Group MIB - ifInDiscards.
         RFC 4293: Management Information Base for the
         Internet Protocol (IP).";
+    }
+
+    leaf in-link-down-discards {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets received on the interface that
+        were dropped because the egress interface or next-hop link
+        selected by forwarding or routing was down.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
 
     leaf out-octets {

--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,13 +51,14 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.9.0";
+  oc-ext:openconfig-version "3.10.0";
 
-  revision "2026-07-15" {
+  revision "2026-07-29" {
       description
-        "Add ingress link-down discard counter to interface counters.";
+        "Add ingress link-down discard counter to interface and
+        subinterface counters.";
       reference
-        "3.9.0";
+        "3.10.0";
   }
 
   revision "2026-01-06" {
@@ -890,9 +891,9 @@ module openconfig-interfaces {
     leaf in-link-down-discards {
       type oc-yang:counter64;
       description
-        "The number of inbound packets received on the interface that
-        were dropped because the egress interface or next-hop link
-        selected by forwarding or routing was down.
+        "The number of inbound packets received on the interface or
+        subinterface that were dropped because the egress interface or
+        next-hop link selected by forwarding or routing was down.
 
         Discontinuities in the value of this counter can occur
         at re-initialization of the management system, and at


### PR DESCRIPTION
This change introduces a new operational state counter `in-link-down-discards` under interface counters (`/interfaces/interface/state/counters/in-link-down-discards` and `/interfaces/interface/subinterfaces/subinterface/state/counters/in-link-down-discards`) to track ingress packets dropped due to egress link-down forwarding conditions.
The version has been bumped to `3.10.0` in `openconfig-interfaces.yang`.

Change-Id: I38c19a483b18e47f583c81a0b98597888405892f

### Change Scope
* **Description:** This PR introduces `in-link-down-discards` to `interface-common-counters-state` in `openconfig-interfaces.yang` to count ingress packets discarded because the resolved egress interface or next-hop link selected by forwarding or routing was down.
* **Backwards Compatibility:** This change is fully backward compatible as it only adds a new read-only operational state leaf counter to the existing `interface-common-counters-state` grouping.

### Use case
This counter is designed for production network debugging and automated failure pinpointing. Silent packet discards in large-scale fabrics are difficult to diagnose using generic discard counters alone. Providing an explicit counter for inbound packet drops due to egress link-down forwarding failures (`in-link-down-discards`) allows network operators and SRE tools to distinguish forwarding blackholes caused by downstream link failures from normal traffic discards.

### Platform Implementations
- SAI specification defines an explicit debug drop reason for egress link down conditions: `SAI_IN_DROP_REASON_EGRESS_LINK_DOWN` ([SAI Debug Counters Proposal](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-Debug-Counters.md)).
- [Nvidia 1](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-511/Monitoring-and-Troubleshooting/Open-Telemetry-Export/) (`nvswitch_interface_discards_egress_link_down` for tx and `nvswitch_interface_discards_ingress_tx_link_down` for rx).
- [Nvidia 2](https://networking-docs.nvidia.com/doca/archive/2-7-0/nvidia-doca-telemetry-service-guide) (`tx_discards_phy`).
- Google network switches export granular ingress link-down drop telemetry via UMF and SAI debug counters.
- Broadcom / SONiC ASIC telemetry pipelines support per-port ingress drop counting for egress link-down events.

### Tree View
```diff
module: openconfig-interfaces

  +--rw interfaces
     +--rw interface* [name]
        +--ro state
        |  +--ro counters
        |     +--ro in-errors?               oc-yang:counter64
        |     +--ro in-discards?             oc-yang:counter64
+       |     +--ro in-link-down-discards?    oc-yang:counter64
        |     +--ro out-octets?              oc-yang:counter64
        +--rw subinterfaces
           +--rw subinterface* [index]
              +--ro state
                 +--ro counters
                    +--ro in-errors?             oc-yang:counter64
                    +--ro in-discards?           oc-yang:counter64
+                   +--ro in-link-down-discards?  oc-yang:counter64
                    +--ro out-octets?            oc-yang:counter64
