### PR TITLE
Add ospf maximum ecmp paths

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,8 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPF global config, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPF global config, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPF global config, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,14 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a max-ecmp-paths leaf to the OSPF global config, matching
+      the equivalent leaf on the ISIS global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -77,6 +83,15 @@ submodule openconfig-ospf-global {
          exists or not. When the leaf is set to RFC3509_ABR,
          the router acts as an ABR when the router participates
          in multiple OSPF areas, one of which must be backbone.";
+    }
+
+    leaf max-ecmp-paths {
+      type uint8;
+      description
+        "The maximum number of equal-cost paths that OSPF can
+        install for a single destination. Equivalent to the
+        max-ecmp-paths leaf on the ISIS global config, and to
+        maximum-paths on the BGP global config.";
     }
   }
 

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,8 +27,8 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a max-ecmp-paths leaf to the OSPF global config, matching
-      the equivalent leaf on the ISIS global config.";
+      "Add max-ecmp-paths leaf to OSPF global config, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -90,8 +90,7 @@ submodule openconfig-ospf-global {
       description
         "The maximum number of equal-cost paths that OSPF can
         install for a single destination. Equivalent to the
-        max-ecmp-paths leaf on the ISIS global config, and to
-        maximum-paths on the BGP global config.";
+        max-ecmp-paths of ISIS global config.";
     }
   }
 

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,14 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add a max-ecmp-paths leaf to the OSPF global config, matching
+      the equivalent leaf on the ISIS global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,8 +31,8 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a max-ecmp-paths leaf to the OSPF global config, matching
-      the equivalent leaf on the ISIS global config.";
+      "Add max-ecmp-paths leaf to OSPF global config, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,8 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,8 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,14 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a max-ecmp-paths leaf to the OSPFv2 global config, matching
+      the equivalent leaf on the ISIS global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -187,6 +193,15 @@ submodule openconfig-ospfv2-global {
         the behaviour discussed in RFC6860.";
       reference
         "RFC6860 - Hiding Transit-Only Networks in OSPF";
+    }
+
+    leaf max-ecmp-paths {
+      type uint8;
+      description
+        "The maximum number of equal-cost paths that OSPFv2 can
+        install for a single destination. Equivalent to the
+        max-ecmp-paths leaf on the ISIS global config, and to
+        maximum-paths on the BGP global config.";
     }
   }
 

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,8 +27,8 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a max-ecmp-paths leaf to the OSPFv2 global config, matching
-      the equivalent leaf on the ISIS global config.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -200,8 +200,7 @@ submodule openconfig-ospfv2-global {
       description
         "The maximum number of equal-cost paths that OSPFv2 can
         install for a single destination. Equivalent to the
-        max-ecmp-paths leaf on the ISIS global config, and to
-        maximum-paths on the BGP global config.";
+        max-ecmp-paths of ISIS global config.";
     }
   }
 

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,8 +38,8 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a max-ecmp-paths leaf to the OSPFv2 global config, matching
-      the equivalent leaf on the ISIS global config.";
+      "Add max-ecmp-paths leaf to OSPFv2 global config, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,14 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a max-ecmp-paths leaf to the OSPFv2 global config, matching
+      the equivalent leaf on the ISIS global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";


### PR DESCRIPTION
### Change Scope

* Add max-ecmp-paths leaf to OSPF global config, equivalent to that
  of ISIS global config.
* Backward compatible: Yes (new optional leaf only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`maximum-paths`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp3102289009) (OSPFv3: `maximum paths`, no hyphen)
```
router ospf <process-id>
 maximum-paths <1-32>

router ospfv3 <process-id>
 maximum paths <maximum-routes-number>
```
* Implementation B: DriveNets DNOS — `maximum-ecmp-paths`
```
protocols ospf maximum-ecmp-paths 20

protocols ospfv3 maximum-ecmp-paths 20
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw config
                        +--rw hide-transit-only-networks?   boolean
+                       +--rw max-ecmp-paths?               uint8
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw config
                        +--rw abr-capability?   identityref
+                       +--rw max-ecmp-paths?   uint8
```