### PR TITLE
Create new YANG path for triggering backup-next-hop-group.

### DIFF
--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for a next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -1080,6 +1086,48 @@ submodule openconfig-aft-common {
                 }
               }
             }
+          }
+        }
+      }
+    }
+  }
+
+  grouping aft-backup-activate-structural {
+    description
+      "Structural grouping for backup next-hop-group activation entries.";
+
+    container backup-activate {
+      config false;
+      description
+        "Surrounding container for external/software-driven backup next-hop-group activations.";
+
+      list backup-activate {
+        key "next-hop-group";
+
+        description
+          "An operational entry indicating that the backup-next-hop-group has been
+           activated for the specified next-hop-group.";
+
+        leaf next-hop-group {
+          type leafref {
+            path "../state/next-hop-group";
+          }
+
+          description
+            "Reference to the target next-hop-group whose backup path is activated.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state parameters relating to backup activation.";
+
+          leaf next-hop-group {
+            type uint64;
+
+            description
+              "The identifier of the next-hop-group for which backup is activated.";
           }
         }
       }

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -1114,7 +1114,7 @@ submodule openconfig-aft-common {
           }
 
           description
-            "Reference to the target next-hop-group whose backup path is activated.";
+            "Reference to the target next-hop-group whose backup next-hop-group is activated.";
         }
 
         container state {

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -1092,16 +1092,16 @@ submodule openconfig-aft-common {
     }
   }
 
-  grouping aft-backup-activate-structural {
+  grouping aft-backup-activations-structural {
     description
       "Structural grouping for backup next-hop-group activation entries.";
 
-    container backup-activate {
+    container backup-activations {
       config false;
       description
         "Surrounding container for external/software-driven backup next-hop-group activations.";
 
-      list backup-activate {
+      list backup-activation {
         key "next-hop-group";
 
         description

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -1124,7 +1124,9 @@ submodule openconfig-aft-common {
             "Operational state parameters relating to backup activation.";
 
           leaf next-hop-group {
-            type uint64;
+            type leafref {
+              path "../../../../next-hop-groups/next-hop-group/state/id";
+            }
 
             description
               "The identifier of the next-hop-group for which backup is activated.";

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -27,7 +27,7 @@ submodule openconfig-aft-common {
 
   revision "2026-09-01" {
     description
-      "Add backup activation state under next-hop-groups.";
+      "Add backup activation state for next-hop-groups.";
     reference "3.5.0";
   }
 

--- a/release/models/aft/openconfig-aft-common.yang
+++ b/release/models/aft/openconfig-aft-common.yang
@@ -23,7 +23,13 @@ submodule openconfig-aft-common {
     "Submodule containing definitions of groupings that are re-used
     across multiple contexts within the AFT model.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state under next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -1080,6 +1086,48 @@ submodule openconfig-aft-common {
                 }
               }
             }
+          }
+        }
+      }
+    }
+  }
+
+  grouping aft-backup-activate-structural {
+    description
+      "Structural grouping for backup next-hop-group activation entries.";
+
+    container backup-activate {
+      config false;
+      description
+        "Surrounding container for external/software-driven backup next-hop-group activations.";
+
+      list backup-activate {
+        key "next-hop-group";
+
+        description
+          "An operational entry indicating that the backup-next-hop-group has been
+           activated for the specified next-hop-group.";
+
+        leaf next-hop-group {
+          type leafref {
+            path "../state/next-hop-group";
+          }
+
+          description
+            "Reference to the target next-hop-group whose backup path is activated.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state parameters relating to backup activation.";
+
+          leaf next-hop-group {
+            type uint64;
+
+            description
+              "The identifier of the next-hop-group for which backup is activated.";
           }
         }
       }

--- a/release/models/aft/openconfig-aft-ethernet.yang
+++ b/release/models/aft/openconfig-aft-ethernet.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ethernet {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for Ethernet.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft-ipv4.yang
+++ b/release/models/aft/openconfig-aft-ipv4.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv4 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv4.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft-ipv6.yang
+++ b/release/models/aft/openconfig-aft-ipv6.yang
@@ -20,7 +20,13 @@ submodule openconfig-aft-ipv6 {
     "Submodule containing definitions of groupings for the abstract
     forwarding tables for IPv6.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft-mpls.yang
+++ b/release/models/aft/openconfig-aft-mpls.yang
@@ -21,7 +21,13 @@ submodule openconfig-aft-mpls {
     "Submodule containing definitions of groupings for the abstract
     forwarding table for MPLS label forwarding.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft-pf.yang
+++ b/release/models/aft/openconfig-aft-pf.yang
@@ -28,7 +28,13 @@ submodule openconfig-aft-pf {
     fields other than the destination address that is used in
     other forwarding tables.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft-state-synced.yang
+++ b/release/models/aft/openconfig-aft-state-synced.yang
@@ -16,7 +16,13 @@ submodule openconfig-aft-state-synced {
     "Submodule containing definitions of groupings for the state
     synced signals corresponding to various abstract forwarding tables.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state for a next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -338,6 +344,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
+      uses aft-backup-activate-structural;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -42,7 +42,13 @@ module openconfig-aft {
     is referred to as an Abstract Forwarding Table (AFT), rather than
     the FIB.";
 
-  oc-ext:openconfig-version "3.4.0";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2026-09-01" {
+    description
+      "Add backup activation state under next-hop-groups.";
+    reference "3.5.0";
+  }
 
   revision "2026-03-10" {
     description
@@ -338,6 +344,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
+      uses aft-backup-activate-structural;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -344,7 +344,7 @@ module openconfig-aft {
         uses aft-state-synced-structural;
       }
 
-      uses aft-backup-activate-structural;
+      uses aft-backup-activations-structural;
       uses aft-next-hop-groups-structural;
       uses aft-nhop-structural;
     }

--- a/release/models/aft/openconfig-aft.yang
+++ b/release/models/aft/openconfig-aft.yang
@@ -46,7 +46,7 @@ module openconfig-aft {
 
   revision "2026-09-01" {
     description
-      "Add backup activation state under next-hop-groups.";
+      "Add backup activation state for next-hop-groups.";
     reference "3.5.0";
   }
 


### PR DESCRIPTION
### Change Scope

* Adding a new path to trigger backup-next-hop-group. Currently backup for a next-hop-group is triggered automatically by the switch. With this new AFT path, the backup could be triggered by the switch client as well through gRIBI. 
* [Please indicate whether this change is backwards compatible.] - Yes

### Platform Implementations

This is a new feature to be implemented by vendors. We already have communicated this feature with a few vendors and have got confirmation from Arista, Juniper and Nokia.

### Tree View
```diff
module: openconfig-network-instance
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw afts
+        |  +--ro backup-activations
+        |  |  +--ro backup-activation* [next-hop-group]
+        |  |     +--ro next-hop-group    -> ../state/next-hop-group
+        |  |     +--ro state
+        |  |        +--ro next-hop-group?   -> ../../../../next-hop-groups/next-hop-group/state/id
```
