### PR TITLE
next-hop-group-backup Activate AFT

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for a next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -1080,6 +1086,48 @@ submodule openconfig-aft-common {
                 }
               }
             }
+          }
+        }
+      }
+    }
+  }
+
+  grouping aft-backup-activate-structural {
+    description
+      "Structural grouping for backup next-hop-group activation entries.";
+
+    container backup-activate {
+      config false;
+      description
+        "Surrounding container for external/software-driven backup next-hop-group activations.";
+
+      list backup-activate {
+        key "next-hop-group";
+
+        description
+          "An operational entry indicating that the backup-next-hop-group has been
+           activated for the specified next-hop-group.";
+
+        leaf next-hop-group {
+          type leafref {
+            path "../state/next-hop-group";
+          }
+
+          description
+            "Reference to the target next-hop-group whose backup path is activated.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state parameters relating to backup activation.";
+
+          leaf next-hop-group {
+            type uint64;
+
+            description
+              "The identifier of the next-hop-group for which backup is activated.";
           }
         }
       }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2026-09-01" {
     description
-      "Add backup activation state under next-hop-groups.";
+      "Add backup activation state for next-hop-groups.";
     reference "3.5.0";
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state under next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -1080,6 +1086,48 @@ submodule openconfig-aft-common {
                 }
               }
             }
+          }
+        }
+      }
+    }
+  }
+
+  grouping aft-backup-activate-structural {
+    description
+      "Structural grouping for backup next-hop-group activation entries.";
+
+    container backup-activate {
+      config false;
+      description
+        "Surrounding container for external/software-driven backup next-hop-group activations.";
+
+      list backup-activate {
+        key "next-hop-group";
+
+        description
+          "An operational entry indicating that the backup-next-hop-group has been
+           activated for the specified next-hop-group.";
+
+        leaf next-hop-group {
+          type leafref {
+            path "../state/next-hop-group";
+          }
+
+          description
+            "Reference to the target next-hop-group whose backup path is activated.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state parameters relating to backup activation.";
+
+          leaf next-hop-group {
+            type uint64;
+
+            description
+              "The identifier of the next-hop-group for which backup is activated.";
           }
         }
       }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for a next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -338,6 +344,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
+      uses aft-backup-activate-structural;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state under next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -338,6 +344,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
+      uses aft-backup-activate-structural;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -46,7 +46,7 @@ module openconfig-aft {
 
   revision "2026-09-01" {
     description
-      "Add backup activation state under next-hop-groups.";
+      "Add backup activation state for next-hop-groups.";
     reference "3.5.0";
   }
 


### PR DESCRIPTION
[Note: Please fill out the following template for your pull request. Replace
all the text in `[]` with your own content.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/contributions-guide.md]

### Change Scope

* [Please briefly describe the change that is being made to the models.] - A new AFT path to activate next_hop_group_backup for a next-hop-group.
* [Please indicate whether this change is backwards compatible.] - Yes

### Platform Implementations

 * This will require new implementation from vendors. Vendor communication has already started.

### Tree View

* [Please provide a view of the tree being modified.  It's preferred if a `diff` format is used for ease of review.]
* [Here are recommended steps to generate the tree view as a diff]

```
git checkout mychangebranch
pyang -f tree -p release/models/*/* > ~/new-tree.txt 
git checkout master
git pull
pyang -f tree -p release/models/*/* > ~/old-tree.txt
diff -bU 100 ~/old-tree.txt ~/new-tree.txt   | less
```

[Next, cut and paste the relevant portion of the tree with enough context for reviewers to quickly understand the change.]
```diff
 module: openconfig-interfaces
   +--rw interfaces
      +--rw interface* [name]
         +--ro state
         |  +--ro counters
         |  |  +--ro in-octets?               oc-yang:counter64
         |  |  +--ro in-pkts?                 oc-yang:counter64
         |  |  +--ro in-unicast-pkts?         oc-yang:counter64
         |  |  +--ro in-broadcast-pkts?       oc-yang:counter64
         |  |  +--ro in-multicast-pkts?       oc-yang:counter64
         |  |  +--ro in-errors?               oc-yang:counter64
         |  |  +--ro in-discards?             oc-yang:counter64
         |  |  +--ro out-octets?              oc-yang:counter64
         |  |  +--ro out-pkts?                oc-yang:counter64
         |  |  +--ro out-unicast-pkts?        oc-yang:counter64
         |  |  +--ro out-broadcast-pkts?      oc-yang:counter64
         |  |  +--ro out-multicast-pkts?      oc-yang:counter64
         |  |  +--ro out-discards?            oc-yang:counter64
         |  |  +--ro out-errors?              oc-yang:counter64
         |  |  +--ro last-clear?              oc-types:timeticks64
         |  |  +--ro in-unknown-protos?       oc-yang:counter64
         |  |  +--ro in-fcs-errors?           oc-yang:counter64
+        |  |  x--ro carrier-transitions?     oc-yang:counter64
-        |  |  +--ro carrier-transitions?     oc-yang:counter64
+        |  |  +--ro interface-transitions?   oc-yang:counter64
+        |  |  +--ro link-transitions?        oc-yang:counter64
         |  |  +--ro resets?                oc-yang:counter64
```
