### PR TITLE
Add ospf nsr

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,8 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPF global structure, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPF global structure, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPF global structure, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -222,7 +222,6 @@ submodule openconfig-ospf-global {
 
     leaf enabled {
       type boolean;
-      default false;
       description
         "When set to true, the functionality within which this leaf
         is defined is enabled; when set to false it is explicitly

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,14 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add an nsr container to the OSPF global structure, matching
+      the equivalent container on the ISIS global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -177,6 +183,23 @@ submodule openconfig-ospf-global {
         indicate that it is restarting, but will accept Grace-LSAs
         from remote systems, and suppress withdrawl of adjacencies
         of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-nsr-config {
+    description
+      "Re-usable grouping to enable or disable Non-Stop Routing (NSR)
+      for OSPF.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, Non-Stop Routing (NSR) is enabled for
+        OSPF, allowing the standby supervisor to take over routing
+        without requiring the OSPF protocol to restart, in contrast
+        to graceful restart which relies on signalling with
+        neighbours.";
     }
   }
 
@@ -374,6 +397,27 @@ submodule openconfig-ospf-global {
             "Operational state parameters relating to OSPF graceful
             restart";
           uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container nsr {
+        description
+          "Configuration and operational state parameters for OSPF
+          Non-Stop Routing (NSR)";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPF Non-Stop
+            Routing (NSR)";
+          uses ospf-global-nsr-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPF Non-Stop
+            Routing (NSR)";
+          uses ospf-global-nsr-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,8 +27,8 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add an nsr container to the OSPF global structure, matching
-      the equivalent container on the ISIS global config.";
+      "Add nsr container to OSPF global structure, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -186,23 +186,6 @@ submodule openconfig-ospf-global {
     }
   }
 
-  grouping ospf-global-nsr-config {
-    description
-      "Re-usable grouping to enable or disable Non-Stop Routing (NSR)
-      for OSPF.";
-
-    leaf enabled {
-      type boolean;
-      default false;
-      description
-        "When set to true, Non-Stop Routing (NSR) is enabled for
-        OSPF, allowing the standby supervisor to take over routing
-        without requiring the OSPF protocol to restart, in contrast
-        to graceful restart which relies on signalling with
-        neighbours.";
-    }
-  }
-
   grouping ospf-global-inter-areapp-config {
     description
       "Configuration parameters for OSPF policies which propagate
@@ -230,6 +213,21 @@ submodule openconfig-ospf-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospf-global-admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular OSPF
+      feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this leaf
+        is defined is enabled; when set to false it is explicitly
+        disabled.";
+    }
   }
 
   grouping ospf-global-max-metric-config {
@@ -400,27 +398,6 @@ submodule openconfig-ospf-global {
         }
       }
 
-      container nsr {
-        description
-          "Configuration and operational state parameters for OSPF
-          Non-Stop Routing (NSR)";
-
-        container config {
-          description
-            "Configuration parameters relating to OSPF Non-Stop
-            Routing (NSR)";
-          uses ospf-global-nsr-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to OSPF Non-Stop
-            Routing (NSR)";
-          uses ospf-global-nsr-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -463,6 +440,27 @@ submodule openconfig-ospf-global {
               propagation policy";
             uses ospf-global-inter-areapp-config;
           }
+        }
+      }
+
+      container nsr {
+        description
+          "Configuration and operational state parameters for OSPF
+          Non-Stop Routing (NSR)";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPF Non-Stop
+            Routing (NSR)";
+          uses ospf-global-admin-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPF Non-Stop
+            Routing (NSR)";
+          uses ospf-global-admin-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,8 +31,8 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add an nsr container to the OSPF global structure, matching
-      the equivalent container on the ISIS global config.";
+      "Add nsr container to OSPF global structure, equivalent to
+      that of ISIS global config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,14 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add an nsr container to the OSPF global structure, matching
+      the equivalent container on the ISIS global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,8 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,8 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,8 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,14 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add an nsr container to the OSPFv2 global structure, matching
+      the equivalent container on the ISIS global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -304,6 +310,23 @@ submodule openconfig-ospfv2-global {
     }
   }
 
+  grouping ospfv2-global-nsr-config {
+    description
+      "Re-usable grouping to enable or disable Non-Stop Routing (NSR)
+      for OSPFv2.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, Non-Stop Routing (NSR) is enabled for
+        OSPFv2, allowing the standby supervisor to take over routing
+        without requiring the OSPFv2 protocol to restart, in
+        contrast to graceful restart which relies on signalling with
+        neighbours.";
+    }
+  }
+
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -498,6 +521,27 @@ submodule openconfig-ospfv2-global {
             "Operational state parameters relating to OSPFv2 graceful
             restart";
           uses ospfv2-global-graceful-restart-config;
+        }
+      }
+
+      container nsr {
+        description
+          "Configuration and operational state parameters for OSPFv2
+          Non-Stop Routing (NSR)";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPFv2 Non-Stop
+            Routing (NSR)";
+          uses ospfv2-global-nsr-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPFv2
+            Non-Stop Routing (NSR)";
+          uses ospfv2-global-nsr-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -346,7 +346,6 @@ submodule openconfig-ospfv2-global {
 
     leaf enabled {
       type boolean;
-      default false;
       description
         "When set to true, the functionality within which this leaf
         is defined is enabled; when set to false it is explicitly

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,8 +27,8 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add an nsr container to the OSPFv2 global structure, matching
-      the equivalent container on the ISIS global config.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -310,23 +310,6 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-nsr-config {
-    description
-      "Re-usable grouping to enable or disable Non-Stop Routing (NSR)
-      for OSPFv2.";
-
-    leaf enabled {
-      type boolean;
-      default false;
-      description
-        "When set to true, Non-Stop Routing (NSR) is enabled for
-        OSPFv2, allowing the standby supervisor to take over routing
-        without requiring the OSPFv2 protocol to restart, in
-        contrast to graceful restart which relies on signalling with
-        neighbours.";
-    }
-  }
-
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -354,6 +337,21 @@ submodule openconfig-ospfv2-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospfv2-global-admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular OSPFv2
+      feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this leaf
+        is defined is enabled; when set to false it is explicitly
+        disabled.";
+    }
   }
 
   grouping ospfv2-global-max-metric-config {
@@ -524,27 +522,6 @@ submodule openconfig-ospfv2-global {
         }
       }
 
-      container nsr {
-        description
-          "Configuration and operational state parameters for OSPFv2
-          Non-Stop Routing (NSR)";
-
-        container config {
-          description
-            "Configuration parameters relating to OSPFv2 Non-Stop
-            Routing (NSR)";
-          uses ospfv2-global-nsr-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to OSPFv2
-            Non-Stop Routing (NSR)";
-          uses ospfv2-global-nsr-config;
-        }
-      }
-
       container mpls {
         description
           "OSPFv2 parameters relating to MPLS";
@@ -626,6 +603,27 @@ submodule openconfig-ospfv2-global {
               propagation policy";
             uses ospfv2-global-inter-areapp-config;
           }
+        }
+      }
+
+      container nsr {
+        description
+          "Configuration and operational state parameters for OSPFv2
+          Non-Stop Routing (NSR)";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPFv2 Non-Stop
+            Routing (NSR)";
+          uses ospfv2-global-admin-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPFv2
+            Non-Stop Routing (NSR)";
+          uses ospfv2-global-admin-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,8 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,8 +38,8 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add an nsr container to the OSPFv2 global structure, matching
-      the equivalent container on the ISIS global config.";
+      "Add nsr container to OSPFv2 global structure, equivalent to
+      that of ISIS global config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,14 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add an nsr container to the OSPFv2 global structure, matching
+      the equivalent container on the ISIS global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";


### PR DESCRIPTION
### Change Scope

* Add nsr container to OSPF global structure, equivalent to that of
  ISIS global config.
* Backward compatible: Yes (new optional container only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`nsr`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp3267382805) (OSPFv3: same command under `router ospfv3`)
```
router ospf 1
 nsr disable

router ospfv3 1
 nsr disable
```
* Implementation B: DriveNets DNOS — `nsr`
```
protocols ospf nsr enabled

protocols ospfv3 nsr enabled
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw nsr
+                       +--rw config
+                          +--rw enabled?   boolean
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw nsr
+                       +--rw config
+                          +--rw enabled?   boolean
```