### PR TITLE
Add ospf administrative distance

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,10 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPF global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPF routes, equivalent to
+      those of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,10 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPF global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPF routes, equivalent to
+      those of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,10 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPF global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPF routes, equivalent to
+      those of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,11 +27,10 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a route-preference container to the OSPF global
-      structure, providing administrative distance (preference)
-      leafs for intra-area, inter-area, and external OSPF routes,
-      matching the naming used by the equivalent route-preference
-      container on the ISIS global config.";
+      "Add route-preference container to OSPF global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPF routes, equivalent to
+      those of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -189,44 +188,6 @@ submodule openconfig-ospf-global {
     }
   }
 
-  grouping ospf-global-route-preference-config {
-    description
-      "Configuration options relating to the administrative distance
-      (or preference) assigned to routes received from different
-      OSPF route types. OSPF distinguishes intra-area, inter-area,
-      and external routes (rather than the internal/external split
-      used by BGP and ISIS), so a separate leaf is provided for
-      each, matching the naming used by the equivalent ISIS
-      route-preference grouping.";
-
-    leaf intra-area-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for intra-area OSPF
-        routes.";
-    }
-
-    leaf inter-area-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for inter-area OSPF
-        routes.";
-    }
-
-    leaf external-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for external OSPF
-        routes.";
-    }
-  }
-
   grouping ospf-global-inter-areapp-config {
     description
       "Configuration parameters for OSPF policies which propagate
@@ -254,6 +215,42 @@ submodule openconfig-ospf-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospf-global-route-preference-config {
+    description
+      "Configuration options relating to the administrative distance
+      (preference) assigned to routes per different OSPF route type,
+      intra-area, inter-area and external routes. Equivalent to
+      external-route-preference and internal-route-preference of
+      ISIS route-preference grouping.";
+
+    leaf intra-area-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for intra-area OSPF
+        routes.";
+    }
+
+    leaf inter-area-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for inter-area OSPF
+        routes.";
+    }
+
+    leaf external-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for external OSPF
+        routes.";
+    }
   }
 
   grouping ospf-global-max-metric-config {
@@ -424,28 +421,6 @@ submodule openconfig-ospf-global {
         }
       }
 
-      container route-preference {
-        description
-          "Administrative distance (or preference) assigned to
-          routes received via different OSPF route types (intra-area,
-          inter-area, external)";
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPF route
-            preference";
-          uses ospf-global-route-preference-config;
-        }
-
-        container state {
-          config false;
-          description
-            "State information relating to the OSPF route
-            preference";
-          uses ospf-global-route-preference-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -488,6 +463,28 @@ submodule openconfig-ospf-global {
               propagation policy";
             uses ospf-global-inter-areapp-config;
           }
+        }
+      }
+
+      container route-preference {
+        description
+          "Administrative distance (or preference) assigned to
+          routes received via different OSPF route types (intra-area,
+          inter-area, external)";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF route
+            preference";
+          uses ospf-global-route-preference-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information relating to the OSPF route
+            preference";
+          uses ospf-global-route-preference-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,11 +27,11 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a default-route-distance container to the OSPF global
-      structure, providing administrative distance leafs for
-      intra-area, inter-area, and external OSPF routes, matching
-      the intent of the equivalent container on the BGP global
-      config.";
+      "Add a route-preference container to the OSPF global
+      structure, providing administrative distance (preference)
+      leafs for intra-area, inter-area, and external OSPF routes,
+      matching the naming used by the equivalent route-preference
+      container on the ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -189,37 +189,41 @@ submodule openconfig-ospf-global {
     }
   }
 
-  grouping ospf-global-default-route-distance-config {
+  grouping ospf-global-route-preference-config {
     description
       "Configuration options relating to the administrative distance
       (or preference) assigned to routes received from different
       OSPF route types. OSPF distinguishes intra-area, inter-area,
       and external routes (rather than the internal/external split
       used by BGP and ISIS), so a separate leaf is provided for
-      each.";
+      each, matching the naming used by the equivalent ISIS
+      route-preference grouping.";
 
-    leaf intra-area-route-distance {
+    leaf intra-area-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for intra-area OSPF routes.";
+        "Administrative distance (preference) for intra-area OSPF
+        routes.";
     }
 
-    leaf inter-area-route-distance {
+    leaf inter-area-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for inter-area OSPF routes.";
+        "Administrative distance (preference) for inter-area OSPF
+        routes.";
     }
 
-    leaf external-route-distance {
+    leaf external-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for external OSPF routes.";
+        "Administrative distance (preference) for external OSPF
+        routes.";
     }
   }
 
@@ -420,7 +424,7 @@ submodule openconfig-ospf-global {
         }
       }
 
-      container default-route-distance {
+      container route-preference {
         description
           "Administrative distance (or preference) assigned to
           routes received via different OSPF route types (intra-area,
@@ -428,16 +432,17 @@ submodule openconfig-ospf-global {
 
         container config {
           description
-            "Configuration parameters relating to the default route
-            distance";
-          uses ospf-global-default-route-distance-config;
+            "Configuration parameters relating to the OSPF route
+            preference";
+          uses ospf-global-route-preference-config;
         }
 
         container state {
           config false;
           description
-            "State information relating to the default route distance";
-          uses ospf-global-default-route-distance-config;
+            "State information relating to the OSPF route
+            preference";
+          uses ospf-global-route-preference-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -468,9 +468,9 @@ submodule openconfig-ospf-global {
 
       container route-preference {
         description
-          "Administrative distance (or preference) assigned to
-          routes received via different OSPF route types (intra-area,
-          inter-area, external)";
+          "Administrative distance (preference) assigned to routes
+          per different OSPF route type, intra-area, inter-area,
+          external routes.";
 
         container config {
           description

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,17 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a default-route-distance container to the OSPF global
+      structure, providing administrative distance leafs for
+      intra-area, inter-area, and external OSPF routes, matching
+      the intent of the equivalent container on the BGP global
+      config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -177,6 +186,40 @@ submodule openconfig-ospf-global {
         indicate that it is restarting, but will accept Grace-LSAs
         from remote systems, and suppress withdrawl of adjacencies
         of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-default-route-distance-config {
+    description
+      "Configuration options relating to the administrative distance
+      (or preference) assigned to routes received from different
+      OSPF route types. OSPF distinguishes intra-area, inter-area,
+      and external routes (rather than the internal/external split
+      used by BGP and ISIS), so a separate leaf is provided for
+      each.";
+
+    leaf intra-area-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for intra-area OSPF routes.";
+    }
+
+    leaf inter-area-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for inter-area OSPF routes.";
+    }
+
+    leaf external-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for external OSPF routes.";
     }
   }
 
@@ -374,6 +417,27 @@ submodule openconfig-ospf-global {
             "Operational state parameters relating to OSPF graceful
             restart";
           uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container default-route-distance {
+        description
+          "Administrative distance (or preference) assigned to
+          routes received via different OSPF route types (intra-area,
+          inter-area, external)";
+
+        container config {
+          description
+            "Configuration parameters relating to the default route
+            distance";
+          uses ospf-global-default-route-distance-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information relating to the default route distance";
+          uses ospf-global-default-route-distance-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,11 +31,11 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a default-route-distance container to the OSPF global
-      structure, providing administrative distance leafs for
-      intra-area, inter-area, and external OSPF routes, matching
-      the intent of the equivalent container on the BGP global
-      config.";
+      "Add a route-preference container to the OSPF global
+      structure, providing administrative distance (preference)
+      leafs for intra-area, inter-area, and external OSPF routes,
+      matching the naming used by the equivalent route-preference
+      container on the ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,17 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add a default-route-distance container to the OSPF global
+      structure, providing administrative distance leafs for
+      intra-area, inter-area, and external OSPF routes, matching
+      the intent of the equivalent container on the BGP global
+      config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,11 +31,10 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a route-preference container to the OSPF global
-      structure, providing administrative distance (preference)
-      leafs for intra-area, inter-area, and external OSPF routes,
-      matching the naming used by the equivalent route-preference
-      container on the ISIS global config.";
+      "Add route-preference container to OSPF global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPF routes, equivalent to
+      those of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,10 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,10 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,10 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,11 +27,10 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a route-preference container to the OSPFv2 global
-      structure, providing administrative distance (preference)
-      leafs for intra-area, inter-area, and external OSPFv2 routes,
-      matching the naming used by the equivalent route-preference
-      container on the ISIS global config.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -313,44 +312,6 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-route-preference-config {
-    description
-      "Configuration options relating to the administrative distance
-      (or preference) assigned to routes received from different
-      OSPFv2 route types. OSPF distinguishes intra-area, inter-area,
-      and external routes (rather than the internal/external split
-      used by BGP and ISIS), so a separate leaf is provided for
-      each, matching the naming used by the equivalent ISIS
-      route-preference grouping.";
-
-    leaf intra-area-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for intra-area OSPFv2
-        routes.";
-    }
-
-    leaf inter-area-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for inter-area OSPFv2
-        routes.";
-    }
-
-    leaf external-route-preference {
-      type uint8 {
-        range "1..255";
-      }
-      description
-        "Administrative distance (preference) for external OSPFv2
-        routes.";
-    }
-  }
-
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -378,6 +339,42 @@ submodule openconfig-ospfv2-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospfv2-global-route-preference-config {
+    description
+      "Configuration options relating to the administrative distance
+      (preference) assigned to routes per different OSPFv2 route
+      type, intra-area, inter-area and external routes. Equivalent
+      to external-route-preference and internal-route-preference of
+      ISIS route-preference grouping.";
+
+    leaf intra-area-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for intra-area OSPFv2
+        routes.";
+    }
+
+    leaf inter-area-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for inter-area OSPFv2
+        routes.";
+    }
+
+    leaf external-route-preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance (preference) for external OSPFv2
+        routes.";
+    }
   }
 
   grouping ospfv2-global-max-metric-config {
@@ -587,28 +584,6 @@ submodule openconfig-ospfv2-global {
         }
       }
 
-      container route-preference {
-        description
-          "Administrative distance (or preference) assigned to
-          routes received via different OSPFv2 route types
-          (intra-area, inter-area, external)";
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPFv2 route
-            preference";
-          uses ospfv2-global-route-preference-config;
-        }
-
-        container state {
-          config false;
-          description
-            "State information relating to the OSPFv2 route
-            preference";
-          uses ospfv2-global-route-preference-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -651,6 +626,28 @@ submodule openconfig-ospfv2-global {
               propagation policy";
             uses ospfv2-global-inter-areapp-config;
           }
+        }
+      }
+
+      container route-preference {
+        description
+          "Administrative distance (or preference) assigned to
+          routes received via different OSPFv2 route types
+          (intra-area, inter-area, external)";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPFv2 route
+            preference";
+          uses ospfv2-global-route-preference-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information relating to the OSPFv2 route
+            preference";
+          uses ospfv2-global-route-preference-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,11 +27,11 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a default-route-distance container to the OSPFv2 global
-      structure, providing administrative distance leafs for
-      intra-area, inter-area, and external OSPFv2 routes, matching
-      the intent of the equivalent container on the BGP global
-      config.";
+      "Add a route-preference container to the OSPFv2 global
+      structure, providing administrative distance (preference)
+      leafs for intra-area, inter-area, and external OSPFv2 routes,
+      matching the naming used by the equivalent route-preference
+      container on the ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -313,37 +313,41 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-default-route-distance-config {
+  grouping ospfv2-global-route-preference-config {
     description
       "Configuration options relating to the administrative distance
       (or preference) assigned to routes received from different
       OSPFv2 route types. OSPF distinguishes intra-area, inter-area,
       and external routes (rather than the internal/external split
       used by BGP and ISIS), so a separate leaf is provided for
-      each.";
+      each, matching the naming used by the equivalent ISIS
+      route-preference grouping.";
 
-    leaf intra-area-route-distance {
+    leaf intra-area-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for intra-area OSPFv2 routes.";
+        "Administrative distance (preference) for intra-area OSPFv2
+        routes.";
     }
 
-    leaf inter-area-route-distance {
+    leaf inter-area-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for inter-area OSPFv2 routes.";
+        "Administrative distance (preference) for inter-area OSPFv2
+        routes.";
     }
 
-    leaf external-route-distance {
+    leaf external-route-preference {
       type uint8 {
         range "1..255";
       }
       description
-        "Administrative distance for external OSPFv2 routes.";
+        "Administrative distance (preference) for external OSPFv2
+        routes.";
     }
   }
 
@@ -583,7 +587,7 @@ submodule openconfig-ospfv2-global {
         }
       }
 
-      container default-route-distance {
+      container route-preference {
         description
           "Administrative distance (or preference) assigned to
           routes received via different OSPFv2 route types
@@ -591,16 +595,17 @@ submodule openconfig-ospfv2-global {
 
         container config {
           description
-            "Configuration parameters relating to the default route
-            distance";
-          uses ospfv2-global-default-route-distance-config;
+            "Configuration parameters relating to the OSPFv2 route
+            preference";
+          uses ospfv2-global-route-preference-config;
         }
 
         container state {
           config false;
           description
-            "State information relating to the default route distance";
-          uses ospfv2-global-default-route-distance-config;
+            "State information relating to the OSPFv2 route
+            preference";
+          uses ospfv2-global-route-preference-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,17 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a default-route-distance container to the OSPFv2 global
+      structure, providing administrative distance leafs for
+      intra-area, inter-area, and external OSPFv2 routes, matching
+      the intent of the equivalent container on the BGP global
+      config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -304,6 +313,40 @@ submodule openconfig-ospfv2-global {
     }
   }
 
+  grouping ospfv2-global-default-route-distance-config {
+    description
+      "Configuration options relating to the administrative distance
+      (or preference) assigned to routes received from different
+      OSPFv2 route types. OSPF distinguishes intra-area, inter-area,
+      and external routes (rather than the internal/external split
+      used by BGP and ISIS), so a separate leaf is provided for
+      each.";
+
+    leaf intra-area-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for intra-area OSPFv2 routes.";
+    }
+
+    leaf inter-area-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for inter-area OSPFv2 routes.";
+    }
+
+    leaf external-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for external OSPFv2 routes.";
+    }
+  }
+
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -537,6 +580,27 @@ submodule openconfig-ospfv2-global {
               synchronization";
             uses ospfv2-common-mpls-igp-ldp-sync-config;
           }
+        }
+      }
+
+      container default-route-distance {
+        description
+          "Administrative distance (or preference) assigned to
+          routes received via different OSPFv2 route types
+          (intra-area, inter-area, external)";
+
+        container config {
+          description
+            "Configuration parameters relating to the default route
+            distance";
+          uses ospfv2-global-default-route-distance-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information relating to the default route distance";
+          uses ospfv2-global-default-route-distance-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -631,9 +631,9 @@ submodule openconfig-ospfv2-global {
 
       container route-preference {
         description
-          "Administrative distance (or preference) assigned to
-          routes received via different OSPFv2 route types
-          (intra-area, inter-area, external)";
+          "Administrative distance (preference) assigned to routes
+          per different OSPFv2 route type, intra-area, inter-area,
+          external routes.";
 
         container config {
           description

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,10 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,11 +38,11 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a default-route-distance container to the OSPFv2 global
-      structure, providing administrative distance leafs for
-      intra-area, inter-area, and external OSPFv2 routes, matching
-      the intent of the equivalent container on the BGP global
-      config.";
+      "Add a route-preference container to the OSPFv2 global
+      structure, providing administrative distance (preference)
+      leafs for intra-area, inter-area, and external OSPFv2 routes,
+      matching the naming used by the equivalent route-preference
+      container on the ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,11 +38,10 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a route-preference container to the OSPFv2 global
-      structure, providing administrative distance (preference)
-      leafs for intra-area, inter-area, and external OSPFv2 routes,
-      matching the naming used by the equivalent route-preference
-      container on the ISIS global config.";
+      "Add route-preference container to OSPFv2 global structure,
+      providing administrative distance (preference) leafs for
+      intra-area, inter-area and external OSPFv2 routes, equivalent
+      to those of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,17 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a default-route-distance container to the OSPFv2 global
+      structure, providing administrative distance leafs for
+      intra-area, inter-area, and external OSPFv2 routes, matching
+      the intent of the equivalent container on the BGP global
+      config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";


### PR DESCRIPTION
### Change Scope

* Add route-preference container to OSPF global structure, providing
  administrative distance (preference) leafs for intra-area,
  inter-area and external OSPF routes, equivalent to those of ISIS
  global config.
* Backward compatible: Yes (new optional container only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`distance ospf`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp1957943792) / `distance ospfv3`
```
router ospf <process-id>
 distance ospf {intra-area | inter-area | external} <distance-value>

router ospfv3 <process-id>
 distance ospfv3 {intra-area | inter-area | external} <distance-value>
```
* Implementation B: DriveNets DNOS — `administrative-distance`
```
protocols ospf administrative-distance {intra-area | inter-area | external} <distance-value>

protocols ospfv3 administrative-distance {intra-area | inter-area | external} <distance-value>
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw route-preference
+                       +--rw config
+                          +--rw intra-area-route-preference?   uint8
+                          +--rw inter-area-route-preference?   uint8
+                          +--rw external-route-preference?     uint8
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw route-preference
+                       +--rw config
+                          +--rw intra-area-route-preference?   uint8
+                          +--rw inter-area-route-preference?   uint8
+                          +--rw external-route-preference?     uint8
```