### PR TITLE
Add Conditional Routes

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -10,6 +10,7 @@ module openconfig-local-routing {
   // import some basic types
   import openconfig-inet-types { prefix inet; }
   import openconfig-policy-types { prefix oc-pt; }
+  import openconfig-routing-policy { prefix oc-rpol; }
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-interfaces { prefix oc-if; }
   import openconfig-bfd { prefix oc-bfd; }
@@ -43,7 +44,13 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "4.1.0";
+  oc-ext:openconfig-version "4.2.0";
+
+  revision "2026-08-12" {
+    description
+      "Add conditional-routes for injecting local routes conditionally.";
+    reference "4.2.0";
+  }
 
   revision "2025-07-29" {
     description
@@ -161,6 +168,26 @@ module openconfig-local-routing {
     description
       "The wecmp-weight leaf inherits value from egress interface
       bandwidth expressed in bps.";
+  }
+
+  identity CONDITIONAL_ROUTES_ACTION {
+    description
+      "Base identity type of actions for conditional routes.";
+  }
+
+  identity NO_ACTION {
+    base CONDITIONAL_ROUTES_ACTION;
+    description
+      "No action to be taken when the conditions for the conditional routes
+      are resulted to true. The prefixes are NOT injected as routes.";
+  }
+
+  identity INSTALL_DROP_NEXTHOP {
+    base CONDITIONAL_ROUTES_ACTION;
+    description
+      "Install the conditional routes with a discard next-hop.
+      Traffic destined to the prefix will be discarded with no
+      ICMP message generated.";
   }
 
   // typedef statements
@@ -513,4 +540,106 @@ module openconfig-local-routing {
     }
   }
 
+  grouping conditional-prefix-set-ref-config {
+    description
+      "Grouping of configuration data for conditional prefix set reference";
+
+    leaf name {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:conditional-prefix-sets/oc-rpol:conditional-prefix-set/oc-rpol:name";
+      }
+
+      description
+        "Reference to the conditional prefix set whose prefixes may be injected as routes.
+        If the condition is satisfied, routes may be injected for each prefix in the
+        target prefix-set.";
+    }
+
+    leaf action {
+      type identityref {
+        base CONDITIONAL_ROUTES_ACTION;
+      }
+      default NO_ACTION;
+      description
+        "The action to take when the conditions for the prefix set results in true.
+        The default behavior is to take no actions and will not inject the prefixes
+        as routes.";
+    }
+
+    leaf preference {
+      type uint32;
+      description
+        "Administrative Distance (preference) of the entry.  The
+        preference defines the order of selection when multiple
+        sources (protocols, static, etc.) contribute to the same
+        prefix entry.  The lower the preference, the more preferable the
+        prefix is.  When this value is not specified, the preference is
+        inherited from the default preference of the implementation for
+        static routes.";
+    }
+  }
+
+  grouping conditional-prefix-set-ref-state {
+    description
+      "Grouping of operational state data for conditional prefix set reference";
+
+    leaf condition-matched {
+      type boolean;
+      description
+        "When true, the match-policy has been resolved to ACCEPT_ROUTE and the
+        routes in the referenced conditional prefix set are currently injected
+        into the RIB.";
+    }
+  }
+
+  grouping conditional-prefix-list {
+    description
+      "Grouping for the list of conditional prefix set references.";
+
+    container conditional-prefix-set-refs {
+      description
+        "Enclosing container for conditional prefix set references.";
+
+      list conditional-prefix-set-ref {
+        key "name";
+        description
+          "List of conditional prefix set references.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the configured prefix set name for this conditional prefix set";
+        }
+
+        container config {
+          description
+            "Configuration data for conditional prefix set reference";
+
+          uses conditional-prefix-set-ref-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state for conditional prefix set reference";
+
+          uses conditional-prefix-set-ref-config;
+          uses conditional-prefix-set-ref-state;
+        }
+      }
+    }
+  }
+
+  grouping conditional-routes-top {
+    description
+      "Top-level grouping for the list of conditional route configurations";
+    container conditional-routes {
+      description
+        "Protocol container for conditional local routes";
+
+      uses conditional-prefix-list;
+    }
+  }
 }

--- a/release/models/network-instance/openconfig-network-instance.yang
+++ b/release/models/network-instance/openconfig-network-instance.yang
@@ -50,7 +50,13 @@ module openconfig-network-instance {
     virtual switch instance (VSI). Mixed Layer 2 and Layer 3
     instances are also supported.";
 
-  oc-ext:openconfig-version "4.7.0";
+  oc-ext:openconfig-version "4.8.0";
+
+  revision "2026-08-12" {
+    description
+      "Add conditional-routes protocol.";
+    reference "4.8.0";
+  }
 
   revision "2026-03-17" {
     description
@@ -952,6 +958,17 @@ module openconfig-network-instance {
                 locally generated aggregate routes";
             }
 
+            uses oc-loc-rt:conditional-routes-top {
+              when "./config/identifier = 'oc-pol-types:CONDITIONAL_ROUTES'" {
+                description
+                  "Include conditional route configuration when the protocol is of type
+                  CONDITIONAL_ROUTES";
+              }
+              description
+                "Configuration and state parameters relating to the
+                Conditional Routes.";
+            }
+
             uses oc-bgp:bgp-top {
               when "./config/identifier = 'oc-pol-types:BGP'" {
                 description
@@ -1012,7 +1029,7 @@ module openconfig-network-instance {
                 Group Management Protocol (IGMP).";
             }
 
-			uses oc-pcep:pcep-top {
+            uses oc-pcep:pcep-top {
               when "./config/identifier = 'oc-pol-types:PCEP'" {
                 description
                   "Include PCEP configuration when the protocol is of type

--- a/release/models/policy/.spec.yml
+++ b/release/models/policy/.spec.yml
@@ -5,12 +5,14 @@
     - yang/isis/openconfig-isis-types.yang
     - yang/ospf/openconfig-ospf-types.yang
     - yang/policy/openconfig-routing-policy.yang
+    - yang/policy/openconfig-policy-network-instance.yang
     - yang/network-instance/openconfig-network-instance-policy.yang
     - yang/bgp/openconfig-bgp-policy.yang
     - yang/isis/openconfig-isis-policy.yang
     - yang/ospf/openconfig-ospf-policy.yang
   build:
     - yang/policy/openconfig-routing-policy.yang
+    - yang/policy/openconfig-policy-network-instance.yang
     - yang/network-instance/openconfig-network-instance-policy.yang
     - yang/bgp/openconfig-bgp-policy.yang
     - yang/isis/openconfig-isis-policy.yang

--- a/release/models/policy/openconfig-policy-network-instance.yang
+++ b/release/models/policy/openconfig-policy-network-instance.yang
@@ -1,0 +1,70 @@
+module openconfig-policy-network-instance {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/policy-netinst";
+
+  prefix "oc-rpol-netinst";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module adds leaves that relate to network-instances
+     to the routing-policy subtree.";
+
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2026-08-12" {
+    description
+      "Add leaves that relate to network-instances to the
+       routing policy module.";
+    reference "1.0.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping conditional-prefix-set-network-instance {
+    description
+      "This grouping define leaves that need references to the network-instance
+       subtree within the routing policy module. It is used to augment the
+       /routing-policy/defined-sets/conditional-prefix-sets/conditional-prefix-set/config/
+       containers.";
+
+    leaf match-policy-network-instance {
+      type leafref {
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:name";
+      }
+
+      description
+        "The specific network instance of which routes from the RIB that will be used
+        for matching the configured match-policy.";
+    }
+  }
+
+  augment "/oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:conditional-prefix-sets/oc-rpol:conditional-prefix-set/oc-rpol:config" {
+    description
+      "Add network-instance leaves to conditional-prefix-set container.";
+
+    uses conditional-prefix-set-network-instance;
+  }
+
+  augment "/oc-rpol:routing-policy/oc-rpol:defined-sets/oc-rpol:conditional-prefix-sets/oc-rpol:conditional-prefix-set/oc-rpol:state" {
+    description
+      "Add network-instance leaves to conditional-prefix-set container.";
+
+    uses conditional-prefix-set-network-instance;
+  }
+}

--- a/release/models/policy/openconfig-policy-types.yang
+++ b/release/models/policy/openconfig-policy-types.yang
@@ -25,7 +25,13 @@ module openconfig-policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  oc-ext:openconfig-version "3.3.0";
+  oc-ext:openconfig-version "3.4.0";
+
+  revision "2026-08-12" {
+    description
+      "Add CONDITIONAL_ROUTES to INSTALL_PROTOCOL_TYPE identity.";
+    reference "3.4.0";
+  }
 
   revision "2024-05-14" {
     description
@@ -33,7 +39,7 @@ module openconfig-policy-types {
     reference "3.3.0";
   }
 
-revision "2022-11-08" {
+  revision "2022-11-08" {
     description
       "Add INSTALL_PROTOCOL_TYPE local.";
     reference "3.2.3";
@@ -293,5 +299,16 @@ revision "2022-11-08" {
       and the derived LOCAL route is
 
       10.244.136.79/32.";
+  }
+
+  identity CONDITIONAL_ROUTES {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Conditional local route.
+
+      A conditional local route is a locally defined prefix-set that can be
+      conditionally injected when the configured policy action results in
+      ACCEPT_ROUTE when that policy is applied against the set of routes
+      that are currently installed in the RIB.";
   }
 }

--- a/release/models/policy/openconfig-routing-policy.yang
+++ b/release/models/policy/openconfig-routing-policy.yang
@@ -92,7 +92,13 @@ module openconfig-routing-policy {
     default value for the default-(import|export)-policy leaf must be
     applied.  See RFC6020 7.6.1 which applies to this model.";
 
-  oc-ext:openconfig-version "3.5.0";
+  oc-ext:openconfig-version "3.6.0";
+
+  revision "2026-08-12" {
+    description
+      "Add conditional prefix sets";
+    reference "3.6.0";
+  }
 
   revision "2024-11-26" {
     description
@@ -403,6 +409,104 @@ module openconfig-routing-policy {
     }
   }
 
+  grouping conditional-prefix-set-config {
+    description
+      "Configuration data for conditional prefix sets used in policy
+      definitions.";
+
+    leaf name {
+      type string;
+      description
+        "Name of the conditional prefix set";
+    }
+
+    leaf match-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+          "oc-rpol:policy-definition/oc-rpol:name";
+      }
+      description
+        "The policy which this conditional prefix set would match on to accept the
+        target prefix-set.";
+    }
+
+    leaf match-source-protocol {
+      type union {
+        type enumeration {
+          enum ANY {
+            description
+              "Use installed routes from any protocols";
+          }
+        }
+
+        type identityref {
+          base oc-pol-types:INSTALL_PROTOCOL_TYPE;
+        }
+      }
+      default ANY;
+      description
+        "The source protocol of the routes to match against the applied policy.
+        The default is to match against any type of routes currently in the RIB.";
+    }
+
+    leaf target-prefix-set {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-rpol:prefix-sets/oc-rpol:prefix-set/oc-rpol:name";
+      }
+
+      description
+        "The prefix-set that would be used when the match-policy results in
+        true or ACCEPT_ROUTE.";
+    }
+  }
+  grouping conditional-prefix-set-state {
+    description
+      "Operational status for conditional prefix sets used in policy
+      definitions.";
+  }
+
+  grouping conditional-prefix-set-top {
+    description
+      "Top level definition of conditional prefix sets";
+
+    container conditional-prefix-sets {
+      description
+        "Enclosing container for conditional prefix set list";
+
+      list conditional-prefix-set {
+        key "name";
+        description
+          "List of the defined conditional prefix sets";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to conditional prefix name list key";
+        }
+
+        container config {
+          description
+            "Configuration container for conditional prefix set";
+
+          uses conditional-prefix-set-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational status container for conditional prefix set";
+
+          uses conditional-prefix-set-config;
+          uses conditional-prefix-set-state;
+        }
+
+      }
+    }
+  }
+
   grouping neighbor-set-config {
     description
       "Configuration data for neighbor set definitions";
@@ -544,6 +648,7 @@ module openconfig-routing-policy {
       protocols.";
 
     uses prefix-set-top;
+    uses conditional-prefix-set-top;
     uses neighbor-set-top;
     uses tag-set-top;
   }
@@ -910,9 +1015,9 @@ module openconfig-routing-policy {
       }
 
       container state {
+        config false;
         description
           "Operational state related to tag application.";
-        config false;
         uses action-tag-set-config;
       }
 
@@ -935,9 +1040,9 @@ module openconfig-routing-policy {
         }
 
         container state {
+          config false;
           description
             "Operational state related to in-line tag specification.";
-          config false;
           uses action-tag-set-inline-config;
         }
       }


### PR DESCRIPTION
### Change Scope

- (M) release/models/local-routing/openconfig-local-routing.yang  
- (M) release/models/network-instance/openconfig-network-instance.yang  
- (A) release/models/policy/openconfig-policy-network-instance.yang  
- (M) release/models/policy/openconfig-policy-types.yang  
- (M) release/models/policy/openconfig-routing-policy.yang

This proposal introduces OpenConfig support for conditional routes and conditional prefix-sets, enabling more granular, policy-driven route management. In some ways, this is a more descriptive configuration model for `local-aggregates`.

This implementation decouples the condition definition from its application for better reusability:

* Defining the Conditional Set:  
  * `conditional-prefix-sets` (located under `/routing-policy/defined-sets/`) serve as the definition layer. It is a combination of a defined `prefix-set` and `policy-definition`. The attached `policy-definition` is matched against the whole RIB or protocol table specified by `match-source-protocol` under a specific `match-policy-network-instance`.  
* Apply the Conditional Set:  
  * `conditional-routes` (located under `/network-instances/.../protocols/`) serve as an application layer. These conditional prefix sets are applied to the `network-instance` with the configured `action`. Currently this proposal only supports `INSTALL_DROP_NEXTHOP` which would install these prefixes as local routes with a drop next-hop to discard all traffic.  
  * The name `conditional-prefix-set-refs` is following the precedence of `community-set-refs` and `ext-community-set-refs`.  
* Redistribute the routes:  
  * `table-connections` (located under  `/network-instances/network-instances/`) can be used to redistribute and advertise these routes.

These changes are backwards compatible.

### Platform Implementations

* Arista: [link to documentation](https://www.arista.com/en/support/toi/eos-4-21-3f/14142-bgp-conditional-route-inject)

### Tree View

#### `/routing-policy/defined-sets/conditional-prefix-sets/`

```
module: openconfig-routing-policy
  +--rw routing-policy
     +--rw defined-sets
        +--rw conditional-prefix-sets
           +--rw conditional-prefix-set* [name]
              +--rw name      -> ../config/name
              +--rw config
              |  +--rw name?                                            string
              |  +--rw match-policy?                                    -> /routing-policy/policy-definitions/policy-definition/name
              |  +--rw match-source-protocol?                           union
              |  +--rw target-prefix-set?                               -> /routing-policy/defined-sets/prefix-sets/prefix-set/name
              |  +--rw oc-rpol-netinst:match-policy-network-instance?   -> /oc-ni:network-instances/network-instance/name
              +--ro state
                 +--ro name?                                            string
                 +--ro match-policy?                                    -> /routing-policy/policy-definitions/policy-definition/name
                 +--ro match-source-protocol?                           union
                 +--ro target-prefix-set?                               -> /routing-policy/defined-sets/prefix-sets/prefix-set/name
                 +--ro oc-rpol-netinst:match-policy-network-instance?   -> /oc-ni:network-instances/network-instance/name
```

#### `/network-instances/network-instance/protocols/protocol/conditional-routes`

```
module: openconfig-network-instance
  +--rw network-instances
     +--rw network-instance* [name]
        +--rw protocols
           +--rw protocol* [identifier name]
              +--rw conditional-routes
                 +--rw config
                 +--rw state
                 +--rw conditional-prefix-set-refs
                    +--rw conditional-prefix-set-ref* [name]
                       +--rw name      -> ../config/name
                       +--rw config
                       |  +--rw name?         -> /oc-rpol:routing-policy/defined-sets/conditional-prefix-sets/conditional-prefix-set/name
                       |  +--rw action?       identityref
                       |  +--rw preference?   uint32
                       +--ro state
                          +--ro name?                -> /oc-rpol:routing-policy/defined-sets/conditional-prefix-sets/conditional-prefix-set/name
                          +--ro action?              identityref
                          +--ro preference?          uint32
                          +--ro condition-matched?   boolean
```