### PR TITLE
Add support for defining a forwarding group identifier under forwarding groups

### DIFF
--- a/release/models/qos/openconfig-qos-elements.yang
+++ b/release/models/qos/openconfig-qos-elements.yang
@@ -36,7 +36,13 @@ submodule openconfig-qos-elements {
       packets for transmission, including policer and shaper
       functions";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.3.0";
+
+  revision "2026-08-27" {
+    description
+      "Add forwarding-group identifier.";
+    reference "2.3.0";
+  }
 
   revision "2026-04-30" {
     description
@@ -426,6 +432,13 @@ submodule openconfig-qos-elements {
       type string;
       description
         "Name of the forwarding group";
+    }
+
+    leaf forwarding-group-id {
+      type uint8;
+      description
+        "An optional identifier which may be required by some hardware to map
+         the named forwarding group to a hardware forwarding group.";
     }
 
     // TODO(robjs, Simon G): Discuss optionally moving

--- a/release/models/qos/openconfig-qos-interfaces.yang
+++ b/release/models/qos/openconfig-qos-interfaces.yang
@@ -25,7 +25,13 @@ submodule openconfig-qos-interfaces {
     configuration and operational state associated with
     interfaces.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.3.0";
+
+  revision "2026-08-27" {
+    description
+      "Add forwarding-group identifier.";
+    reference "2.3.0";
+  }
 
   revision "2026-04-30" {
     description

--- a/release/models/qos/openconfig-qos-mem-mgmt.yang
+++ b/release/models/qos/openconfig-qos-mem-mgmt.yang
@@ -29,7 +29,13 @@ submodule openconfig-qos-mem-mgmt {
       per-queue basis, and determine how packets are marked/dropped within
       the queue instantiation.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.3.0";
+
+  revision "2026-08-27" {
+    description
+      "Add forwarding-group identifier.";
+    reference "2.3.0";
+  }
 
   revision "2026-04-30" {
     description

--- a/release/models/qos/openconfig-qos.yang
+++ b/release/models/qos/openconfig-qos.yang
@@ -27,7 +27,13 @@ module openconfig-qos {
     "This module defines configuration and operational state data
     related to network quality-of-service.";
 
-  oc-ext:openconfig-version "2.2.0";
+  oc-ext:openconfig-version "2.3.0";
+
+  revision "2026-08-27" {
+    description
+      "Add forwarding-group identifier.";
+    reference "2.3.0";
+  }
 
   revision "2026-04-30" {
     description


### PR DESCRIPTION
### Change Scope

- (M) qos/openconfig-qos-interfaces.yang
- (M) qos/openconfig-qos-elements.yang
- (M) qos/openconfig-qos.yang

- Add support for defining a numeric forwarding-group identifier per forwarding-group.

This addition allows the user to map the forwarding-group to the systems traffic-class identifiers ( often 0-7 ) 

### Tree View

```
   module: openconfig-qos
     +--rw qos
        +--rw forwarding-groups
           +--rw forwarding-group* [name]
              +--rw name       -> ../config/name
              +--rw config
              |  +--rw name?                    string
  +           |  +--rw forwarding-group-id?     uint8
              |  +--rw fabric-priority?         uint8
              |  +--rw output-queue?            -> ../../../../queues/queue/config/name
              |  +--rw unicast-output-queue?    -> ../../../../queues/queue/config/name
              |  +--rw multicast-output-queue?  -> ../../../../queues/queue/config/name
              +--ro state
                 +--ro name?                    string
  +              +--ro forwarding-group-id?     uint8
                 +--ro fabric-priority?         uint8
                 +--ro output-queue?            -> ../../../../queues/queue/config/name
                 +--ro unicast-output-queue?    -> ../../../../queues/queue/config/name
                 +--ro multicast-output-queue?  -> ../../../../queues/queue/config/name
```
Example of usage of  traffic class in numeric value
https://www.arista.com/en/um-eos/eos-quality-of-service 
The EOS CLI that currently maps forwarding-group name to traffic-class 
`qos traffic-class 0 name FOO`