### PR TITLE
Add tag and track-id to static route next-hop attributes

### DIFF
--- a/release/models/local-routing/openconfig-local-routing.yang
+++ b/release/models/local-routing/openconfig-local-routing.yang
@@ -43,7 +43,15 @@ module openconfig-local-routing {
     protocol-specific policy after importing the route into the
     protocol for distribution (again via routing policy).";
 
-  oc-ext:openconfig-version "4.1.0";
+  oc-ext:openconfig-version "4.2.0";
+
+  revision "2026-08-24" {
+    description
+      "Add per-nexthop tag and track-id leaves to local-static-nexthop-config
+      for static route next-hops. The tag leaf uses oc-pt:tag-type for
+      consistency with other OpenConfig tag fields.";
+    reference "4.2.0";
+  }
 
   revision "2025-07-29" {
     description
@@ -327,6 +335,31 @@ module openconfig-local-routing {
         recursion is hence disabled.
         This leaf is mutualy exclusive with next-network-instance
         leaf";
+    }
+
+    leaf tag {
+      type oc-pt:tag-type;
+      description
+        "Administrative tag associated with this static-route nexthop.
+         The tag is an opaque identifier used for policy actions such
+         as route-map matching, redistribution filtering, or BGP export
+         control. It does not affect route preference or nexthop
+         selection by itself.
+         When multiple ECMP nexthops are configured for the same prefix,
+         each nexthop may carry a distinct tag value.
+         If unset, the implementation default applies (typically no tag).";
+    }
+
+    leaf track-id {
+      type string;
+      description
+        "Identifier of a reachability track object associated with this
+         nexthop. The static route nexthop is eligible for installation
+         only while the referenced track object reports an 'up' state.
+         The track object is defined separately (e.g., IP SLA, NQA,
+         RPM, or active probe profile) and may monitor reachability to
+         an endpoint that is not necessarily identical to this nexthop
+         address.";
     }
 
     uses local-common-route-attributes;


### PR DESCRIPTION
Add per-nexthop tag and track-id leaves to the
local-common-route-attributes grouping used by static route next-hop config and state.

### Change Scope

This change adds two optional leaves to the `local-common-route-attributes` grouping in `openconfig-local-routing.yang`:

- **`tag`** (`uint32`, range `1..4294967295`) — per-nexthop administrative tag for route-map matching, redistribution filtering, and BGP export control. It does not affect route preference or nexthop selection.
- **`track-id`** (`string`) — identifier of a reachability track object (e.g., IP SLA, NQA, RPM, active probe). The nexthop is eligible for installation only while the referenced track object reports an `up` state.

These leaves appear on static route next-hop **config** and **state** via existing `uses local-static-nexthop-config` → `uses local-common-route-attributes`. They also appear on local aggregate config/state, which reuses the same grouping.

**Backwards compatibility:** Yes. Both leaves are optional additions with no changes to existing leaves or keys.

### Platform Implementations

**Route tag**
* **Cisco NX-OS:** [Static route configuration — route tag](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/9-x/unicast/configuration/guide/l3_cli_nxos/l3_route.html)
* **FRRouting:** [Static route tag](https://docs.frrouting.org/en/latest/static.html#route-tag)
* **Arista EOS:** [IPv4 static routes — tag](https://www.arista.com/en/um-eos/eos-ipv4#xx1142428)

**Track Id**
* **Cisco NX-OS:** [Static route tracking](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/9-x/unicast/configuration/guide/l3_cli_nxos/l3_route.html)
* **Arista EOS (Ansible):** [eos_static_routes — track parameter](https://github.com/ansible-collections/arista.eos/blob/main/docs/arista.eos.eos_static_routes_module.rst)
* **Cisco IOS / IP SLA:** [Reliable static routing with IP SLA](https://networklessons.com/ip-routing/reliable-static-routing-with-ip-sla)
* **Huawei:** [NQA for IPv4 static routes](https://support.huawei.com/enterprise/en/doc/EDOC1100333627/3fc55dd5/configuring-nqa-for-ipv4-static-routes)

### Tree View

Relevant portion of `openconfig-network-instance` tree under `protocols/protocol/static-routes/static/next-hops/next-hop`:

```diff
 module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw static-routes
                  +--rw static* [prefix]
                     +--rw next-hops
                        +--rw next-hop* [index]
                           +--rw config
                           |  +--rw index?          string
                           |  +--rw next-hop?       union
                           |  +--rw recurse?        boolean
                           |  +--rw metric?         uint32
                           |  +--rw preference?     uint32
                           |  +--rw wecmp-weight?   union
+                          |  +--rw tag?            uint32
+                          |  +--rw track-id?       string
                           +--ro state
                           |  +--ro index?          string
                           |  +--ro next-hop?       union
                           |  +--ro recurse?        boolean
                           |  +--ro metric?         uint32
                           |  +--ro preference?     uint32
                           |  +--ro wecmp-weight?   union
+                          |  +--ro tag?            uint32
+                          |  +--ro track-id?       string
                           +--rw enable-bfd
                           +--rw interface-ref
```

**Note:** The same `tag` and `track-id` leaves also appear under `local-aggregates/aggregate/{config,state}` because that container reuses `local-common-route-attributes`.