### PR TITLE
Add route lookup ingress drop counter to interface and subinterface counters

### DIFF
--- a/release/models/interfaces/openconfig-interfaces.yang
+++ b/release/models/interfaces/openconfig-interfaces.yang
@@ -51,7 +51,15 @@ module openconfig-interfaces {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "3.8.1";
+  oc-ext:openconfig-version "3.11.0";
+
+  revision "2026-07-29" {
+      description
+        "Add ingress route lookup drop counter to interface and
+        subinterface counters.";
+      reference
+        "3.11.0";
+  }
 
   revision "2026-01-06" {
       description
@@ -1005,6 +1013,19 @@ module openconfig-interfaces {
         The value is the timestamp in nanoseconds relative to
         the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
       oc-ext:telemetry-on-change;
+    }
+
+    leaf in-route-lookup-drop {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets received on the interface or
+        subinterface that were dropped during routing lookup due to no
+        matching route entry in the forwarding table (LPM miss) or
+        matching an explicit drop route.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of 'last-clear'.";
     }
   }
 


### PR DESCRIPTION
This change introduces a new operational state counter `in-route-lookup-drop` under common interface counters (`/interfaces/interface/state/counters/in-route-lookup-drop` and `/interfaces/interface/subinterfaces/subinterface/state/counters/in-route-lookup-drop`) to track inbound packets dropped during routing table lookup. This could be due to no matching route entry in the forwarding table (LPM miss) or matching an explicit drop route.
The version has been bumped to `3.11.0` in `openconfig-interfaces.yang`.

Change-Id: I2f1a6c4290871e86b3e94a815a1e2f89104b28cd

### Change Scope
* **Description:** This PR introduces `in-route-lookup-drop` to `openconfig-interfaces.yang` (under `interface-common-counters-state`) to count inbound packets discarded on a routed interface or subinterface when a routing table lookup fails to find a matching route entry (LPM miss) or encounters an explicit drop/blackhole route.
* **Backwards Compatibility:** This change is fully backward compatible as it only adds a new read-only operational state leaf counter to the existing `interface-common-counters-state` grouping.

### Use case
In routed fabrics (such as spine-leaf or multi-tenant networks), silent packet discards due to routing table misses or blackhole routes are difficult to isolate using generic discard counters (`in-discards`). Providing an explicit counter for route lookup drops (`in-route-lookup-drop`) enables network operations and automated failure pinpointing tools to immediately identify routing blackholes, unassigned IP prefix drops, or route table sync issues at both interface and subinterface granularity.

### Platform Implementations
- **SAI Specification:** Defines explicit debug drop reasons for LPM miss and LPM drops: `SAI_IN_DROP_REASON_LPM_MISS` / `SAI_IN_DROP_REASON_LPM_DROP` ([SAI Debug Counters Proposal](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-Debug-Counters.md#L107)).
- **Google Switch Telemetry:** Google production switches export granular ingress routing lookup drop telemetry via UMF and SAI debug counters.
- **[Cisco IOS Reference](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipapp/iap-cr-book.pdf)** P202, [Cisco YANG model](https://raw.githubusercontent.com/YangModels/yang/refs/heads/main/vendor/cisco/nx/9.3-9/Cisco-NX-OS-device.yang), `in-no-routes`)** Exposes routing drop statistics (`show ip traffic` no route discards).
- **SONiC / Broadcom Telemetry:** Pipeline counters support tracking `SWITCH_INGRESS_DROPS` with drop reason `SAI_IN_DROP_REASON_LPM4_MISS` and `SAI_IN_DROP_REASON_LPM6_MISS`.

### Tree View
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         ...
         +--ro state
         |  +--ro counters
         |     +--ro out-discards?            oc-yang:counter64
         |     +--ro out-errors?              oc-yang:counter64
         |     +--ro last-clear?              oc-types:timeticks64
+        |     +--ro in-route-lookup-drop?    oc-yang:counter64
         ...
         +--rw subinterfaces
            +--rw subinterface* [index]
               ...
               +--ro state
                  +--ro counters
                     +--ro out-discards?           oc-yang:counter64
                     +--ro out-errors?             oc-yang:counter64
                     +--ro last-clear?             oc-types:timeticks64
+                    +--ro in-route-lookup-drop?   oc-yang:counter64
