### PR TITLE
Add ospf auto cost reference bandwidth

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,8 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPF global structure,
+      equivalent to that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPF global structure,
+      equivalent to that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPF global structure,
+      equivalent to that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -222,8 +222,9 @@ submodule openconfig-ospf-global {
 
     leaf reference-bandwidth {
       type uint32;
+      units Mbps;
       description
-        "The reference bandwidth, in Mbit/s, used by the local
+        "The reference bandwidth, in Mbps, used by the local
         system to calculate the default metric for an interface
         based on its bandwidth. Equivalent to the
         reference-bandwidth leaf on the ISIS global config.";

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,9 +27,8 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a reference-bandwidth container to the OSPF global
-      structure, matching the equivalent container on the ISIS
-      global config.";
+      "Add reference-bandwidth container to OSPF global structure,
+      equivalent to that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -187,21 +186,6 @@ submodule openconfig-ospf-global {
     }
   }
 
-  grouping ospf-global-reference-bandwidth-config {
-    description
-      "Configuration parameters relating to the OSPF auto-cost
-      reference bandwidth.";
-
-    leaf reference-bandwidth {
-      type uint32;
-      description
-        "The reference bandwidth, in Mbit/s, used by the local
-        system to calculate the default metric for an interface
-        based on its bandwidth. Equivalent to the
-        reference-bandwidth leaf on the ISIS global config.";
-    }
-  }
-
   grouping ospf-global-inter-areapp-config {
     description
       "Configuration parameters for OSPF policies which propagate
@@ -229,6 +213,21 @@ submodule openconfig-ospf-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospf-global-reference-bandwidth-config {
+    description
+      "Configuration parameters relating to the OSPF auto-cost
+      reference bandwidth.";
+
+    leaf reference-bandwidth {
+      type uint32;
+      description
+        "The reference bandwidth, in Mbit/s, used by the local
+        system to calculate the default metric for an interface
+        based on its bandwidth. Equivalent to the
+        reference-bandwidth leaf on the ISIS global config.";
+    }
   }
 
   grouping ospf-global-max-metric-config {
@@ -399,27 +398,6 @@ submodule openconfig-ospf-global {
         }
       }
 
-      container reference-bandwidth {
-        description
-          "Configuration and operational state parameters relating
-          to the OSPF auto-cost reference bandwidth.";
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPF auto-cost
-            reference bandwidth.";
-          uses ospf-global-reference-bandwidth-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to the OSPF
-            auto-cost reference bandwidth.";
-          uses ospf-global-reference-bandwidth-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -462,6 +440,27 @@ submodule openconfig-ospf-global {
               propagation policy";
             uses ospf-global-inter-areapp-config;
           }
+        }
+      }
+
+      container reference-bandwidth {
+        description
+          "Configuration and operational state parameters relating
+          to the OSPF auto-cost reference bandwidth.";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF auto-cost
+            reference bandwidth.";
+          uses ospf-global-reference-bandwidth-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the OSPF
+            auto-cost reference bandwidth.";
+          uses ospf-global-reference-bandwidth-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,15 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a reference-bandwidth container to the OSPF global
+      structure, matching the equivalent container on the ISIS
+      global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -177,6 +184,21 @@ submodule openconfig-ospf-global {
         indicate that it is restarting, but will accept Grace-LSAs
         from remote systems, and suppress withdrawl of adjacencies
         of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-reference-bandwidth-config {
+    description
+      "Configuration parameters relating to the OSPF auto-cost
+      reference bandwidth.";
+
+    leaf reference-bandwidth {
+      type uint32;
+      description
+        "The reference bandwidth, in Mbit/s, used by the local
+        system to calculate the default metric for an interface
+        based on its bandwidth. Equivalent to the
+        reference-bandwidth leaf on the ISIS global config.";
     }
   }
 
@@ -374,6 +396,27 @@ submodule openconfig-ospf-global {
             "Operational state parameters relating to OSPF graceful
             restart";
           uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container reference-bandwidth {
+        description
+          "Configuration and operational state parameters relating
+          to the OSPF auto-cost reference bandwidth.";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF auto-cost
+            reference bandwidth.";
+          uses ospf-global-reference-bandwidth-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the OSPF
+            auto-cost reference bandwidth.";
+          uses ospf-global-reference-bandwidth-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,15 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add a reference-bandwidth container to the OSPF global
+      structure, matching the equivalent container on the ISIS
+      global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,9 +31,8 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a reference-bandwidth container to the OSPF global
-      structure, matching the equivalent container on the ISIS
-      global config.";
+      "Add reference-bandwidth container to OSPF global structure,
+      equivalent to that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,8 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,8 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -346,8 +346,9 @@ submodule openconfig-ospfv2-global {
 
     leaf reference-bandwidth {
       type uint32;
+      units Mbps;
       description
-        "The reference bandwidth, in Mbit/s, used by the local
+        "The reference bandwidth, in Mbps, used by the local
         system to calculate the default metric for an interface
         based on its bandwidth. Equivalent to the
         reference-bandwidth leaf on the ISIS global config.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,9 +27,8 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a reference-bandwidth container to the OSPFv2 global
-      structure, matching the equivalent container on the ISIS
-      global config.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -311,21 +310,6 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-reference-bandwidth-config {
-    description
-      "Configuration parameters relating to the OSPFv2 auto-cost
-      reference bandwidth.";
-
-    leaf reference-bandwidth {
-      type uint32;
-      description
-        "The reference bandwidth, in Mbit/s, used by the local
-        system to calculate the default metric for an interface
-        based on its bandwidth. Equivalent to the
-        reference-bandwidth leaf on the ISIS global config.";
-    }
-  }
-
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -353,6 +337,21 @@ submodule openconfig-ospfv2-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospfv2-global-reference-bandwidth-config {
+    description
+      "Configuration parameters relating to the OSPFv2 auto-cost
+      reference bandwidth.";
+
+    leaf reference-bandwidth {
+      type uint32;
+      description
+        "The reference bandwidth, in Mbit/s, used by the local
+        system to calculate the default metric for an interface
+        based on its bandwidth. Equivalent to the
+        reference-bandwidth leaf on the ISIS global config.";
+    }
   }
 
   grouping ospfv2-global-max-metric-config {
@@ -562,27 +561,6 @@ submodule openconfig-ospfv2-global {
         }
       }
 
-      container reference-bandwidth {
-        description
-          "Configuration and operational state parameters relating
-          to the OSPFv2 auto-cost reference bandwidth.";
-
-        container config {
-          description
-            "Configuration parameters relating to the OSPFv2
-            auto-cost reference bandwidth.";
-          uses ospfv2-global-reference-bandwidth-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to the OSPFv2
-            auto-cost reference bandwidth.";
-          uses ospfv2-global-reference-bandwidth-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -625,6 +603,27 @@ submodule openconfig-ospfv2-global {
               propagation policy";
             uses ospfv2-global-inter-areapp-config;
           }
+        }
+      }
+
+      container reference-bandwidth {
+        description
+          "Configuration and operational state parameters relating
+          to the OSPFv2 auto-cost reference bandwidth.";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPFv2
+            auto-cost reference bandwidth.";
+          uses ospfv2-global-reference-bandwidth-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the OSPFv2
+            auto-cost reference bandwidth.";
+          uses ospfv2-global-reference-bandwidth-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,15 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a reference-bandwidth container to the OSPFv2 global
+      structure, matching the equivalent container on the ISIS
+      global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -304,6 +311,21 @@ submodule openconfig-ospfv2-global {
     }
   }
 
+  grouping ospfv2-global-reference-bandwidth-config {
+    description
+      "Configuration parameters relating to the OSPFv2 auto-cost
+      reference bandwidth.";
+
+    leaf reference-bandwidth {
+      type uint32;
+      description
+        "The reference bandwidth, in Mbit/s, used by the local
+        system to calculate the default metric for an interface
+        based on its bandwidth. Equivalent to the
+        reference-bandwidth leaf on the ISIS global config.";
+    }
+  }
+
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -537,6 +559,27 @@ submodule openconfig-ospfv2-global {
               synchronization";
             uses ospfv2-common-mpls-igp-ldp-sync-config;
           }
+        }
+      }
+
+      container reference-bandwidth {
+        description
+          "Configuration and operational state parameters relating
+          to the OSPFv2 auto-cost reference bandwidth.";
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPFv2
+            auto-cost reference bandwidth.";
+          uses ospfv2-global-reference-bandwidth-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the OSPFv2
+            auto-cost reference bandwidth.";
+          uses ospfv2-global-reference-bandwidth-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,15 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a reference-bandwidth container to the OSPFv2 global
+      structure, matching the equivalent container on the ISIS
+      global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,9 +38,8 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a reference-bandwidth container to the OSPFv2 global
-      structure, matching the equivalent container on the ISIS
-      global config.";
+      "Add reference-bandwidth container to OSPFv2 global structure,
+      equivalent to that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {


### PR DESCRIPTION
### Change Scope

* Add reference-bandwidth container to OSPF global structure,
  equivalent to that of ISIS global config.
* Backward compatible: Yes (new optional container only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`auto-cost reference-bandwidth`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp1929254026) (OSPFv3: same command under `router ospfv3`)
```
router ospf <process-id>
 auto-cost reference-bandwidth <mbps>

router ospfv3 <process-id>
 auto-cost reference-bandwidth <mbps>
```
* Implementation B: DriveNets DNOS — `auto-cost reference-bandwidth`
```
protocols ospf auto-cost reference-bandwidth <mbps>

protocols ospfv3 auto-cost reference-bandwidth <mbps>
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw reference-bandwidth
+                       +--rw config
+                          +--rw reference-bandwidth?   uint32
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw reference-bandwidth
+                       +--rw config
+                          +--rw reference-bandwidth?   uint32
```