### PR TITLE
Add ospf three stage spf lsa timers

### DIFF
--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -30,7 +30,9 @@ submodule openconfig-ospf-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPF global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-area-interface.yang
+++ b/release/models/ospf/openconfig-ospf-area-interface.yang
@@ -26,8 +26,13 @@ submodule openconfig-ospf-area-interface {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospf-area {
     "This submodule provides common OSPF configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes";

--- a/release/models/ospf/openconfig-ospf-area.yang
+++ b/release/models/ospf/openconfig-ospf-area.yang
@@ -26,7 +26,9 @@ submodule openconfig-ospf-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPF global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospf-common {
     "This submodule provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf-common.yang
+++ b/release/models/ospf/openconfig-ospf-common.yang
@@ -21,7 +21,9 @@ submodule openconfig-ospf-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPF global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -23,8 +23,16 @@ submodule openconfig-ospf-global {
     "This submodule provides common OSPF configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a second-delay leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial, second, maximum)
+      exponential backoff, consistent with the equivalent IS-IS
+      timers.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";
@@ -96,6 +104,18 @@ submodule openconfig-ospf-global {
         algorithm.";
     }
 
+    leaf second-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the delay between the
+        first and second runs of the SPF algorithm following a
+        topology change. Together with initial-delay and
+        maximum-delay, this leaf allows a three-stage exponential
+        backoff (first-wait, second-wait, max-wait) to be
+        configured, matching the equivalent IS-IS SPF timers.";
+    }
+
     leaf maximum-delay {
       // rjs TODO: same question as above
       type uint32;
@@ -106,12 +126,6 @@ submodule openconfig-ospf-global {
         running. This value is used for implementations that support
         increasing the wait time between SPF runs.";
     }
-
-    // rjs TODO: some questions here around what we should specify:
-    // JUNOS has rapid-runs and holddown
-    // Cisco has maximum time between runs, and then a doubling of
-    // the wait interval up to that maximum.
-    // ALU has first-wait, second-wait, max-wait
   }
 
   grouping ospf-global-lsa-generation-timers-config {
@@ -126,6 +140,19 @@ submodule openconfig-ospf-global {
         "The value of this leaf specifies the time between the first
         time an LSA is generated and advertised and the subsequent
         generation of that LSA.";
+    }
+
+    leaf second-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the delay between the
+        first and second generation of an LSA following a change
+        that requires it to be regenerated. Together with
+        initial-delay and maximum-delay, this leaf allows a
+        three-stage exponential backoff (first-wait, second-wait,
+        max-wait) to be configured, matching the equivalent IS-IS
+        LSP generation timers.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,10 +27,11 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a second-delay leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial, second, maximum)
-      exponential backoff, consistent with the equivalent IS-IS
-      timers.";
+      "Add a minimum-hold leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial delay, minimum
+      hold, maximum delay) exponential backoff, matching the Cisco
+      IOS-XR 'timers throttle spf' minimum hold time and the
+      equivalent IS-IS timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -104,16 +105,17 @@ submodule openconfig-ospf-global {
         algorithm.";
     }
 
-    leaf second-delay {
+    leaf minimum-hold {
       type uint32;
       units msec;
       description
-        "The value of this leaf specifies the delay between the
-        first and second runs of the SPF algorithm following a
-        topology change. Together with initial-delay and
-        maximum-delay, this leaf allows a three-stage exponential
-        backoff (first-wait, second-wait, max-wait) to be
-        configured, matching the equivalent IS-IS SPF timers.";
+        "The value of this leaf specifies the minimum hold time
+        between consecutive SPF runs, once the initial run governed
+        by initial-delay has occurred. Together with initial-delay
+        and maximum-delay, this leaf allows a three-stage
+        exponential backoff to be configured, matching the Cisco
+        IOS-XR 'timers throttle spf' minimum hold time and the
+        equivalent IS-IS SPF timers.";
     }
 
     leaf maximum-delay {
@@ -142,17 +144,17 @@ submodule openconfig-ospf-global {
         generation of that LSA.";
     }
 
-    leaf second-delay {
+    leaf minimum-hold {
       type uint32;
       units msec;
       description
-        "The value of this leaf specifies the delay between the
-        first and second generation of an LSA following a change
-        that requires it to be regenerated. Together with
-        initial-delay and maximum-delay, this leaf allows a
-        three-stage exponential backoff (first-wait, second-wait,
-        max-wait) to be configured, matching the equivalent IS-IS
-        LSP generation timers.";
+        "The value of this leaf specifies the minimum hold time
+        between consecutive generations of an LSA, once the initial
+        generation governed by initial-delay has occurred. Together
+        with initial-delay and maximum-delay, this leaf allows a
+        three-stage exponential backoff to be configured, matching
+        the Cisco IOS-XR 'timers throttle lsa' minimum hold time and
+        the equivalent IS-IS LSP generation timers.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospf-global.yang
+++ b/release/models/ospf/openconfig-ospf-global.yang
@@ -27,11 +27,9 @@ submodule openconfig-ospf-global {
 
   revision "2026-09-06" {
     description
-      "Add a minimum-hold leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial delay, minimum
-      hold, maximum delay) exponential backoff, matching the Cisco
-      IOS-XR 'timers throttle spf' minimum hold time and the
-      equivalent IS-IS timers.";
+      "Add minimum-hold leaf to OSPF global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {
@@ -110,12 +108,8 @@ submodule openconfig-ospf-global {
       units msec;
       description
         "The value of this leaf specifies the minimum hold time
-        between consecutive SPF runs, once the initial run governed
-        by initial-delay has occurred. Together with initial-delay
-        and maximum-delay, this leaf allows a three-stage
-        exponential backoff to be configured, matching the Cisco
-        IOS-XR 'timers throttle spf' minimum hold time and the
-        equivalent IS-IS SPF timers.";
+        between consecutive SPF runs. Equivalent to
+        spf-second-interval of IS-IS SPF timer.";
     }
 
     leaf maximum-delay {
@@ -149,12 +143,8 @@ submodule openconfig-ospf-global {
       units msec;
       description
         "The value of this leaf specifies the minimum hold time
-        between consecutive generations of an LSA, once the initial
-        generation governed by initial-delay has occurred. Together
-        with initial-delay and maximum-delay, this leaf allows a
-        three-stage exponential backoff to be configured, matching
-        the Cisco IOS-XR 'timers throttle lsa' minimum hold time and
-        the equivalent IS-IS LSP generation timers.";
+        between consecutive generations of an LSA. Equivalent to
+        lsp-second-wait-interval of IS-IS LSP generation timer.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,10 +31,11 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a second-delay leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial, second, maximum)
-      exponential backoff, consistent with the equivalent IS-IS
-      timers.";
+      "Add a minimum-hold leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial delay, minimum
+      hold, maximum delay) exponential backoff, matching the Cisco
+      IOS-XR 'timers throttle spf' minimum hold time and the
+      equivalent IS-IS timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -27,9 +27,16 @@ module openconfig-ospf {
     "This module provides common OSPF configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.1.1";
+  oc-ext:openconfig-version "0.2.0";
 
-
+  revision "2026-09-06" {
+    description
+      "Add a second-delay leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial, second, maximum)
+      exponential backoff, consistent with the equivalent IS-IS
+      timers.";
+    reference "0.2.0";
+  }
   revision "2025-08-10" {
     description
       "Removed duplicate import and updated prefixes in openconfig-ospf-area";

--- a/release/models/ospf/openconfig-ospf.yang
+++ b/release/models/ospf/openconfig-ospf.yang
@@ -31,11 +31,9 @@ module openconfig-ospf {
 
   revision "2026-09-06" {
     description
-      "Add a minimum-hold leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial delay, minimum
-      hold, maximum delay) exponential backoff, matching the Cisco
-      IOS-XR 'timers throttle spf' minimum hold time and the
-      equivalent IS-IS timers.";
+      "Add minimum-hold leaf to OSPF global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.2.0";
   }
   revision "2025-08-10" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -29,7 +29,9 @@ submodule openconfig-ospfv2-area-interface {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-area-interface.yang
+++ b/release/models/ospf/openconfig-ospfv2-area-interface.yang
@@ -25,8 +25,13 @@ submodule openconfig-ospfv2-area-interface {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -23,8 +23,13 @@ submodule openconfig-ospfv2-area {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are specific to the area context";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-area.yang
+++ b/release/models/ospf/openconfig-ospfv2-area.yang
@@ -27,7 +27,9 @@ submodule openconfig-ospfv2-area {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -21,7 +21,9 @@ submodule openconfig-ospfv2-common {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2-common.yang
+++ b/release/models/ospf/openconfig-ospfv2-common.yang
@@ -17,8 +17,13 @@ submodule openconfig-ospfv2-common {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are shared across multiple contexts";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,11 +27,9 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a minimum-hold leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial delay, minimum
-      hold, maximum delay) exponential backoff, matching the Cisco
-      IOS-XR 'timers throttle spf' minimum hold time and the
-      equivalent IS-IS timers.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -220,12 +218,8 @@ submodule openconfig-ospfv2-global {
       units msec;
       description
         "The value of this leaf specifies the minimum hold time
-        between consecutive SPF runs, once the initial run governed
-        by initial-delay has occurred. Together with initial-delay
-        and maximum-delay, this leaf allows a three-stage
-        exponential backoff to be configured, matching the Cisco
-        IOS-XR 'timers throttle spf' minimum hold time and the
-        equivalent IS-IS SPF timers.";
+        between consecutive SPF runs. Equivalent to
+        spf-second-interval of IS-IS SPF timer.";
     }
 
     leaf maximum-delay {
@@ -259,12 +253,8 @@ submodule openconfig-ospfv2-global {
       units msec;
       description
         "The value of this leaf specifies the minimum hold time
-        between consecutive generations of an LSA, once the initial
-        generation governed by initial-delay has occurred. Together
-        with initial-delay and maximum-delay, this leaf allows a
-        three-stage exponential backoff to be configured, matching
-        the Cisco IOS-XR 'timers throttle lsa' minimum hold time and
-        the equivalent IS-IS LSP generation timers.";
+        between consecutive generations of an LSA. Equivalent to
+        lsp-second-wait-interval of IS-IS LSP generation timer.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -23,8 +23,16 @@ submodule openconfig-ospfv2-global {
     "This submodule provides OSPFv2 configuration and operational
     state parameters that are global to a particular OSPF instance";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a second-delay leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial, second, maximum)
+      exponential backoff, consistent with the equivalent IS-IS
+      timers.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";
@@ -206,6 +214,18 @@ submodule openconfig-ospfv2-global {
         algorithm.";
     }
 
+    leaf second-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the delay between the
+        first and second runs of the SPF algorithm following a
+        topology change. Together with initial-delay and
+        maximum-delay, this leaf allows a three-stage exponential
+        backoff (first-wait, second-wait, max-wait) to be
+        configured, matching the equivalent IS-IS SPF timers.";
+    }
+
     leaf maximum-delay {
       // rjs TODO: same question as above
       type uint32;
@@ -216,12 +236,6 @@ submodule openconfig-ospfv2-global {
         running. This value is used for implementations that support
         increasing the wait time between SPF runs.";
     }
-
-    // rjs TODO: some questions here around what we should specify:
-    // JUNOS has rapid-runs and holddown
-    // Cisco has maximum time between runs, and then a doubling of
-    // the wait interval up to that maximum.
-    // ALU has first-wait, second-wait, max-wait
   }
 
   grouping ospfv2-global-lsa-generation-timers-config {
@@ -236,6 +250,19 @@ submodule openconfig-ospfv2-global {
         "The value of this leaf specifies the time between the first
         time an LSA is generated and advertised and the subsequent
         generation of that LSA.";
+    }
+
+    leaf second-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the delay between the
+        first and second generation of an LSA following a change
+        that requires it to be regenerated. Together with
+        initial-delay and maximum-delay, this leaf allows a
+        three-stage exponential backoff (first-wait, second-wait,
+        max-wait) to be configured, matching the equivalent IS-IS
+        LSP generation timers.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospfv2-global.yang
+++ b/release/models/ospf/openconfig-ospfv2-global.yang
@@ -27,10 +27,11 @@ submodule openconfig-ospfv2-global {
 
   revision "2026-09-06" {
     description
-      "Add a second-delay leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial, second, maximum)
-      exponential backoff, consistent with the equivalent IS-IS
-      timers.";
+      "Add a minimum-hold leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial delay, minimum
+      hold, maximum delay) exponential backoff, matching the Cisco
+      IOS-XR 'timers throttle spf' minimum hold time and the
+      equivalent IS-IS timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {
@@ -214,16 +215,17 @@ submodule openconfig-ospfv2-global {
         algorithm.";
     }
 
-    leaf second-delay {
+    leaf minimum-hold {
       type uint32;
       units msec;
       description
-        "The value of this leaf specifies the delay between the
-        first and second runs of the SPF algorithm following a
-        topology change. Together with initial-delay and
-        maximum-delay, this leaf allows a three-stage exponential
-        backoff (first-wait, second-wait, max-wait) to be
-        configured, matching the equivalent IS-IS SPF timers.";
+        "The value of this leaf specifies the minimum hold time
+        between consecutive SPF runs, once the initial run governed
+        by initial-delay has occurred. Together with initial-delay
+        and maximum-delay, this leaf allows a three-stage
+        exponential backoff to be configured, matching the Cisco
+        IOS-XR 'timers throttle spf' minimum hold time and the
+        equivalent IS-IS SPF timers.";
     }
 
     leaf maximum-delay {
@@ -252,17 +254,17 @@ submodule openconfig-ospfv2-global {
         generation of that LSA.";
     }
 
-    leaf second-delay {
+    leaf minimum-hold {
       type uint32;
       units msec;
       description
-        "The value of this leaf specifies the delay between the
-        first and second generation of an LSA following a change
-        that requires it to be regenerated. Together with
-        initial-delay and maximum-delay, this leaf allows a
-        three-stage exponential backoff (first-wait, second-wait,
-        max-wait) to be configured, matching the equivalent IS-IS
-        LSP generation timers.";
+        "The value of this leaf specifies the minimum hold time
+        between consecutive generations of an LSA, once the initial
+        generation governed by initial-delay has occurred. Together
+        with initial-delay and maximum-delay, this leaf allows a
+        three-stage exponential backoff to be configured, matching
+        the Cisco IOS-XR 'timers throttle lsa' minimum hold time and
+        the equivalent IS-IS LSP generation timers.";
     }
 
     leaf maximum-delay {

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -22,8 +22,13 @@ submodule openconfig-ospfv2-lsdb {
     "An OpenConfig model for the Open Shortest Path First (OSPF)
     version 2 link-state database (LSDB)";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Align revisions across modules.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";

--- a/release/models/ospf/openconfig-ospfv2-lsdb.yang
+++ b/release/models/ospf/openconfig-ospfv2-lsdb.yang
@@ -26,7 +26,9 @@ submodule openconfig-ospfv2-lsdb {
 
   revision "2026-09-06" {
     description
-      "Align revisions across modules.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,11 +38,9 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a minimum-hold leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial delay, minimum
-      hold, maximum delay) exponential backoff, matching the Cisco
-      IOS-XR 'timers throttle spf' minimum hold time and the
-      equivalent IS-IS timers.";
+      "Add minimum-hold leaf to OSPFv2 global timers, equivalent to
+      spf-second-interval and lsp-second-wait-interval of IS-IS
+      global timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -38,10 +38,11 @@ module openconfig-ospfv2 {
 
   revision "2026-09-06" {
     description
-      "Add a second-delay leaf to the SPF and LSA generation timer
-      groupings to support a three-stage (initial, second, maximum)
-      exponential backoff, consistent with the equivalent IS-IS
-      timers.";
+      "Add a minimum-hold leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial delay, minimum
+      hold, maximum delay) exponential backoff, matching the Cisco
+      IOS-XR 'timers throttle spf' minimum hold time and the
+      equivalent IS-IS timers.";
     reference "0.6.0";
   }
   revision "2024-06-17" {

--- a/release/models/ospf/openconfig-ospfv2.yang
+++ b/release/models/ospf/openconfig-ospfv2.yang
@@ -34,8 +34,16 @@ module openconfig-ospfv2 {
     "An OpenConfig model for Open Shortest Path First (OSPF)
     version 2";
 
-  oc-ext:openconfig-version "0.5.2";
+  oc-ext:openconfig-version "0.6.0";
 
+  revision "2026-09-06" {
+    description
+      "Add a second-delay leaf to the SPF and LSA generation timer
+      groupings to support a three-stage (initial, second, maximum)
+      exponential backoff, consistent with the equivalent IS-IS
+      timers.";
+    reference "0.6.0";
+  }
   revision "2024-06-17" {
     description
       "Correct ROUTER_INFORMATION_LSA to ROUTER_INFORMATION.";


### PR DESCRIPTION
### Change Scope

* Add minimum-hold leaf to OSPF global timers, equivalent to
  spf-second-interval and lsp-second-wait-interval of IS-IS global
  timers.
* Backward compatible: Yes (new optional leaf only).

### Platform Implementations

* Implementation A: Cisco IOS XR — [`timers throttle spf` / `timers throttle lsa`](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/routing/command/reference/b-routing-cr-asr9000/ospf-commands.html#wp2854264773) (OSPFv3: same commands under `router ospfv3`)
```
router ospf <process-id>
 timers throttle spf <spf-start> <spf-hold> <spf-max-wait>
 timers throttle lsa all <start-interval> <hold-interval> <max-interval>

router ospfv3 <process-id>
 timers throttle spf <spf-start> <spf-hold> <spf-max-wait>
 timers throttle lsa all <lsa-start> <lsa-hold> <lsa-max-wait>
```
* Implementation B: DriveNets DNOS — `timers throttle spf` / `timers throttle lsa`
```
protocols ospf timers throttle spf delay 1 min-holdtime 1000 max-holdtime 90000
protocols ospf timers throttle lsa all hold-interval 100 start-interval 5 max-interval 5000

protocols ospfv3 timers throttle spf delay 1 min-holdtime 1000 max-holdtime 90000
protocols ospfv3 timers throttle lsa all hold-interval 100 start-interval 5 max-interval 5000
```

### Tree View

```diff
 module: openconfig-ospfv2
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv2
                  +--rw global
                     +--rw timers
                        +--rw spf
                           +--rw config
                              +--rw initial-delay?   uint32
+                             +--rw minimum-hold?    uint32
                              +--rw maximum-delay?   uint32
                        +--rw lsa-generation
                           +--rw config
                              +--rw initial-delay?   uint32
+                             +--rw minimum-hold?    uint32
                              +--rw maximum-delay?   uint32
```
```diff
 module: openconfig-ospf (OSPFv3, shares the ospf-global submodule)
   +--rw network-instances
      +--rw network-instance* [name]
         +--rw protocols
            +--rw protocol* [identifier name]
               +--rw ospfv3
                  +--rw global
                     +--rw timers
                        +--rw spf
                           +--rw config
                              +--rw initial-delay?   uint32
+                             +--rw minimum-hold?    uint32
                              +--rw maximum-delay?   uint32
                        +--rw lsa-generation
                           +--rw config
                              +--rw initial-delay?   uint32
+                             +--rw minimum-hold?    uint32
                              +--rw maximum-delay?   uint32
```