### PR TITLE
Add ospf send default route

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,9 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPF global structure,
+      allowing origination of a default external route, equivalent
+      send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -31,7 +31,7 @@ submodule openconfig-ospf-area-interface {
   revision "2026-09-06" {
     description
       "Add send-default-route container to the OSPF global structure,
-      allowing origination of a default external route, equivalent
+      allowing origination of a default external route, equivalent to
       send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -27,7 +27,7 @@ submodule openconfig-ospf-area {
   revision "2026-09-06" {
     description
       "Add send-default-route container to the OSPF global structure,
-      allowing origination of a default external route, equivalent
+      allowing origination of a default external route, equivalent to
       send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,9 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPF global structure,
+      allowing origination of a default external route, equivalent
+      send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -22,7 +22,7 @@ submodule openconfig-ospf-common {
   revision "2026-09-06" {
     description
       "Add send-default-route container to the OSPF global structure,
-      allowing origination of a default external route, equivalent
+      allowing origination of a default external route, equivalent to
       send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,9 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPF global structure,
+      allowing origination of a default external route, equivalent
+      send-default-route of BGP global and neighbors config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,11 +27,10 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a send-default-route container to the OSPF global
-      structure, allowing origination of a default external route
-      (optionally unconditionally, via the always leaf) to be
-      configured, matching the intent of the equivalent
-      send-default-route leaf on the BGP global config.";
+      "Add send-default-route container to the OSPF global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -189,58 +188,6 @@ submodule openconfig-ospf-global {
     }
   }
 
-  grouping ospf-global-send-default-route-config {
-    description
-      "Configuration parameters relating to origination of a default
-      external route by the local OSPF instance.";
-
-    leaf enabled {
-      type boolean;
-      default false;
-      description
-        "When set to true, originate a default external route,
-        subject to the value of the always leaf and the metric and
-        metric-type leafs.";
-    }
-
-    leaf always {
-      type boolean;
-      default false;
-      description
-        "When set to true, originate the default external route
-        even when no default route exists in the local system's
-        routing information base. When set to false (the default),
-        the default external route is only originated when a
-        default route is already present locally.";
-    }
-
-    leaf metric {
-      type oc-ospft:ospf-metric;
-      description
-        "The metric to advertise for the originated default
-        external route.";
-    }
-
-    leaf metric-type {
-      type enumeration {
-        enum EXTERNAL_TYPE_1 {
-          description
-            "Advertise the default external route with an OSPF
-            external type 1 metric.";
-        }
-        enum EXTERNAL_TYPE_2 {
-          description
-            "Advertise the default external route with an OSPF
-            external type 2 metric.";
-        }
-      }
-      default "EXTERNAL_TYPE_2";
-      description
-        "Specify the type of metric with which the default external
-        route should be advertised.";
-    }
-  }
-
   grouping ospf-global-inter-areapp-config {
     description
       "Configuration parameters for OSPF policies which propagate
@@ -268,6 +215,58 @@ submodule openconfig-ospf-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospf-global-send-default-route-config {
+    description
+      "Configuration parameters relating to origination of a default
+      external route into the local OSPF instance.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route,
+        subject to the values of the always, metric, and
+        metric-type leafs.";
+    }
+
+    leaf always {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route even
+        when no default route exists in the local system's routing
+        information base. When set to false (default), the default
+        external route is only originated when a default route is
+        already present locally.";
+    }
+
+    leaf metric {
+      type oc-ospft:ospf-metric;
+      description
+        "The metric to advertise for the originated default
+        external route.";
+    }
+
+    leaf metric-type {
+      type enumeration {
+        enum EXTERNAL_TYPE_1 {
+          description
+            "Advertise the default external route with an OSPF
+            external route type 1.";
+        }
+        enum EXTERNAL_TYPE_2 {
+          description
+            "Advertise the default external route with an OSPF
+            external route type 2.";
+        }
+      }
+      default "EXTERNAL_TYPE_2";
+      description
+        "Specify the external route type with which the default
+        external route is advertised.";
+    }
   }
 
   grouping ospf-global-max-metric-config {
@@ -438,28 +437,6 @@ submodule openconfig-ospf-global {
         }
       }
 
-      container send-default-route {
-        description
-          "Configuration and operational state parameters relating
-          to origination of a default external route by the local
-          OSPF instance.";
-
-        container config {
-          description
-            "Configuration parameters relating to origination of a
-            default external route.";
-          uses ospf-global-send-default-route-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to origination
-            of a default external route.";
-          uses ospf-global-send-default-route-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -502,6 +479,28 @@ submodule openconfig-ospf-global {
               propagation policy";
             uses ospf-global-inter-areapp-config;
           }
+        }
+      }
+
+      container send-default-route {
+        description
+          "Configuration and operational state parameters relating
+          to origination of a default external route into the local
+          OSPF instance.";
+
+        container config {
+          description
+            "Configuration parameters relating to origination of a
+            default external route.";
+          uses ospf-global-send-default-route-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to origination
+            of a default external route.";
+          uses ospf-global-send-default-route-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -29,7 +29,7 @@ submodule openconfig-ospf-global {
     description
       "Add send-default-route container to the OSPF global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.2.0";
   }

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -243,7 +243,9 @@ submodule openconfig-ospf-global {
     }
 
     leaf metric {
-      type oc-ospft:ospf-metric;
+      type uint32 {
+        range "0..16777214";
+      }
       description
         "The metric to advertise for the originated default
         external route.";

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,17 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a send-default-route container to the OSPF global
+      structure, allowing origination of a default external route
+      (optionally unconditionally, via the always leaf) to be
+      configured, matching the intent of the equivalent
+      send-default-route leaf on the BGP global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -177,6 +186,58 @@ submodule openconfig-ospf-global {
         indicate that it is restarting, but will accept Grace-LSAs
         from remote systems, and suppress withdrawl of adjacencies
         of the system for the grace period specified";
+    }
+  }
+
+  grouping ospf-global-send-default-route-config {
+    description
+      "Configuration parameters relating to origination of a default
+      external route by the local OSPF instance.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route,
+        subject to the value of the always leaf and the metric and
+        metric-type leafs.";
+    }
+
+    leaf always {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate the default external route
+        even when no default route exists in the local system's
+        routing information base. When set to false (the default),
+        the default external route is only originated when a
+        default route is already present locally.";
+    }
+
+    leaf metric {
+      type oc-ospft:ospf-metric;
+      description
+        "The metric to advertise for the originated default
+        external route.";
+    }
+
+    leaf metric-type {
+      type enumeration {
+        enum EXTERNAL_TYPE_1 {
+          description
+            "Advertise the default external route with an OSPF
+            external type 1 metric.";
+        }
+        enum EXTERNAL_TYPE_2 {
+          description
+            "Advertise the default external route with an OSPF
+            external type 2 metric.";
+        }
+      }
+      default "EXTERNAL_TYPE_2";
+      description
+        "Specify the type of metric with which the default external
+        route should be advertised.";
     }
   }
 
@@ -374,6 +435,28 @@ submodule openconfig-ospf-global {
             "Operational state parameters relating to OSPF graceful
             restart";
           uses ospf-global-graceful-restart-config;
+        }
+      }
+
+      container send-default-route {
+        description
+          "Configuration and operational state parameters relating
+          to origination of a default external route by the local
+          OSPF instance.";
+
+        container config {
+          description
+            "Configuration parameters relating to origination of a
+            default external route.";
+          uses ospf-global-send-default-route-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to origination
+            of a default external route.";
+          uses ospf-global-send-default-route-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -33,7 +33,7 @@ module openconfig-ospf {
     description
       "Add send-default-route container to the OSPF global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.2.0";
   }

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,17 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add a send-default-route container to the OSPF global
+      structure, allowing origination of a default external route
+      (optionally unconditionally, via the always leaf) to be
+      configured, matching the intent of the equivalent
+      send-default-route leaf on the BGP global config.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,11 +31,10 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a send-default-route container to the OSPF global
-      structure, allowing origination of a default external route
-      (optionally unconditionally, via the always leaf) to be
-      configured, matching the intent of the equivalent
-      send-default-route leaf on the BGP global config.";
+      "Add send-default-route container to the OSPF global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -31,7 +31,7 @@ submodule openconfig-ospfv2-area-interface {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,10 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -29,7 +29,7 @@ submodule openconfig-ospfv2-area {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,10 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -23,7 +23,7 @@ submodule openconfig-ospfv2-common {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,10 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,11 +27,10 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a send-default-route container to the OSPFv2 global
-      structure, allowing origination of a default external route
-      (optionally unconditionally, via the always leaf) to be
-      configured, matching the intent of the equivalent
-      send-default-route leaf on the BGP global config.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -313,58 +312,6 @@ submodule openconfig-ospfv2-global {
     }
   }
 
-  grouping ospfv2-global-send-default-route-config {
-    description
-      "Configuration parameters relating to origination of a default
-      external route by the local OSPFv2 instance.";
-
-    leaf enabled {
-      type boolean;
-      default false;
-      description
-        "When set to true, originate a default external route,
-        subject to the value of the always leaf and the metric and
-        metric-type leafs.";
-    }
-
-    leaf always {
-      type boolean;
-      default false;
-      description
-        "When set to true, originate the default external route
-        even when no default route exists in the local system's
-        routing information base. When set to false (the default),
-        the default external route is only originated when a
-        default route is already present locally.";
-    }
-
-    leaf metric {
-      type oc-ospft:ospf-metric;
-      description
-        "The metric to advertise for the originated default
-        external route.";
-    }
-
-    leaf metric-type {
-      type enumeration {
-        enum EXTERNAL_TYPE_1 {
-          description
-            "Advertise the default external route with an OSPFv2
-            external type 1 metric.";
-        }
-        enum EXTERNAL_TYPE_2 {
-          description
-            "Advertise the default external route with an OSPFv2
-            external type 2 metric.";
-        }
-      }
-      default "EXTERNAL_TYPE_2";
-      description
-        "Specify the type of metric with which the default external
-        route should be advertised.";
-    }
-  }
-
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -392,6 +339,58 @@ submodule openconfig-ospfv2-global {
 
     uses oc-rpol:apply-policy-import-config;
     uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospfv2-global-send-default-route-config {
+    description
+      "Configuration parameters relating to origination of a default
+      external route into the local OSPFv2 instance.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route,
+        subject to the values of the always, metric, and
+        metric-type leafs.";
+    }
+
+    leaf always {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route even
+        when no default route exists in the local system's routing
+        information base. When set to false (default), the default
+        external route is only originated when a default route is
+        already present locally.";
+    }
+
+    leaf metric {
+      type oc-ospft:ospf-metric;
+      description
+        "The metric to advertise for the originated default
+        external route.";
+    }
+
+    leaf metric-type {
+      type enumeration {
+        enum EXTERNAL_TYPE_1 {
+          description
+            "Advertise the default external route with an OSPFv2
+            external route type 1.";
+        }
+        enum EXTERNAL_TYPE_2 {
+          description
+            "Advertise the default external route with an OSPFv2
+            external route type 2.";
+        }
+      }
+      default "EXTERNAL_TYPE_2";
+      description
+        "Specify the external route type with which the default
+        external route is advertised.";
+    }
   }
 
   grouping ospfv2-global-max-metric-config {
@@ -601,28 +600,6 @@ submodule openconfig-ospfv2-global {
         }
       }
 
-      container send-default-route {
-        description
-          "Configuration and operational state parameters relating
-          to origination of a default external route by the local
-          OSPFv2 instance.";
-
-        container config {
-          description
-            "Configuration parameters relating to origination of a
-            default external route.";
-          uses ospfv2-global-send-default-route-config;
-        }
-
-        container state {
-          config false;
-          description
-            "Operational state parameters relating to origination
-            of a default external route.";
-          uses ospfv2-global-send-default-route-config;
-        }
-      }
-
       container inter-area-propagation-policies {
         description
           "Policies defining how inter-area propagation should be performed
@@ -665,6 +642,28 @@ submodule openconfig-ospfv2-global {
               propagation policy";
             uses ospfv2-global-inter-areapp-config;
           }
+        }
+      }
+
+      container send-default-route {
+        description
+          "Configuration and operational state parameters relating
+          to origination of a default external route into the local
+          OSPFv2 instance.";
+
+        container config {
+          description
+            "Configuration parameters relating to origination of a
+            default external route.";
+          uses ospfv2-global-send-default-route-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to origination
+            of a default external route.";
+          uses ospfv2-global-send-default-route-config;
         }
       }
     }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -29,7 +29,7 @@ submodule openconfig-ospfv2-global {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,17 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route
+      (optionally unconditionally, via the always leaf) to be
+      configured, matching the intent of the equivalent
+      send-default-route leaf on the BGP global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -304,6 +313,58 @@ submodule openconfig-ospfv2-global {
     }
   }
 
+  grouping ospfv2-global-send-default-route-config {
+    description
+      "Configuration parameters relating to origination of a default
+      external route by the local OSPFv2 instance.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate a default external route,
+        subject to the value of the always leaf and the metric and
+        metric-type leafs.";
+    }
+
+    leaf always {
+      type boolean;
+      default false;
+      description
+        "When set to true, originate the default external route
+        even when no default route exists in the local system's
+        routing information base. When set to false (the default),
+        the default external route is only originated when a
+        default route is already present locally.";
+    }
+
+    leaf metric {
+      type oc-ospft:ospf-metric;
+      description
+        "The metric to advertise for the originated default
+        external route.";
+    }
+
+    leaf metric-type {
+      type enumeration {
+        enum EXTERNAL_TYPE_1 {
+          description
+            "Advertise the default external route with an OSPFv2
+            external type 1 metric.";
+        }
+        enum EXTERNAL_TYPE_2 {
+          description
+            "Advertise the default external route with an OSPFv2
+            external type 2 metric.";
+        }
+      }
+      default "EXTERNAL_TYPE_2";
+      description
+        "Specify the type of metric with which the default external
+        route should be advertised.";
+    }
+  }
+
   grouping ospfv2-global-inter-areapp-config {
     description
       "Configuration parameters for OSPFv2 policies which propagate
@@ -537,6 +598,28 @@ submodule openconfig-ospfv2-global {
               synchronization";
             uses ospfv2-common-mpls-igp-ldp-sync-config;
           }
+        }
+      }
+
+      container send-default-route {
+        description
+          "Configuration and operational state parameters relating
+          to origination of a default external route by the local
+          OSPFv2 instance.";
+
+        container config {
+          description
+            "Configuration parameters relating to origination of a
+            default external route.";
+          uses ospfv2-global-send-default-route-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to origination
+            of a default external route.";
+          uses ospfv2-global-send-default-route-config;
         }
       }
 

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -367,7 +367,9 @@ submodule openconfig-ospfv2-global {
     }
 
     leaf metric {
-      type oc-ospft:ospf-metric;
+      type uint32 {
+        range "0..16777214";
+      }
       description
         "The metric to advertise for the originated default
         external route.";

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -28,7 +28,7 @@ submodule openconfig-ospfv2-lsdb {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,10 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,11 +38,10 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a send-default-route container to the OSPFv2 global
-      structure, allowing origination of a default external route
-      (optionally unconditionally, via the always leaf) to be
-      configured, matching the intent of the equivalent
-      send-default-route leaf on the BGP global config.";
+      "Add send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route,
+      equivalent send-default-route of BGP global and neighbors
+      config.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,17 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a send-default-route container to the OSPFv2 global
+      structure, allowing origination of a default external route
+      (optionally unconditionally, via the always leaf) to be
+      configured, matching the intent of the equivalent
+      send-default-route leaf on the BGP global config.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -40,7 +40,7 @@ module openconfig-ospfv2 {
     description
       "Add send-default-route container to the OSPFv2 global
       structure, allowing origination of a default external route,
-      equivalent send-default-route of BGP global and neighbors
+      equivalent to send-default-route of BGP global and neighbors
       config.";
     reference "0.6.0";
   }


### PR DESCRIPTION
### Change Scope

* Add send-default-route container to the OSPF global structure,
  allowing origination of a default external route, equivalent to
  send-default-route of BGP global and neighbors config.
* Backward compatible: Yes (new optional container only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`default-information originate`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp1717960090) (OSPFv3: same command under `router ospfv3`)
```
router ospf <process-id>
default-information originate always metric 100 metric-type 1

router ospfv3 <process-id>
default-information originate always metric 100 metric-type 1
```
* Implementation B: DriveNets DNOS — `default-originate`
```
protocols ospf default-originate metric-type 2 metric 3000 always

protocols ospfv3 default-originate metric-type 2 metric 3000 always
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw send-default-route
+                       +--rw config
+                          +--rw enabled?       boolean
+                          +--rw always?        boolean
+                          +--rw metric?        oc-ospft:ospf-metric
+                          +--rw metric-type?   enumeration
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw inter-area-propagation-policies
                        ...
+                    +--rw send-default-route
+                       +--rw config
+                          +--rw enabled?       boolean
+                          +--rw always?        boolean
+                          +--rw metric?        oc-ospft:ospf-metric
+                          +--rw metric-type?   enumeration
```